### PR TITLE
Add Dependabot config for the monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot version updates for the lux monorepo.
+#
+# This configures scheduled *version* updates. Security updates are alert-driven
+# and run independently of this file (they cannot be disabled here — dismiss a
+# specific alert in the Security tab, or it clears when the affected dependency
+# is upgradable).
+version: 2
+updates:
+  # Tauri desktop backend
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo:
+        patterns: ["*"]
+
+  # Discord bot Lambda
+  - package-ecosystem: "cargo"
+    directory: "/bot"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo:
+        patterns: ["*"]
+
+  # GitHub Actions used by the workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Weekly grouped version updates for cargo (`/src-tauri` and the new `/bot` crate) and github-actions.

Note: this configures *version* updates only. The recent failing jobs were *security* updates (alert-driven, separate mechanism) for a transitive `rustls-webpki` advisory on old lines (0.101.7 in /bot, 0.102.8 in /src-tauri) with no patched release — those aren't silenced by this file; dismiss the alert as tolerable in the Security tab or it clears when the parent deps move to rustls 0.23.