### PR TITLE
feat: add network DMX output (sACN/E1.31) with auto-detected device selection

### DIFF
--- a/src-tauri/.env.example
+++ b/src-tauri/.env.example
@@ -7,7 +7,3 @@ AWS_IOT_CERT_PATH=./certs/device.pem.crt
 AWS_IOT_KEY_PATH=./certs/device.private.key
 AWS_IOT_ROOT_CA_PATH=./certs/AmazonRootCA1.pem
 LUX_DEVICE_ID=lux-1
-
-TURSO_SYNC_URL=""
-TURSO_AUTH_TOKEN=""
-DB_PATH=./lux.db

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2224,7 +2224,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lux"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "array-init",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lux"
 version = "0.4.1" # x-release-please-version
-description = "A DMX lighting control system for Enttec Open DMX USB devices."
+description = "A DMX lighting control system for Enttec Open DMX USB and sACN/E1.31 network nodes."
 authors = ["John Carmack"]
 edition = "2021"
 repository = "https://github.com/johncarmack1984/lux"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Merged into the generated macOS Info.plist by the Tauri bundler (`tauri build`).
+  Tauri 2 has no inline Info.plist field in tauri.conf.json; this file is the
+  supported way to add keys. https://v2.tauri.app/distribute/macos-application-bundle/
+
+  NSLocalNetworkUsageDescription: macOS gates local-network multicast/broadcast
+  behind a TCC prompt. lux needs it to discover (Art-Net ArtPoll) and drive
+  (sACN/E1.31 multicast) DMX nodes like the DMXKing eDMX1 Pro. Without this key
+  the prompt can fail to appear and sACN output is silently blocked.
+-->
+<plist version="1.0">
+  <dict>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>lux discovers and controls DMX lighting nodes (Art-Net / sACN) on your local network.</string>
+  </dict>
+</plist>

--- a/src-tauri/src/buffer.rs
+++ b/src-tauri/src/buffer.rs
@@ -1,7 +1,6 @@
-use crate::{devices::enttec_open_dmx_usb::EnttecOpenDMX, sync::SyncEvent};
+use crate::{devices::DmxOutput, sync::SyncEvent};
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{Manager, Runtime};
 
@@ -17,34 +16,6 @@ pub type Buffer = [u8; BUFFER_SIZE];
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
 pub struct LuxBuffer {
     pub buffer: Arc<Mutex<Buffer>>,
-}
-
-/// Tray-toggleable emit ordering for `LuxBuffer::set`. When `optimistic` is set,
-/// the buffer event is emitted *before* the DMX render (the UI reflects a command
-/// immediately, even with no fixture attached); otherwise it is emitted only after
-/// a successful render (the UI mirrors the hardware). Default: optimistic, so the
-/// UI reflects a command immediately instead of waiting on the slower DMX render
-/// (waiting makes the sliders snap back to the lagging value and judder mid-drag).
-pub struct EmitMode {
-    optimistic: AtomicBool,
-}
-
-impl Default for EmitMode {
-    fn default() -> Self {
-        EmitMode {
-            optimistic: AtomicBool::new(true),
-        }
-    }
-}
-
-impl EmitMode {
-    pub fn optimistic(&self) -> bool {
-        self.optimistic.load(Ordering::Relaxed)
-    }
-
-    pub fn set(&self, optimistic: bool) {
-        self.optimistic.store(optimistic, Ordering::Relaxed);
-    }
 }
 
 impl ConvertFromVec for Buffer {
@@ -83,17 +54,12 @@ impl LuxBuffer {
     ) -> Result<LuxBuffer, String> {
         *self.buffer.lock().unwrap() = incoming_buffer;
 
-        // Tray toggle: emit the buffer event before the DMX render (optimistic —
-        // the UI reflects the command even with no fixture) or only after a
-        // successful render (the UI mirrors the hardware).
-        let optimistic = app.state::<EmitMode>().optimistic();
-        if optimistic {
-            emit_buffer(incoming_buffer, &app)?;
-        }
-        render(incoming_buffer)?;
-        if !optimistic {
-            emit_buffer(incoming_buffer, &app)?;
-        }
+        // Optimistic: reflect the command in the UI immediately, before the DMX
+        // render — which may hit the network (sACN) or have no device attached.
+        // Always on: with a network node in the path, leading the render is what
+        // keeps the sliders from snapping back to a lagging value mid-drag.
+        emit_buffer(incoming_buffer, &app)?;
+        render(incoming_buffer, &app)?;
 
         Ok(self.clone())
     }
@@ -110,25 +76,12 @@ impl LuxBuffer {
     }
 }
 
-/// Push the 6-channel buffer to the Enttec OpenDMX fixture (channels 1..=6 of the
-/// 512-channel universe). Fails (e.g. `DEVICE_NOT_FOUND`) when no unit is attached.
-fn render(buffer: Buffer) -> Result<(), String> {
-    let mut temp_buffer = [0u8; 513];
-    temp_buffer[1..BUFFER_SIZE + 1].copy_from_slice(&buffer);
-
-    let mut interface = EnttecOpenDMX::new()
-        .map_err(|e| format!("Enttec OpenDMX USB initialization failed: {}", e))?;
-    interface
-        .open()
-        .map_err(|e| format!("Enttec OpenDMX USB failed to open: {}", e))?;
-    interface.set_buffer(temp_buffer);
-    interface
-        .render()
-        .map_err(|e| format!("Enttec OpenDMX USB failed to render: {}", e))?;
-    interface
-        .close()
-        .map_err(|e| format!("Enttec OpenDMX USB failed to close: {}", e))?;
-    Ok(())
+/// Push the 6-channel buffer to the active DMX output (Enttec USB or sACN
+/// network node), selected at startup into `DmxOutput`. Channels map to slots
+/// 1..=6 of the 512-channel universe. Fails (e.g. `DEVICE_NOT_FOUND`, socket
+/// error) when the output can't accept the frame.
+fn render<R: Runtime>(buffer: Buffer, app: &tauri::AppHandle<R>) -> Result<(), String> {
+    app.state::<DmxOutput>().render(&buffer)
 }
 
 fn emit_buffer<R: Runtime>(buffer: Buffer, app: &tauri::AppHandle<R>) -> Result<(), String> {

--- a/src-tauri/src/devices/discovery.rs
+++ b/src-tauri/src/devices/discovery.rs
@@ -1,0 +1,216 @@
+//! Art-Net device discovery (ArtPoll / ArtPollReply).
+//!
+//! sACN is a data-only protocol — it has no way to ask a node "what universe
+//! are you on?". Art-Net does: an `ArtPoll` broadcast makes every node reply
+//! with an `ArtPollReply` describing itself (IP, name, firmware, and the
+//! universe each port is bound to). This is exactly how the DMXKing eDMX Config
+//! tool finds devices — doing it here lets lux auto-target the eDMX's universe
+//! and skip that tool entirely.
+//!
+//! Best-effort: if Art-Net is blocked, the port is busy, or nothing answers,
+//! `discover` returns an empty list and the caller falls back to the configured
+//! universe. Packet offsets follow Art-Net 4 and are validated against a real
+//! eDMX1 PRO (see the Python prototype this was ported from).
+
+use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
+use std::time::{Duration, Instant};
+
+const ARTNET_PORT: u16 = 6454;
+
+/// A node that answered our `ArtPoll`.
+#[derive(Debug, Clone)]
+pub struct ArtNetNode {
+    pub ip: Ipv4Addr,
+    pub short_name: String,
+    pub long_name: String,
+    pub firmware: (u8, u8),
+    /// True if output port A can drive DMX from the network (i.e. it listens for
+    /// our sACN/Art-Net). Input-only ports are ignored for universe targeting.
+    pub output: bool,
+    net: u8,
+    sub: u8,
+    sw_out: u8,
+}
+
+impl ArtNetNode {
+    /// 15-bit Art-Net Port-Address of output port A.
+    pub fn port_address(&self) -> u16 {
+        ((self.net as u16) << 8) | ((self.sub as u16) << 4) | self.sw_out as u16
+    }
+
+    /// sACN/E1.31 universe of output port A. DMXKing maps sACN universe N to
+    /// Art-Net Port-Address N-1 ("sACN universe 1 = Art-Net 0:0:0").
+    pub fn sacn_universe(&self) -> u16 {
+        self.port_address() + 1
+    }
+}
+
+/// The 14-byte `ArtPoll`: ID + OpCode 0x2000 + ProtVer 14 + TalkToMe + Priority.
+fn build_artpoll() -> [u8; 14] {
+    let mut p = [0u8; 14];
+    p[0..8].copy_from_slice(b"Art-Net\0");
+    p[8..10].copy_from_slice(&0x2000u16.to_le_bytes()); // OpCode is little-endian on the wire
+    p[11] = 14; // ProtVerLo (Hi=0); TalkToMe + Priority stay 0 (broadcast reply)
+    p
+}
+
+/// Parse an `ArtPollReply`. Returns `None` for anything that isn't one.
+fn parse_reply(data: &[u8]) -> Option<ArtNetNode> {
+    if data.len() < 200 || &data[0..8] != b"Art-Net\0" {
+        return None;
+    }
+    if u16::from_le_bytes([data[8], data[9]]) != 0x2100 {
+        return None;
+    }
+    let cstr = |b: &[u8]| {
+        let end = b.iter().position(|&c| c == 0).unwrap_or(b.len());
+        String::from_utf8_lossy(&b[..end]).into_owned()
+    };
+    Some(ArtNetNode {
+        ip: Ipv4Addr::new(data[10], data[11], data[12], data[13]),
+        firmware: (data[16], data[17]),
+        net: data[18] & 0x7f,
+        sub: data[19] & 0x0f,
+        short_name: cstr(&data[26..44]),
+        long_name: cstr(&data[44..108]),
+        output: data[174] & 0x80 != 0, // PortTypes[0] bit7 = "can output from network"
+        sw_out: data[190] & 0x0f,      // SwOut[0] low nibble
+    })
+}
+
+fn bind() -> std::io::Result<UdpSocket> {
+    // Bind 0.0.0.0:6454 so broadcast replies are received; enable SO_BROADCAST
+    // so we can send the poll to the limited broadcast address.
+    let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, ARTNET_PORT))?;
+    socket.set_broadcast(true)?;
+    Ok(socket)
+}
+
+/// Broadcast an `ArtPoll` and collect replies for up to `timeout`, returning
+/// early once replies go quiet. The poll egresses the OS-routed interface (the
+/// wired NIC, on the confirmed setup); replies broadcast back to UDP 6454.
+pub fn discover(timeout: Duration) -> Vec<ArtNetNode> {
+    let socket = match bind() {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("Art-Net discovery: bind to :{ARTNET_PORT} failed ({e}); skipping");
+            return Vec::new();
+        }
+    };
+    let dest = SocketAddrV4::new(Ipv4Addr::BROADCAST, ARTNET_PORT);
+    let poll = build_artpoll();
+    let _ = socket.set_read_timeout(Some(Duration::from_millis(150)));
+    if let Err(e) = socket.send_to(&poll, dest) {
+        log::warn!("Art-Net discovery: poll send failed ({e})");
+    }
+
+    let mut nodes: Vec<ArtNetNode> = Vec::new();
+    let start = Instant::now();
+    let mut last_new = start;
+    let mut last_poll = Instant::now();
+    let mut buf = [0u8; 1024];
+
+    while start.elapsed() < timeout {
+        // Art-Net nodes reply with a random delay (up to ~1s, to avoid reply
+        // storms), so keep re-polling until one answers rather than giving up.
+        if nodes.is_empty() && last_poll.elapsed() >= Duration::from_millis(500) {
+            let _ = socket.send_to(&poll, dest);
+            last_poll = Instant::now();
+        }
+        if let Ok((n, _)) = socket.recv_from(&mut buf) {
+            if let Some(node) = parse_reply(&buf[..n]) {
+                if !nodes.iter().any(|x| x.ip == node.ip) {
+                    nodes.push(node);
+                    last_new = Instant::now();
+                }
+            }
+        }
+        // Once something answered and it's gone quiet, stop early to keep startup snappy.
+        if !nodes.is_empty() && last_new.elapsed() >= Duration::from_millis(400) {
+            break;
+        }
+    }
+    nodes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_reply() -> Vec<u8> {
+        let mut p = vec![0u8; 214];
+        p[0..8].copy_from_slice(b"Art-Net\0");
+        p[8..10].copy_from_slice(&0x2100u16.to_le_bytes());
+        p[10..14].copy_from_slice(&[192, 168, 1, 111]);
+        p[16] = 3;
+        p[17] = 12;
+        p[18] = 0; // net
+        p[19] = 0; // sub
+        p[26..35].copy_from_slice(b"edmx1-pro");
+        p[44..65].copy_from_slice(b"DMXking.com eDMX1 PRO");
+        p[174] = 0xc0; // PortTypes[0]: output + input capable
+        p[190] = 0; // SwOut[0]
+        p
+    }
+
+    #[test]
+    fn parses_real_edmx_reply_shape() {
+        let node = parse_reply(&sample_reply()).expect("valid reply");
+        assert_eq!(node.ip, Ipv4Addr::new(192, 168, 1, 111));
+        assert_eq!(node.firmware, (3, 12));
+        assert_eq!(node.short_name, "edmx1-pro");
+        assert_eq!(node.long_name, "DMXking.com eDMX1 PRO");
+        assert!(node.output);
+        assert_eq!(node.sacn_universe(), 1); // Net 0 / Sub 0 / Uni 0 -> sACN universe 1
+    }
+
+    #[test]
+    fn universe_math_matches_artnet_offset() {
+        let node = |net: u8, sub: u8, sw_out: u8| ArtNetNode {
+            ip: Ipv4Addr::UNSPECIFIED,
+            short_name: String::new(),
+            long_name: String::new(),
+            firmware: (0, 0),
+            output: true,
+            net,
+            sub,
+            sw_out,
+        };
+        assert_eq!(node(0, 0, 0).sacn_universe(), 1); // first universe
+        assert_eq!(node(0, 0, 3).sacn_universe(), 4); // eDMX4 default top port
+        assert_eq!(node(1, 0, 0).sacn_universe(), 257); // Net 1 -> Port-Address 256
+    }
+
+    #[test]
+    fn rejects_non_replies() {
+        assert!(parse_reply(b"too short").is_none());
+        let mut wrong_op = sample_reply();
+        wrong_op[8..10].copy_from_slice(&0x2000u16.to_le_bytes()); // an ArtPoll, not a reply
+        assert!(parse_reply(&wrong_op).is_none());
+    }
+
+    #[test]
+    fn artpoll_is_well_formed() {
+        let p = build_artpoll();
+        assert_eq!(&p[0..8], b"Art-Net\0");
+        assert_eq!(u16::from_le_bytes([p[8], p[9]]), 0x2000); // OpCode ArtPoll
+        assert_eq!(p[11], 14); // ProtVerLo
+    }
+
+    #[test]
+    #[ignore = "hits the LAN; run with `--ignored --nocapture` against a real Art-Net node"]
+    fn live_discover() {
+        let nodes = discover(Duration::from_millis(3000));
+        for n in &nodes {
+            println!(
+                "{} '{}' fw {}.{} -> sACN universe {}",
+                n.ip,
+                n.short_name,
+                n.firmware.0,
+                n.firmware.1,
+                n.sacn_universe()
+            );
+        }
+        assert!(!nodes.is_empty(), "no Art-Net nodes answered on the LAN");
+    }
+}

--- a/src-tauri/src/devices/enttec_open_dmx_usb.rs
+++ b/src-tauri/src/devices/enttec_open_dmx_usb.rs
@@ -179,3 +179,33 @@ impl Default for EnttecOpenDMX {
         EnttecOpenDMX::new().unwrap()
     }
 }
+
+/// `DmxSink` adapter for the Enttec Open DMX USB. Each render re-enumerates,
+/// opens, writes, and closes the FTDI device — the device is stateless between
+/// frames and `LuxBuffer` only renders on change, so per-frame open/close is
+/// fine. Fails (e.g. `DEVICE_NOT_FOUND`) when no unit is attached.
+pub struct EnttecSink;
+
+impl super::DmxSink for EnttecSink {
+    fn render(&self, channels: &[u8]) -> Result<(), String> {
+        // Pack the fixture channels into a 513-byte DMX frame: index 0 is the
+        // start code, 1..=N the channel data.
+        let mut frame = [0u8; BUF_SIZE];
+        let n = channels.len().min(BUF_SIZE - 1);
+        frame[1..1 + n].copy_from_slice(&channels[..n]);
+
+        let mut interface = EnttecOpenDMX::new()
+            .map_err(|e| format!("Enttec OpenDMX USB initialization failed: {e}"))?;
+        interface
+            .open()
+            .map_err(|e| format!("Enttec OpenDMX USB failed to open: {e:?}"))?;
+        interface.set_buffer(frame);
+        interface
+            .render()
+            .map_err(|e| format!("Enttec OpenDMX USB failed to render: {e:?}"))?;
+        interface
+            .close()
+            .map_err(|e| format!("Enttec OpenDMX USB failed to close: {e:?}"))?;
+        Ok(())
+    }
+}

--- a/src-tauri/src/devices/mod.rs
+++ b/src-tauri/src/devices/mod.rs
@@ -1,1 +1,326 @@
+//! DMX output transports + device auto-detection.
+//!
+//! A [`DmxSink`] is "somewhere to push the fixture's channel bytes". Two impls
+//! exist: the Enttec Open DMX USB (a local FTDI device) and sACN/E1.31
+//! multicast (network nodes like the DMXKing eDMX1 Pro). [`detect_devices`]
+//! finds what's actually present — FTDI over USB and Art-Net nodes over the
+//! network — and the tray lets you pick one; the chosen sink lives in
+//! [`DmxOutput`] and is swapped in at runtime. The render path
+//! (`buffer::render`) stays transport-agnostic.
+
+pub mod discovery;
 pub mod enttec_open_dmx_usb;
+pub mod sacn;
+
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tauri::{AppHandle, Manager, Runtime};
+
+/// A DMX output: take the fixture's channel bytes (lux uses 6: RGBAW + master)
+/// and push them to hardware.
+pub trait DmxSink: Send + Sync {
+    fn render(&self, channels: &[u8]) -> Result<(), String>;
+}
+
+/// The kind of transport behind a [`Device`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    Enttec,
+    Sacn,
+}
+
+impl Transport {
+    /// Network transports must be re-sent periodically (the node times out and
+    /// drops the light otherwise); the USB device holds its last frame.
+    pub fn needs_keepalive(self) -> bool {
+        matches!(self, Transport::Sacn)
+    }
+}
+
+/// A detected output the user can select from the tray.
+#[derive(Debug, Clone)]
+pub struct Device {
+    pub transport: Transport,
+    /// sACN universe to drive (auto-detected via Art-Net); ignored for Enttec.
+    pub universe: u16,
+    /// Human-readable menu label, e.g. `eDMX1 PRO — 192.168.1.111 · U1`.
+    pub label: String,
+}
+
+impl Device {
+    /// Stable identity used as the tray menu-item id and persistence key.
+    pub fn key(&self) -> String {
+        match self.transport {
+            Transport::Enttec => "enttec".to_string(),
+            Transport::Sacn => format!("sacn:{}", self.universe),
+        }
+    }
+}
+
+/// Detect available outputs: FTDI/USB (Enttec) and Art-Net/sACN network nodes.
+/// Network discovery blocks ~1.5s, so call this off the UI thread.
+pub fn detect_devices() -> Vec<Device> {
+    let mut devices = Vec::new();
+
+    // USB: any FTDI device present means an Enttec-compatible interface is here.
+    match libftd2xx::list_devices() {
+        Ok(infos) if !infos.is_empty() => {
+            let detail = infos
+                .iter()
+                .map(|i| i.description.clone())
+                .find(|d| !d.is_empty())
+                .unwrap_or_else(|| "FT232".to_string());
+            log::info!("detected USB FTDI interface ({detail})");
+            devices.push(Device {
+                transport: Transport::Enttec,
+                universe: 1,
+                label: format!("Enttec Open DMX USB ({detail})"),
+            });
+        }
+        Ok(_) => {}
+        Err(e) => log::debug!("FTDI enumeration: {e:?}"),
+    }
+
+    // Network: Art-Net discovery — each output-capable node becomes an sACN device.
+    // Nodes reply with a random delay, so give discovery a few seconds.
+    for n in discovery::discover(Duration::from_millis(3000)) {
+        if !n.output {
+            continue;
+        }
+        log::info!(
+            "detected Art-Net node {} ({}, fw {}.{}) at {} -> sACN universe {}",
+            n.short_name,
+            n.long_name,
+            n.firmware.0,
+            n.firmware.1,
+            n.ip,
+            n.sacn_universe()
+        );
+        devices.push(Device {
+            transport: Transport::Sacn,
+            universe: n.sacn_universe(),
+            label: format!("{} — {} · U{}", n.short_name, n.ip, n.sacn_universe()),
+        });
+    }
+    devices
+}
+
+/// Pick which detected device to make active: the remembered one if still
+/// present, else the lone device, else prefer a network node, else nothing.
+fn choose_active(devices: &[Device], saved: Option<&str>) -> Option<Device> {
+    if let Some(key) = saved {
+        if let Some(d) = devices.iter().find(|d| d.key() == key) {
+            return Some(d.clone());
+        }
+    }
+    devices
+        .iter()
+        .find(|d| d.transport == Transport::Sacn)
+        .or_else(|| devices.first())
+        .cloned()
+}
+
+/// Tauri-managed state: the active output sink plus the last detection result
+/// (so the tray can list devices). The sink is swapped in place on switch, so
+/// all callers — render path and keepalive — see the new device.
+pub struct DmxOutput {
+    inner: Mutex<Active>,
+    devices: Mutex<Vec<Device>>,
+}
+
+struct Active {
+    transport: Transport,
+    sink: Arc<dyn DmxSink>,
+    key: String,
+}
+
+impl Default for DmxOutput {
+    fn default() -> Self {
+        // No device selected until detection runs (right at startup).
+        DmxOutput {
+            inner: Mutex::new(Active {
+                transport: Transport::Enttec,
+                sink: Arc::new(NullSink),
+                key: String::new(),
+            }),
+            devices: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl DmxOutput {
+    pub fn render(&self, channels: &[u8]) -> Result<(), String> {
+        // Clone the Arc out of the lock so a (possibly slow) render doesn't hold
+        // it — a tray switch can then proceed concurrently.
+        let sink = self.inner.lock().unwrap().sink.clone();
+        sink.render(channels)
+    }
+
+    pub fn needs_keepalive(&self) -> bool {
+        self.inner.lock().unwrap().transport.needs_keepalive()
+    }
+
+    pub fn active_key(&self) -> String {
+        self.inner.lock().unwrap().key.clone()
+    }
+
+    pub fn devices(&self) -> Vec<Device> {
+        self.devices.lock().unwrap().clone()
+    }
+
+    fn set_devices(&self, devices: Vec<Device>) {
+        *self.devices.lock().unwrap() = devices;
+    }
+
+    fn set_device(&self, device: &Device) {
+        let sink = build_sink(device);
+        let mut active = self.inner.lock().unwrap();
+        active.transport = device.transport;
+        active.sink = sink;
+        active.key = device.key();
+    }
+}
+
+/// A sink that drops frames — active when nothing is selected or a transport
+/// can't initialize, so the UI still works (optimistic emits) while we log why.
+struct NullSink;
+impl DmxSink for NullSink {
+    fn render(&self, _channels: &[u8]) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+fn build_sink(device: &Device) -> Arc<dyn DmxSink> {
+    match device.transport {
+        Transport::Enttec => Arc::new(enttec_open_dmx_usb::EnttecSink),
+        Transport::Sacn => match sacn::SacnSink::new(device.universe, sacn_interface_override()) {
+            Ok(sink) => Arc::new(sink),
+            Err(e) => {
+                log::error!("sACN init failed ({e}); output disabled until reselected");
+                Arc::new(NullSink)
+            }
+        },
+    }
+}
+
+/// Optional advanced override for which local NIC sends multicast (multi-homed
+/// machines); normally unset — the OS routes out the interface the node is on.
+fn sacn_interface_override() -> Option<Ipv4Addr> {
+    let _ = dotenvy::dotenv();
+    std::env::var("LUX_SACN_INTERFACE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse::<Ipv4Addr>().ok())
+}
+
+// --- runtime selection + auto-detect ---------------------------------------
+
+/// Make `device` the active output: build its sink, remember it, and push the
+/// current buffer so it lights up immediately. Cheap (no discovery) — safe to
+/// call on the UI thread from the tray handler.
+pub fn switch_to_device<R: Runtime>(app: &AppHandle<R>, device: &Device) {
+    app.state::<DmxOutput>().set_device(device);
+    persist_key(app, &device.key());
+    let buffer = *app.state::<crate::buffer::LuxBuffer>().buffer.lock().unwrap();
+    if let Err(e) = app.state::<DmxOutput>().render(&buffer) {
+        log::trace!("post-switch render failed: {e}");
+    }
+    log::info!("active DMX output: {}", device.label);
+}
+
+/// Manual rescan (tray "Rescan"): one detection pass off the UI thread, then
+/// auto-select and rebuild the menu.
+pub fn rescan<R: Runtime>(app: &AppHandle<R>) {
+    let app = app.clone();
+    std::thread::spawn(move || apply_detection(&app, detect_devices()));
+}
+
+/// Startup auto-detect: retry until a device appears. The first scan right after
+/// launch often comes up empty — the network stack (and macOS local-network
+/// access) is still warming up, so the eDMX's reply misses that first window.
+/// Retry a few times before giving up, so no manual "Rescan" is needed.
+pub fn start_autodetect<R: Runtime>(app: &AppHandle<R>) {
+    let app = app.clone();
+    std::thread::spawn(move || {
+        for attempt in 1..=6 {
+            let devices = detect_devices();
+            if !devices.is_empty() {
+                apply_detection(&app, devices);
+                return;
+            }
+            log::debug!("auto-detect attempt {attempt}: nothing yet, retrying");
+            std::thread::sleep(Duration::from_secs(1));
+        }
+        log::info!("auto-detect found nothing; connect a device and use the tray's Rescan");
+    });
+}
+
+/// Apply a detection result: pick the active device and refresh the tray. Menu
+/// mutation must run on the main thread.
+fn apply_detection<R: Runtime>(app: &AppHandle<R>, devices: Vec<Device>) {
+    let active = choose_active(&devices, saved_key(app).as_deref());
+    app.state::<DmxOutput>().set_devices(devices);
+    let app = app.clone();
+    let _ = app.clone().run_on_main_thread(move || {
+        if let Some(device) = active {
+            switch_to_device(&app, &device);
+        }
+        if let Err(e) = crate::tray::refresh(&app) {
+            log::warn!("tray refresh failed: {e}");
+        }
+    });
+}
+
+// --- persistence ------------------------------------------------------------
+
+fn persist_key<R: Runtime>(app: &AppHandle<R>, key: &str) {
+    if let Some(path) = key_file(app) {
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        if let Err(e) = std::fs::write(&path, key) {
+            log::warn!("could not persist device choice: {e}");
+        }
+    }
+}
+
+fn saved_key<R: Runtime>(app: &AppHandle<R>) -> Option<String> {
+    key_file(app)
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn key_file<R: Runtime>(app: &AppHandle<R>) -> Option<PathBuf> {
+    app.path()
+        .app_config_dir()
+        .ok()
+        .map(|dir| dir.join("dmx-device"))
+}
+
+// --- keepalive --------------------------------------------------------------
+
+/// Spawn the keepalive loop for the life of the app. Each second it re-sends the
+/// current buffer *only* while a network transport is active, so the node
+/// doesn't time out and drop the light when the UI is idle. Sends directly
+/// through the sink, bypassing `LuxBuffer::set`, so it never re-emits UI events.
+pub fn start_keepalive<R: Runtime>(app: &AppHandle<R>) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(1));
+        loop {
+            tick.tick().await;
+            if !app.state::<DmxOutput>().needs_keepalive() {
+                continue;
+            }
+            // Copy out of the lock before the render so no guard is held across it.
+            let buffer = *app.state::<crate::buffer::LuxBuffer>().buffer.lock().unwrap();
+            if let Err(e) = app.state::<DmxOutput>().render(&buffer) {
+                log::trace!("sACN keepalive render failed: {e}");
+            }
+        }
+    });
+}

--- a/src-tauri/src/devices/sacn.rs
+++ b/src-tauri/src/devices/sacn.rs
@@ -1,0 +1,171 @@
+//! ANSI E1.31 (sACN) multicast output — for network DMX nodes like the
+//! DMXKing eDMX1 Pro.
+//!
+//! Unlike the Enttec Open DMX USB (a "dumb" FTDI chip the host bit-bangs the
+//! DMX waveform through), an sACN node receives DMX *frames* over the network
+//! and generates the waveform itself. We build a standard E1.31 data packet
+//! (root + framing + DMP layers, full 512-slot universe) and send it to the
+//! universe's well-known multicast group `239.255.{hi}.{lo}` on UDP 5568.
+//!
+//! Multicast means we never need the node's IP address — the eDMX1 Pro (which
+//! defaults to DHCP) subscribes to the multicast group for its configured
+//! universe, so this is genuinely zero-config beyond matching the universe.
+
+use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use super::DmxSink;
+
+/// E1.31 listens on UDP 5568 (ACN-defined).
+const SACN_PORT: u16 = 5568;
+/// Total packet length for a full 512-slot universe:
+/// root layer (38) + framing layer (77) + DMP layer (523).
+const PACKET_LEN: usize = 638;
+
+/// An sACN/E1.31 multicast sender bound to a single DMX universe.
+pub struct SacnSink {
+    socket: UdpSocket,
+    dest: SocketAddrV4,
+    universe: u16,
+    /// Sender component identifier — stable for the life of the process.
+    cid: [u8; 16],
+    /// Per-packet sequence number; receivers use it to spot lost/old packets.
+    /// Wraps 255 -> 0 naturally via `AtomicU8`.
+    sequence: AtomicU8,
+}
+
+impl SacnSink {
+    /// Bind a sender for `universe` (1..=63999). When `interface` is given (a
+    /// local NIC's IPv4), bind to it so multicast egresses that interface —
+    /// needed on multi-homed machines (e.g. Wi-Fi + Ethernet) where the node
+    /// hangs off a specific NIC. Otherwise bind `0.0.0.0` and let the OS route.
+    pub fn new(universe: u16, interface: Option<Ipv4Addr>) -> Result<Self, String> {
+        if universe == 0 || universe > 63999 {
+            return Err(format!("sACN universe {universe} out of range (1..=63999)"));
+        }
+        let bind_ip = interface.unwrap_or(Ipv4Addr::UNSPECIFIED);
+        let socket = UdpSocket::bind((bind_ip, 0))
+            .map_err(|e| format!("sACN socket bind to {bind_ip} failed: {e}"))?;
+        // Universe N -> multicast group 239.255.{N>>8}.{N&0xff} (per E1.31).
+        let group = Ipv4Addr::new(239, 255, (universe >> 8) as u8, (universe & 0xff) as u8);
+        Ok(Self {
+            socket,
+            dest: SocketAddrV4::new(group, SACN_PORT),
+            universe,
+            cid: *uuid::Uuid::new_v4().as_bytes(),
+            sequence: AtomicU8::new(0),
+        })
+    }
+}
+
+impl DmxSink for SacnSink {
+    fn render(&self, channels: &[u8]) -> Result<(), String> {
+        let seq = self.sequence.fetch_add(1, Ordering::Relaxed);
+        let packet = build_packet(&self.cid, self.universe, channels, seq);
+        self.socket
+            .send_to(&packet, self.dest)
+            .map(|_| ())
+            .map_err(|e| format!("sACN send to {} failed: {e}", self.dest))
+    }
+}
+
+/// Build one E1.31 data packet carrying `channels` at DMX slots 1.. of
+/// `universe`. Free function (not a method) so the byte layout is testable
+/// without binding a socket. Layout follows ANSI E1.31-2018 §4.1.
+fn build_packet(cid: &[u8; 16], universe: u16, channels: &[u8], sequence: u8) -> [u8; PACKET_LEN] {
+    let mut p = [0u8; PACKET_LEN];
+
+    // ---- Root layer (ACN root, 38 bytes) ----
+    p[0..2].copy_from_slice(&0x0010u16.to_be_bytes()); // preamble size
+                                                       // [2..4] post-amble size = 0
+    p[4..16].copy_from_slice(b"ASC-E1.17\0\0\0"); // ACN packet identifier
+    p[16..18].copy_from_slice(&(0x7000u16 | (PACKET_LEN as u16 - 16)).to_be_bytes()); // flags+length
+    p[18..22].copy_from_slice(&4u32.to_be_bytes()); // VECTOR_ROOT_E131_DATA
+    p[22..38].copy_from_slice(cid);
+
+    // ---- Framing layer (77 bytes) ----
+    p[38..40].copy_from_slice(&(0x7000u16 | (PACKET_LEN as u16 - 38)).to_be_bytes()); // flags+length
+    p[40..44].copy_from_slice(&2u32.to_be_bytes()); // VECTOR_E131_DATA_PACKET
+    p[44..47].copy_from_slice(b"lux"); // source name (64 bytes, null-padded)
+    p[108] = 100; // priority (0..=200, 100 = default)
+                  // [109..111] synchronization address = 0 (unused)
+    p[111] = sequence;
+    // [112] options = 0 (not preview, not terminated)
+    p[113..115].copy_from_slice(&universe.to_be_bytes());
+
+    // ---- DMP layer (523 bytes) ----
+    p[115..117].copy_from_slice(&(0x7000u16 | (PACKET_LEN as u16 - 115)).to_be_bytes()); // flags+length
+    p[117] = 0x02; // VECTOR_DMP_SET_PROPERTY
+    p[118] = 0xa1; // address type & data type
+                   // [119..121] first property address = 0
+    p[121..123].copy_from_slice(&1u16.to_be_bytes()); // address increment
+    p[123..125].copy_from_slice(&513u16.to_be_bytes()); // property value count (start code + 512 slots)
+                                                        // [125] DMX start code = 0
+    let n = channels.len().min(512);
+    p[126..126 + n].copy_from_slice(&channels[..n]); // slots 1.. carry the fixture channels
+
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn packet_layout_is_e131_conformant() {
+        let cid = [0xABu8; 16];
+        let channels = [10u8, 20, 30, 40, 50, 60];
+        let p = build_packet(&cid, 1, &channels, 7);
+
+        assert_eq!(p.len(), 638);
+        // Root layer
+        assert_eq!(p[0..2], [0x00, 0x10]); // preamble size = 16
+        assert_eq!(p[2..4], [0x00, 0x00]); // post-amble size = 0
+        assert_eq!(p[4..16], *b"ASC-E1.17\0\0\0"); // ACN packet identifier
+        assert_eq!(p[16..18], [0x72, 0x6e]); // flags(0x7) + length 622
+        assert_eq!(p[18..22], [0, 0, 0, 4]); // VECTOR_ROOT_E131_DATA
+        assert_eq!(p[22..38], cid);
+        // Framing layer
+        assert_eq!(p[38..40], [0x72, 0x58]); // flags(0x7) + length 600
+        assert_eq!(p[40..44], [0, 0, 0, 2]); // VECTOR_E131_DATA_PACKET
+        assert_eq!(p[44..47], *b"lux"); // source name
+        assert_eq!(p[108], 100); // priority
+        assert_eq!(p[111], 7); // sequence
+        assert_eq!(p[113..115], [0, 1]); // universe 1
+        // DMP layer
+        assert_eq!(p[115..117], [0x72, 0x0b]); // flags(0x7) + length 523
+        assert_eq!(p[117], 0x02); // VECTOR_DMP_SET_PROPERTY
+        assert_eq!(p[118], 0xa1); // address & data type
+        assert_eq!(p[121..123], [0, 1]); // address increment
+        assert_eq!(p[123..125], [0x02, 0x01]); // property value count = 513
+        assert_eq!(p[125], 0x00); // DMX start code
+        assert_eq!(p[126..132], channels); // fixture channels at slots 1..=6
+        assert!(p[132..].iter().all(|&b| b == 0)); // remaining slots zeroed
+    }
+
+    #[test]
+    fn universe_maps_to_multicast_group() {
+        let sink = SacnSink::new(1, None).unwrap();
+        assert_eq!(sink.dest, SocketAddrV4::new(Ipv4Addr::new(239, 255, 0, 1), 5568));
+        // 300 = 0x012C -> 239.255.1.44
+        let sink = SacnSink::new(300, None).unwrap();
+        assert_eq!(sink.dest.ip(), &Ipv4Addr::new(239, 255, 1, 44));
+    }
+
+    #[test]
+    fn rejects_out_of_range_universe() {
+        assert!(SacnSink::new(0, None).is_err());
+        assert!(SacnSink::new(64000, None).is_err());
+    }
+
+    #[test]
+    fn sequence_increments_and_wraps() {
+        let sink = SacnSink::new(1, None).unwrap();
+        // fetch_add returns the prior value; first render uses 0, then 1, 2...
+        assert_eq!(sink.sequence.fetch_add(1, Ordering::Relaxed), 0);
+        assert_eq!(sink.sequence.fetch_add(1, Ordering::Relaxed), 1);
+        sink.sequence.store(255, Ordering::Relaxed);
+        assert_eq!(sink.sequence.fetch_add(1, Ordering::Relaxed), 255);
+        assert_eq!(sink.sequence.load(Ordering::Relaxed), 0); // wrapped
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,10 +10,12 @@ mod error;
 mod logger;
 mod remote;
 mod sync;
+mod tray;
 
-use buffer::{EmitMode, LuxBuffer};
+use buffer::LuxBuffer;
 use channels::LuxChannels;
 use cmd::*;
+use devices::DmxOutput;
 use sync::*;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -24,9 +26,13 @@ pub async fn run() {
 
     let builder = setup(tauri::Builder::default(), |app| {
         remote::connect(app.handle());
-        if let Err(e) = build_tray(app) {
+        if let Err(e) = tray::build(app) {
             log::error!("tray setup failed: {e}");
         }
+        // Auto-detect DMX devices (USB + network), select one, and populate the
+        // tray (retries through cold-start); then keep the network node fed.
+        devices::start_autodetect(app.handle());
+        devices::start_keepalive(app.handle());
     });
     let default_buffer = LuxBuffer::from([121, 255, 255, 0, 0, 42]);
     let default_channels = LuxChannels::default();
@@ -41,7 +47,7 @@ pub async fn run() {
         .plugin(logger::logger().build())
         .manage(default_buffer)
         .manage(default_channels)
-        .manage(EmitMode::default())
+        .manage(DmxOutput::default())
         .invoke_handler(taurpc)
         .run(tauri::generate_context!())
         .expect("error while running tauri application")
@@ -53,51 +59,6 @@ where
     F: FnOnce(&tauri::App<R>) + Send + 'static,
 {
     builder.setup(move |app| Ok(setup(app)))
-}
-
-/// Build the menu-bar (tray) menu. Its one toggle flips `EmitMode` so you can
-/// feel, on real hardware, whether the UI feels more "real-time" updating before
-/// or after the DMX render.
-fn build_tray<R: tauri::Runtime>(app: &tauri::App<R>) -> tauri::Result<()> {
-    use tauri::image::Image;
-    use tauri::menu::{CheckMenuItemBuilder, Menu, MenuItemBuilder, PredefinedMenuItem};
-    use tauri::tray::TrayIconBuilder;
-    use tauri::Manager;
-
-    let optimistic = CheckMenuItemBuilder::with_id("toggle_optimistic", "Optimistic light updates")
-        .checked(app.state::<EmitMode>().optimistic())
-        .build(app)?;
-    let quit = MenuItemBuilder::with_id("quit", "Quit lux").build(app)?;
-    let menu = Menu::with_items(
-        app,
-        &[&optimistic, &PredefinedMenuItem::separator(app)?, &quit],
-    )?;
-
-    let toggle = optimistic.clone();
-    TrayIconBuilder::with_id("lux-tray")
-        .icon(Image::from_bytes(include_bytes!("../icons/tray.png"))?)
-        .icon_as_template(true)
-        .menu(&menu)
-        .on_menu_event(move |app, event| match event.id.as_ref() {
-            "toggle_optimistic" => {
-                let mode = app.state::<EmitMode>();
-                let on = !mode.optimistic();
-                mode.set(on);
-                let _ = toggle.set_checked(on);
-                log::info!(
-                    "light updates: {}",
-                    if on {
-                        "optimistic (before DMX render)"
-                    } else {
-                        "after DMX render"
-                    }
-                );
-            }
-            "quit" => app.exit(0),
-            _ => {}
-        })
-        .build(app)?;
-    Ok(())
 }
 
 pub fn ttipc_bindings() -> ttipc::Bindings {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,95 @@
+//! System-tray menu.
+//!
+//! Lists the auto-detected DMX devices (USB + network nodes), a "Rescan" action,
+//! and quit. The device list is dynamic: it's (re)built from the last
+//! [`DmxOutput`] detection result, with the active device checked. Selecting a
+//! device switches the live output; "Rescan" re-detects. The optimistic-update
+//! toggle is gone — optimistic emits are now always on (a network node in the
+//! path makes leading the render mandatory).
+
+use tauri::image::Image;
+use tauri::menu::{CheckMenuItemBuilder, IsMenuItem, Menu, MenuItemBuilder, PredefinedMenuItem};
+use tauri::tray::TrayIconBuilder;
+use tauri::{App, AppHandle, Manager, Runtime};
+
+use crate::devices::{self, DmxOutput};
+
+const TRAY_ID: &str = "lux-tray";
+
+/// Create the tray icon and its (initially empty) menu, wiring the menu-event
+/// handler. Devices populate once `devices::rescan` finishes detection.
+pub fn build<R: Runtime>(app: &App<R>) -> tauri::Result<()> {
+    let menu = build_menu(app.handle())?;
+    TrayIconBuilder::with_id(TRAY_ID)
+        .icon(Image::from_bytes(include_bytes!("../icons/tray.png"))?)
+        .icon_as_template(true)
+        .menu(&menu)
+        .on_menu_event(move |app, event| match event.id.as_ref() {
+            "quit" => app.exit(0),
+            "rescan" => devices::rescan(app),
+            "header" | "none" => {}
+            key => {
+                if let Some(device) = app
+                    .state::<DmxOutput>()
+                    .devices()
+                    .into_iter()
+                    .find(|d| d.key() == key)
+                {
+                    devices::switch_to_device(app, &device);
+                    if let Err(e) = refresh(app) {
+                        log::warn!("tray refresh failed: {e}");
+                    }
+                }
+            }
+        })
+        .build(app)?;
+    Ok(())
+}
+
+/// Rebuild the menu from the current detection result + active device and set it
+/// on the tray. Must run on the main thread (menu mutation is a UI operation).
+pub fn refresh<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
+    let menu = build_menu(app)?;
+    if let Some(tray) = app.tray_by_id(TRAY_ID) {
+        tray.set_menu(Some(menu))?;
+    }
+    Ok(())
+}
+
+fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
+    let output = app.state::<DmxOutput>();
+    let devices = output.devices();
+    let active = output.active_key();
+
+    let mut items: Vec<Box<dyn IsMenuItem<R>>> = Vec::new();
+    items.push(Box::new(
+        MenuItemBuilder::with_id("header", "DMX output")
+            .enabled(false)
+            .build(app)?,
+    ));
+    if devices.is_empty() {
+        items.push(Box::new(
+            MenuItemBuilder::with_id("none", "No devices detected")
+                .enabled(false)
+                .build(app)?,
+        ));
+    } else {
+        for d in &devices {
+            items.push(Box::new(
+                CheckMenuItemBuilder::with_id(d.key(), &d.label)
+                    .checked(d.key() == active)
+                    .build(app)?,
+            ));
+        }
+    }
+    items.push(Box::new(PredefinedMenuItem::separator(app)?));
+    items.push(Box::new(
+        MenuItemBuilder::with_id("rescan", "Rescan devices").build(app)?,
+    ));
+    items.push(Box::new(
+        MenuItemBuilder::with_id("quit", "Quit lux").build(app)?,
+    ));
+
+    let refs: Vec<&dyn IsMenuItem<R>> = items.iter().map(|i| i.as_ref()).collect();
+    Menu::with_items(app, &refs)
+}


### PR DESCRIPTION
## What

Adds network DMX output so lux can drive the **DMXKing eDMX1 Pro** (and other Art-Net/sACN nodes) over **sACN/E1.31 multicast**, alongside the existing Enttec Open DMX USB. Output now lives behind a `DmxSink` transport trait and is **auto-detected and selected from the tray** — no env config.

## Highlights

- **Auto-detect devices** — FTDI USB enumeration + Art-Net `ArtPoll` discovery. Each detected output appears in the tray; selection persists across launches, switches live, and a "Rescan" item re-detects. Startup retries through the cold-start window.
- **Zero-config universe** — discovery reads the node's universe from its `ArtPollReply`, so there's nothing to configure for the eDMX (it lands on universe 1 automatically).
- **Keepalive** — network transports re-send the current frame ~1×/s so the node doesn't hit its data-loss timeout while the UI is idle.
- **Optimistic updates always on** — removed the tray toggle; with a network node in the render path the UI must lead the render.
- **macOS Local Network** — `src-tauri/Info.plist` adds `NSLocalNetworkUsageDescription` so the notarized build prompts for Local Network access (sACN multicast needs it).
- Hand-rolled E1.31 + ArtPoll/ArtPollReply packets — no new dependencies.

## Testing

- `cargo test` green, including the bindings drift-guard (no IPC surface change) and new unit tests for the sACN packet layout and ArtPollReply parsing.
- Live-verified against real hardware: discovery finds the eDMX1 PRO at 192.168.1.111 / universe 1; the sACN data path drives the fixture end-to-end; `bun run tauri dev` auto-detects and selects it at startup.
- clippy clean in the new modules.

## Not verified here

- The tray menu's click/switch UX (detection + sink-building are tested, but a tray can't be driven from CI) — eyeball after merge.
- The `Info.plist` merge only happens in a full `tauri build` (dev runs the raw binary); validated well-formed with `plutil -lint`.
