### PR TITLE
Raw ttipc-migrate output (no fixes) — reference for codemod issues

### DIFF
--- a/src-tauri/src/buffer.rs
+++ b/src-tauri/src/buffer.rs
@@ -75,8 +75,10 @@ impl LuxBuffer {
             .close()
             .map_err(|e| format!("Enttec OpenDMX USB failed to close: {}", e))?;
 
-        SyncEventTrigger::new(app)
-            .buffer_set(incoming_buffer)
+        SyncEvent::BufferSet {
+            buffer: incoming_buffer,
+        }
+            .emit(&app)
             .map_err(|e| format!("Failed to emit buffer_set event: {}", e))?;
 
         Ok(self.clone())

--- a/src-tauri/src/channels.rs
+++ b/src-tauri/src/channels.rs
@@ -145,8 +145,10 @@ impl LuxChannels {
             .get(channel_number)
             .insert(LuxChannel::from(new_metadata))
             .to_owned();
-        CmdEventTrigger::new(app)
-            .channel_data_set(self.channels.lock().unwrap().clone())
+        CmdEvent::ChannelDataSet {
+            channels: self.channels.lock().unwrap().clone(),
+        }
+            .emit(&app)
             .map_err(|e| format!("Failed to emit channel_data_set event: {}", e))?;
         Ok(channel)
     }
@@ -165,8 +167,10 @@ impl LuxChannels {
     ) -> Result<LuxChannels, String> {
         self.set_all(channels.into())?;
 
-        CmdEventTrigger::new(app)
-            .channel_data_set(self.channels.lock().unwrap().clone())
+        CmdEvent::ChannelDataSet {
+            channels: self.channels.lock().unwrap().clone(),
+        }
+            .emit(&app)
             .map_err(|e| format!("Failed to emit channel_data_set event: {}", e))?;
         Ok(self.clone())
     }

--- a/src-tauri/src/cmd.rs
+++ b/src-tauri/src/cmd.rs
@@ -1,3 +1,10 @@
+// Migrated from TauRPC by ttipc-migrate. Manual follow-ups:
+//   - errors: each `Result<_, E>` needs `E: ttipc::Error` (derive it on the error type).
+//   - imports: drop the now-unused `Runtime`; `Channel` is now `ttipc::Channel`.
+//   - de-async: methods with no blocking `.await` were made sync (ttipc's default), and their `.await`s on now-sync siblings were dropped.
+//   - async injection: ttipc rejects an `async` procedure that takes `AppHandle`/`State<T>`; make it sync, or rework so the async body needs no injected handle/state.
+//   - events: `#[taurpc(event)]` methods were lifted into a `#[derive(ttipc::Event)]` enum (matching emit sites were rewritten to `Enum::Variant.emit(&h)`); drop any now-empty trait/impl.
+
 use crate::{
     buffer::{Buffer, LuxBuffer, BUFFER_SIZE},
     channel::LuxChannel,
@@ -6,54 +13,58 @@ use crate::{
 };
 use tauri::{AppHandle, Manager, Runtime};
 
-#[taurpc::procedures(path = "cmd", event_trigger = CmdEventTrigger, export_to = "../src/bindings.ts")]
+#[ttipc::procedures(path = "cmd")]
 pub trait CmdMethods {
-    async fn set_buffer<R: Runtime>(
-        app_handle: AppHandle<R>,
+    fn set_buffer(
+        &self,
+        app_handle: AppHandle,
         buffer: Buffer,
     ) -> Result<LuxBuffer, String>;
-    async fn update_channel_value<R: Runtime>(
-        app_handle: AppHandle<R>,
+    fn update_channel_value(
+        &self,
+        app_handle: AppHandle,
         channel_number: usize,
         value: u8,
     ) -> Result<LuxBuffer, String>;
-    async fn insert_channel<R: Runtime>(
-        app_handle: AppHandle<R>,
+    fn insert_channel(
+        &self,
+        app_handle: AppHandle,
         new_metadata: LuxChannel,
     ) -> Result<LuxChannel, String>;
-    async fn delete_channel<R: Runtime>(
-        app_handle: AppHandle<R>,
+    fn delete_channel(
+        &self,
+        app_handle: AppHandle,
         channel_number: usize,
     ) -> Result<(), String>;
-    async fn update_channel_metadata<R: Runtime>(
-        app_handle: AppHandle<R>,
+    fn update_channel_metadata(
+        &self,
+        app_handle: AppHandle,
         channel_number: usize,
         new_metadata: LuxChannel,
     ) -> Result<LuxChannel, String>;
-    async fn sync_state<R: Runtime>(app_handle: AppHandle<R>) -> Result<String, String>;
-
-    #[taurpc(event)]
-    async fn channel_data_set(channels: [LuxChannel; BUFFER_SIZE]);
+    async fn sync_state(&self, app_handle: AppHandle) -> Result<String, String>;
+}
+#[derive(ttipc::Event)]
+pub enum CmdEvent {
+    ChannelDataSet { channels: [LuxChannel; BUFFER_SIZE] },
 }
 
 #[derive(Clone)]
 pub struct CmdEndpoint;
 
-#[taurpc::resolvers]
 impl CmdMethods for CmdEndpoint {
-    async fn set_buffer<R: Runtime>(
-        self,
-        app_handle: AppHandle<R>,
+    fn set_buffer(
+        &self,
+        app_handle: AppHandle,
         buffer: Buffer,
     ) -> Result<LuxBuffer, String> {
         log::trace!("received buffer {:?}", buffer);
         let mut state = app_handle.state::<LuxBuffer>().inner().clone();
         state.set(buffer, app_handle.clone())
     }
-
-    async fn update_channel_value<R: Runtime>(
-        self,
-        app_handle: AppHandle<R>,
+    fn update_channel_value(
+        &self,
+        app_handle: AppHandle,
         channel_number: usize,
         value: u8,
     ) -> Result<LuxBuffer, String> {
@@ -61,33 +72,26 @@ impl CmdMethods for CmdEndpoint {
         let mut state = app_handle.state::<LuxBuffer>().inner().clone();
         state.set_channel(channel_number, value, app_handle.clone())
     }
-
-    async fn insert_channel<R: Runtime>(
-        self,
-        app_handle: AppHandle<R>,
+    fn insert_channel(
+        &self,
+        app_handle: AppHandle,
         new_metadata: LuxChannel,
     ) -> Result<LuxChannel, String> {
         log::trace!("received channel {:?}", new_metadata);
         let mut state = app_handle.state::<LuxChannels>().inner().clone();
-        state.set(
-            new_metadata.get_channel_number(),
-            new_metadata,
-            app_handle.clone(),
-        )
+        state.set(new_metadata.get_channel_number(), new_metadata, app_handle.clone())
     }
-
-    async fn delete_channel<R: Runtime>(
-        self,
-        _app_handle: AppHandle<R>,
+    fn delete_channel(
+        &self,
+        _app_handle: AppHandle,
         channel_number: usize,
     ) -> Result<(), String> {
         log::debug!("received channel {} to delete", channel_number);
         Ok(())
     }
-
-    async fn update_channel_metadata<R: Runtime>(
-        self,
-        app_handle: AppHandle<R>,
+    fn update_channel_metadata(
+        &self,
+        app_handle: AppHandle,
         channel_number: usize,
         new_metadata: LuxChannel,
     ) -> Result<LuxChannel, String> {
@@ -95,8 +99,7 @@ impl CmdMethods for CmdEndpoint {
         let mut state = app_handle.state::<LuxChannels>().inner().clone();
         state.set(channel_number, new_metadata, app_handle.clone())
     }
-
-    async fn sync_state<R: Runtime>(self, app: AppHandle<R>) -> Result<String, String> {
+    async fn sync_state(&self, app: AppHandle) -> Result<String, String> {
         log::trace!("sync_state");
         SyncEndpoint.sync_state(app.clone()).await
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,6 @@
+// Migrated from TauRPC by ttipc-migrate. Manual follow-ups:
+//   - mount: the TauRPC Router/handler became `ttipc::handler(..)` (a `-> Router` factory now returns `ttipc::Procedures`); generate bindings separately (`ttipc::Bindings`, replacing the dropped `export_config`), keep app state on `.manage(..)`, and drop any now-unused local config bindings.
+
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 mod buffer;
@@ -20,20 +23,13 @@ use sync::*;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub async fn run() {
     let builder = setup(tauri::Builder::default(), |_| {});
-
     let default_buffer = LuxBuffer::from([121, 255, 255, 0, 0, 42]);
     let default_channels = LuxChannels::default();
-
     let formatter = specta_typescript::formatter::prettier;
     let bigint = specta_typescript::BigIntExportBehavior::Number;
     let bindings = Typescript::default().formatter(formatter).bigint(bigint);
-    let router = taurpc::Router::new()
-        .export_config(bindings)
-        .merge(SyncEndpoint.into_handler())
-        .merge(CmdEndpoint.into_handler());
-
-    let taurpc = router.into_handler();
-
+    let router = SyncEndpoint.into_procedures().merge(CmdEndpoint.into_procedures());
+    let taurpc = ttipc::handler(router);
     builder
         .plugin(tauri_plugin_shell::init())
         .plugin(logger::logger().build())

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -1,3 +1,9 @@
+// Migrated from TauRPC by ttipc-migrate. Manual follow-ups:
+//   - errors: each `Result<_, E>` needs `E: ttipc::Error` (derive it on the error type).
+//   - imports: drop the now-unused `Runtime`; `Channel` is now `ttipc::Channel`.
+//   - de-async: methods with no blocking `.await` were made sync (ttipc's default), and their `.await`s on now-sync siblings were dropped.
+//   - events: `#[taurpc(event)]` methods were lifted into a `#[derive(ttipc::Event)]` enum (matching emit sites were rewritten to `Enum::Variant.emit(&h)`); drop any now-empty trait/impl.
+
 use crate::{
     buffer::{Buffer, LuxBuffer},
     channels::LuxChannels,
@@ -5,41 +11,36 @@ use crate::{
 
 use tauri::{AppHandle, Manager, Runtime};
 
-#[taurpc::procedures(path = "sync", event_trigger = SyncEventTrigger)]
+#[ttipc::procedures(path = "sync")]
 pub trait SyncMethods {
-    async fn sync_buffer<R: Runtime>(app_handle: AppHandle<R>) -> Result<LuxBuffer, String>;
-    async fn sync_channels<R: Runtime>(app_handle: AppHandle<R>) -> Result<LuxChannels, String>;
-    async fn sync_state<R: Runtime>(app_handle: AppHandle<R>) -> Result<String, String>;
-
-    #[taurpc(event)]
-    async fn buffer_set(buffer: Buffer);
+    fn sync_buffer(&self, app_handle: AppHandle) -> Result<LuxBuffer, String>;
+    fn sync_channels(&self, app_handle: AppHandle) -> Result<LuxChannels, String>;
+    fn sync_state(&self, app_handle: AppHandle) -> Result<String, String>;
+}
+#[derive(ttipc::Event)]
+pub enum SyncEvent {
+    BufferSet { buffer: Buffer },
 }
 
 #[derive(Clone)]
 pub struct SyncEndpoint;
 
-#[taurpc::resolvers]
 impl SyncMethods for SyncEndpoint {
-    async fn sync_buffer<R: Runtime>(self, app_handle: AppHandle<R>) -> Result<LuxBuffer, String> {
+    fn sync_buffer(&self, app_handle: AppHandle) -> Result<LuxBuffer, String> {
         log::trace!("sync_buffer");
         let mut state = app_handle.state::<LuxBuffer>().inner().clone();
         let buffer = state.buffer.lock().as_deref().unwrap().clone();
         state.set(buffer, app_handle.clone())
     }
-
-    async fn sync_channels<R: Runtime>(
-        self,
-        app_handle: AppHandle<R>,
-    ) -> Result<LuxChannels, String> {
+    fn sync_channels(&self, app_handle: AppHandle) -> Result<LuxChannels, String> {
         log::trace!("sync_channels");
         let mut state = app_handle.state::<LuxChannels>().get_all();
         state.set_channels(LuxChannels::from(&state), app_handle.clone())
     }
-
-    async fn sync_state<R: Runtime>(self, app_handle: AppHandle<R>) -> Result<String, String> {
+    fn sync_state(&self, app_handle: AppHandle) -> Result<String, String> {
         log::trace!("sync_state");
-        SyncEndpoint.sync_buffer(app_handle.clone()).await?;
-        SyncEndpoint.sync_channels(app_handle).await?;
+        SyncEndpoint.sync_buffer(app_handle.clone())?;
+        SyncEndpoint.sync_channels(app_handle)?;
         let msg = format!("State synced!");
         log::trace!("{:?}", msg);
         Ok(msg)


### PR DESCRIPTION
**Draft / do not merge.** This is the *unmodified* output of `ttipc-migrate --write` run on lux's `taurpc` code (single commit `migrate from taurpc to ttipc`), pushed as a reference for the codemod issues in [`johncarmack1984/tauri-typed-ipc`](https://github.com/johncarmack1984/tauri-typed-ipc/issues). It contains **no manual fixes**, so it does **not compile** — that is the point: each breakage below maps to a ttipc issue, to be fixed there commit-by-commit.

The working migration (all follow-ups applied) is preserved locally on `ttipc-migration-fixed`.

## Problems in this diff → ttipc issues
- [ ] **Stale `*EventTrigger` imports** — johncarmack1984/tauri-typed-ipc#5 — `channels.rs`/`buffer.rs`: emit sites rewritten to `CmdEvent`/`SyncEvent`, trigger imports left dangling. rustc: `E0432 unresolved import CmdEventTrigger`, `E0433 cannot find type CmdEvent`.
- [ ] **Cross-file de-async** — johncarmack1984/tauri-typed-ipc#6 — `cmd.rs::sync_state` left `async` with `.await` on the now-sync `sync.rs::sync_state`. rustc: `E0277 Result<String, String> is not a future`.
- [ ] **Orphaned `export_config` locals** — johncarmack1984/tauri-typed-ipc#7 — `lib.rs`: `use specta_typescript::Typescript;` + `let formatter/bigint/bindings` left after the mount rewrite.
- [ ] **BigInt wire fields** — johncarmack1984/tauri-typed-ipc#8 — `channel_number: usize` kept while `BigIntExportBehavior::Number` dropped; ttipc's exporter rejects `usize`.
- [ ] **`Result<_, String>` errors** — johncarmack1984/tauri-typed-ipc#9 — every procedure still returns `Result<_, String>`, which is not a `ttipc::Error`.