### PR TITLE
ci: strip trailing newline from the fetched signing key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,9 @@ jobs:
           role-to-assume: arn:aws:iam::735853783919:role/lux-release-signing
           aws-region: us-west-1
       - name: Load updater signing key
-        run: aws secretsmanager get-secret-value --secret-id lux/updater-signing-key --query SecretString --output text > "$RUNNER_TEMP/updater.key"
+        # printf '%s' + "$(...)" strips the trailing newline that --output text
+        # adds, which otherwise breaks the base64 key decode (Invalid symbol 10).
+        run: printf '%s' "$(aws secretsmanager get-secret-value --secret-id lux/updater-signing-key --query SecretString --output text)" > "$RUNNER_TEMP/updater.key"
 
       - uses: tauri-apps/tauri-action@v0
         env:


### PR DESCRIPTION
The v0.2.1 build got all the way through compile + bundling + OIDC, then failed signing with `Invalid symbol 10, offset 348` (symbol 10 = newline). `aws ... --output text` appends a newline that breaks the base64 key decode. Strip it with `printf '%s' "$(...)"`. I'll validate by re-running the build for the existing v0.2.1 tag via workflow_dispatch.