### PR TITLE
fix: password-protected updater key from JSON secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,15 +64,20 @@ jobs:
           role-to-assume: arn:aws:iam::735853783919:role/lux-release-signing
           aws-region: us-west-1
       - name: Load updater signing key
-        # printf '%s' + "$(...)" strips the trailing newline that --output text
-        # adds, which otherwise breaks the base64 key decode (Invalid symbol 10).
-        run: printf '%s' "$(aws secretsmanager get-secret-value --secret-id lux/updater-signing-key --query SecretString --output text)" > "$RUNNER_TEMP/updater.key"
+        # The secret is JSON {key, password}. Write the key to a file (printf '%s'
+        # avoids a trailing newline that would break the base64 decode) and pass
+        # the password via $GITHUB_ENV, masked so it never appears in logs.
+        run: |
+          secret=$(aws secretsmanager get-secret-value --secret-id lux/updater-signing-key --query SecretString --output text)
+          printf '%s' "$(printf '%s' "$secret" | jq -r '.key')" > "$RUNNER_TEMP/updater.key"
+          password=$(printf '%s' "$secret" | jq -r '.password')
+          echo "::add-mask::$password"
+          echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=$password" >> "$GITHUB_ENV"
 
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ runner.temp }}/updater.key
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
         with:
           tagName: ${{ env.TAG }}
           args: --target universal-apple-darwin

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,7 +52,7 @@
       "endpoints": [
         "https://github.com/johncarmack1984/lux/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDA5OUJDMTc5NEJBOTRCOTcKUldTWFM2bExlY0diQ1lONTVwVEYraU5mSTY3ejBWMkxVMCtTT3BFMGVTb1lZdktrM2p6Y1lTSWsK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDAwRUMwMDNDQThGRTAzQUUKUldTdUEvNm9QQURzQVA3OEppYmloY2tJSGZFaFRxcldKNkVROTFUSzAvNG94VGlRK0dkUDllcUsK"
     }
   }
 }


### PR DESCRIPTION
v0.2.1's build reached the very last step and failed signing with `Wrong password for that key`. The `tauri signer generate --ci` key (despite saying "without password") carried a password that an empty string doesn't decrypt — confirmed locally. 

Regenerated the key with a known password and verified signing locally (produced a `.sig`). The AWS secret `lux/updater-signing-key` now holds `{key, password}` as JSON; the workflow writes the key to a file and exports the password via `$GITHUB_ENV` (masked). New `pubkey` in `tauri.conf.json`. OIDC role unchanged (same secret). This cuts v0.2.2 — the first release whose embedded pubkey matches the signing key.