### PR TITLE
fix: type-only import so next build / tauri build resolves

### DIFF
--- a/src/components/control-grid/grid.tsx
+++ b/src/components/control-grid/grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ChannelProps } from "@/global";
+import type { ChannelProps } from "@/global";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 
 import GridFooter from "./footer";

--- a/src/components/control-grid/row.tsx
+++ b/src/components/control-grid/row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ChannelProps } from "@/global";
+import type { ChannelProps } from "@/global";
 import { TableRow } from "@/components/ui/table";
 import { flexRender, type Row } from "@tanstack/react-table";
 


### PR DESCRIPTION
`grid.tsx` and `row.tsx` imported `ChannelProps` from `@/global` (a `.d.ts`) with `import { type ... }` instead of `import type { ... }`, which kept the module in the runtime graph and broke `next build`'s static export (surfaced by the first `tauri-action` run — `tauri dev` skips the build). Verified `bun run build` passes locally. This is the fix that makes the release build (v0.1.1) produce a .dmg.