### PR TITLE
fix(deps): patch glib to clear RUSTSEC-2024-0429

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1488,8 +1488,7 @@ dependencies = [
 [[package]]
 name = "glib"
 version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+source = "git+https://github.com/johncarmack1984/gtk-rs-core?branch=lux%2Fglib-0.18-patch#0869c7efc510daf87622847bcf3ea8db48373a64"
 dependencies = [
  "bitflags 2.13.0",
  "futures-channel",
@@ -2225,7 +2224,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lux"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "array-init",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,3 +65,12 @@ opt-level = "s"
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.
 # DO NOT REMOVE!!
 prod = ["tauri/custom-protocol"]
+
+# RUSTSEC-2024-0429: UB in glib's VariantStrIter::impl_get. tauri's Linux gtk
+# stack pins glib 0.18 and there is no tauri release on glib 0.20, so the
+# advisory can't be cleared by a version bump. Patch glib to a fork carrying the
+# backported fix. The branch resolves glib's gtk-rs-core siblings from crates.io,
+# so this single patch doesn't pull git *-sys crates that would duplicate the
+# crates.io ones and collide on `links`. Upstream PR: gtk-rs/gtk-rs-core#1991.
+[patch.crates-io]
+glib = { git = "https://github.com/johncarmack1984/gtk-rs-core", branch = "lux/glib-0.18-patch" }


### PR DESCRIPTION
Clears the `glib` RUSTSEC-2024-0429 advisory. It is transitive via tauri's Linux gtk-0.18 stack, and there is no tauri release on glib 0.20 — no version bump to take. Patches `glib` to a fork with the backported `VariantStrIter::impl_get` fix (`&mut p`); the branch resolves the `*-sys` siblings from crates.io so only glib is repointed (no duplicate `*-sys` / `links` collision). glib only compiles on Linux, so CI is the real build check here.

Upstream: gtk-rs/gtk-rs-core#1991