### PR TITLE
fix: keep src-tauri/Cargo.lock in sync with the released version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,44 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - uses: actions/checkout@v7
+
       - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please uses release-type "simple", which bumps src-tauri/Cargo.toml
+      # but leaves the `lux` entry in src-tauri/Cargo.lock at the old version, so the
+      # lockfile shows up dirty on the next local `cargo` run. While a release PR is
+      # open, sync the lockfile onto its branch so main never lands a stale lock.
+      # Runs in this job by necessity: a push authored by GITHUB_TOKEN can't trigger
+      # a separate workflow, so the release branch wouldn't get picked up elsewhere.
+      - name: Sync Cargo.lock to the release version
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          set -euo pipefail
+          PR_BRANCH=$(printf '%s' "$PR_JSON" | jq -r '.headBranchName')
+          echo "Release PR branch: $PR_BRANCH"
+          git fetch --depth=1 origin "$PR_BRANCH"
+          git checkout "$PR_BRANCH"
+          version=$(jq -r '."."' .release-please-manifest.json)
+          # The `lux` workspace member has no checksum in the lock, so its version
+          # is a pure text field — sync it without invoking cargo (no dep churn).
+          VER="$version" perl -0pi -e 's/(name = "lux"\nversion = ")[^"]*/$1$ENV{VER}/' src-tauri/Cargo.lock
+          if git diff --quiet -- src-tauri/Cargo.lock; then
+            echo "Cargo.lock already in sync at $version"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src-tauri/Cargo.lock
+          git commit -m "chore: sync Cargo.lock to $version"
+          git push origin "HEAD:$PR_BRANCH"
+          echo "Synced Cargo.lock to $version on $PR_BRANCH"
 
   # Builds the macOS app and attaches it to the release — after a release-please
   # release, or on a manual dispatch for an existing tag. Unsigned for now

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2218,7 +2218,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lux"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dotenvy",


### PR DESCRIPTION
## Problem

`release-please-config.json` uses `release-type: simple`, which bumps the version in `src-tauri/Cargo.toml` (via `extra-files`) but has no awareness of `Cargo.lock`. So every release the `lux` package's own `version` in `src-tauri/Cargo.lock` was left at the previous version, and the next local `cargo` invocation (`cargo tauri dev`, `cargo test`, …) rewrote it — surfacing as a perpetually-dirty `Cargo.lock` after each release. The 0.6.0 release left it at `0.5.0`.

## Fix

- Catch the lockfile up to `0.6.0` (the already-pending working-tree change).
- Add a **Sync Cargo.lock to the release version** step to the `release-please` job. While a release PR is open, it checks out that PR's branch and rewrites the `lux` version in `src-tauri/Cargo.lock` to match `.release-please-manifest.json`, committing it onto the branch. So the lock is correct *before* the release merges, and main never lands a stale lock again.

## Notes

- The `lux` workspace member has no checksum in the lock, so its `version` is a pure text field — the step syncs it with a one-line `perl` substitution and never invokes `cargo`, so there's zero dependency churn. Verified against the current lockfile that it touches exactly that one line.
- The step has to live inside the existing `release-please` job: release-please authors the PR with `GITHUB_TOKEN`, and pushes by `GITHUB_TOKEN` don't trigger a separate workflow, so a standalone `on: push`/`on: pull_request` workflow watching the release branch would never fire.
- Gated on `steps.release.outputs.pr`, so it's a no-op on runs that don't open/update a release PR.