### PR TITLE
feat: sign + notarize macOS releases (Developer ID)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,24 @@ jobs:
           echo "::add-mask::$password"
           echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=$password" >> "$GITHUB_ENV"
 
+      - name: Load Apple signing secret
+        # JSON {certificate (.p12 b64), certificate_password, signing_identity,
+        # team_id, api_key (.p8), api_key_id, api_issuer_id} -> tauri-action env.
+        # tauri-action reads APPLE_* from the process env (set via $GITHUB_ENV).
+        run: |
+          s=$(aws secretsmanager get-secret-value --secret-id lux/apple-signing --query SecretString --output text)
+          echo "::add-mask::$(printf '%s' "$s" | jq -r '.certificate_password')"
+          {
+            echo "APPLE_CERTIFICATE=$(printf '%s' "$s" | jq -r '.certificate')"
+            echo "APPLE_CERTIFICATE_PASSWORD=$(printf '%s' "$s" | jq -r '.certificate_password')"
+            echo "APPLE_SIGNING_IDENTITY=$(printf '%s' "$s" | jq -r '.signing_identity')"
+            echo "APPLE_TEAM_ID=$(printf '%s' "$s" | jq -r '.team_id')"
+            echo "APPLE_API_ISSUER=$(printf '%s' "$s" | jq -r '.api_issuer_id')"
+            echo "APPLE_API_KEY=$(printf '%s' "$s" | jq -r '.api_key_id')"
+          } >> "$GITHUB_ENV"
+          printf '%s' "$s" | jq -r '.api_key' > "$RUNNER_TEMP/asc_api_key.p8"
+          echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/asc_api_key.p8" >> "$GITHUB_ENV"
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/infra/release-signing.tf
+++ b/infra/release-signing.tf
@@ -10,6 +10,10 @@ data "aws_secretsmanager_secret" "updater_signing_key" {
   name = "lux/updater-signing-key"
 }
 
+data "aws_secretsmanager_secret" "apple_signing" {
+  name = "lux/apple-signing"
+}
+
 resource "aws_iam_role" "release_signing" {
   name = "lux-release-signing"
   assume_role_policy = jsonencode({
@@ -37,9 +41,12 @@ resource "aws_iam_role_policy" "read_updater_signing_key" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect   = "Allow"
-      Action   = "secretsmanager:GetSecretValue"
-      Resource = data.aws_secretsmanager_secret.updater_signing_key.arn
+      Effect = "Allow"
+      Action = "secretsmanager:GetSecretValue"
+      Resource = [
+        data.aws_secretsmanager_secret.updater_signing_key.arn,
+        data.aws_secretsmanager_secret.apple_signing.arn,
+      ]
     }]
   })
 }


### PR DESCRIPTION
Releases are now **code-signed with Developer ID and notarized**, so they clear Gatekeeper (no "unidentified developer" / "damaged" warnings) for direct download + Homebrew.

- New AWS secret `lux/apple-signing` (JSON): the Developer ID `.p12` (cert + key + G2 intermediate) and an App Store Connect API key for notarization. CI pulls it over the existing OIDC role.
- `infra/release-signing.tf`: OIDC role policy extended to read the new secret (applied).
- `release.yml`: a step maps the secret into tauri-action's `APPLE_CERTIFICATE` / `APPLE_API_*` env.
- The cert + `.p12` were verified locally: `codesign` produces a complete chain (Developer ID Application → Developer ID CA → Apple Root CA).

Cuts v0.3.0 — the first signed + notarized release.