### PR TITLE
feat: add named setups, each a fixture patch bound to a DMX universe

### DIFF
--- a/src-tauri/src/cmd.rs
+++ b/src-tauri/src/cmd.rs
@@ -1,8 +1,10 @@
 use crate::{
-    buffer::{Buffer, LuxBuffer},
+    buffer::{Buffer, LuxBuffer, UNIVERSE_SIZE},
     channel::LuxChannel,
     channels::LuxChannels,
-    fixture::{self, ChannelDef, Fixture, FixturePreset, LuxPatch},
+    devices::{self, DmxOutput},
+    fixture::{self, ChannelDef, Fixture, FixturePreset},
+    setup::{self, LuxSetups, SetupSummary},
     sync::*,
 };
 use tauri::{AppHandle, Manager};
@@ -29,6 +31,7 @@ pub trait CmdMethods {
     ) -> Result<LuxChannel, String>;
     fn sync_state(&self, app_handle: AppHandle) -> Result<String, String>;
     fn list_presets(&self) -> Result<Vec<FixturePreset>, String>;
+    // Fixtures — operate on the active setup's patch.
     fn get_patch(&self, app_handle: AppHandle) -> Result<Vec<Fixture>, String>;
     fn add_fixture(
         &self,
@@ -46,11 +49,43 @@ pub trait CmdMethods {
         channels: Vec<ChannelDef>,
     ) -> Result<Vec<Fixture>, String>;
     fn remove_fixture(&self, app_handle: AppHandle, id: String) -> Result<Vec<Fixture>, String>;
+    // Setups — a user's named (fixtures + universe) configurations.
+    fn list_setups(&self, app_handle: AppHandle) -> Result<Vec<SetupSummary>, String>;
+    fn create_setup(
+        &self,
+        app_handle: AppHandle,
+        name: String,
+        universe: u16,
+    ) -> Result<Vec<SetupSummary>, String>;
+    fn rename_setup(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        name: String,
+    ) -> Result<Vec<SetupSummary>, String>;
+    fn set_setup_universe(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        universe: u16,
+    ) -> Result<Vec<SetupSummary>, String>;
+    fn delete_setup(&self, app_handle: AppHandle, id: String)
+        -> Result<Vec<SetupSummary>, String>;
+    fn set_active_setup(&self, app_handle: AppHandle, id: String) -> Result<SetupSummary, String>;
 }
 #[derive(ttipc::Event)]
 pub enum CmdEvent {
-    ChannelDataSet { channels: Vec<LuxChannel> },
-    PatchSet { fixtures: Vec<Fixture> },
+    ChannelDataSet {
+        channels: Vec<LuxChannel>,
+    },
+    PatchSet {
+        setup_id: String,
+        fixtures: Vec<Fixture>,
+    },
+    SetupsChanged {
+        setups: Vec<SetupSummary>,
+        active_setup_id: String,
+    },
 }
 
 #[derive(Clone)]
@@ -105,7 +140,7 @@ impl CmdMethods for CmdEndpoint {
     }
 
     fn get_patch(&self, app_handle: AppHandle) -> Result<Vec<Fixture>, String> {
-        Ok(app_handle.state::<LuxPatch>().list())
+        Ok(app_handle.state::<LuxSetups>().active_fixtures())
     }
 
     fn add_fixture(
@@ -115,9 +150,9 @@ impl CmdMethods for CmdEndpoint {
         address: u16,
         channels: Vec<ChannelDef>,
     ) -> Result<Vec<Fixture>, String> {
-        let patch = app_handle.state::<LuxPatch>();
-        patch.add(name, address, channels)?;
-        commit_patch(&app_handle, patch.inner())
+        let setups = app_handle.state::<LuxSetups>();
+        setups.add_fixture(name, address, channels)?;
+        commit_patch(&app_handle, setups.inner())
     }
 
     fn update_fixture(
@@ -128,28 +163,153 @@ impl CmdMethods for CmdEndpoint {
         address: u16,
         channels: Vec<ChannelDef>,
     ) -> Result<Vec<Fixture>, String> {
-        let id = uuid::Uuid::parse_str(&id).map_err(|e| format!("bad fixture id: {e}"))?;
-        let patch = app_handle.state::<LuxPatch>();
-        patch.update(id, name, address, channels)?;
-        commit_patch(&app_handle, patch.inner())
+        let id = parse_fixture_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        setups.update_fixture(id, name, address, channels)?;
+        commit_patch(&app_handle, setups.inner())
     }
 
     fn remove_fixture(&self, app_handle: AppHandle, id: String) -> Result<Vec<Fixture>, String> {
-        let id = uuid::Uuid::parse_str(&id).map_err(|e| format!("bad fixture id: {e}"))?;
-        let patch = app_handle.state::<LuxPatch>();
-        patch.remove(id)?;
-        commit_patch(&app_handle, patch.inner())
+        let id = parse_fixture_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        setups.remove_fixture(id)?;
+        commit_patch(&app_handle, setups.inner())
+    }
+
+    fn list_setups(&self, app_handle: AppHandle) -> Result<Vec<SetupSummary>, String> {
+        Ok(app_handle.state::<LuxSetups>().summaries())
+    }
+
+    fn create_setup(
+        &self,
+        app_handle: AppHandle,
+        name: String,
+        universe: u16,
+    ) -> Result<Vec<SetupSummary>, String> {
+        let setups = app_handle.state::<LuxSetups>();
+        setups.create(name, universe)?;
+        commit_setups(&app_handle, setups.inner())
+    }
+
+    fn rename_setup(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        name: String,
+    ) -> Result<Vec<SetupSummary>, String> {
+        let id = parse_setup_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        setups.rename(id, name)?;
+        commit_setups(&app_handle, setups.inner())
+    }
+
+    fn set_setup_universe(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        universe: u16,
+    ) -> Result<Vec<SetupSummary>, String> {
+        let id = parse_setup_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        setups.set_universe(id, universe)?;
+        // Retuning the *active* setup's universe takes effect on the wire now;
+        // a non-active setup just stores the value for when it's next activated.
+        if setups.active_id() == id {
+            devices::set_active_universe(&app_handle, setups.active_universe());
+            rerender_current(&app_handle);
+        }
+        commit_setups(&app_handle, setups.inner())
+    }
+
+    fn delete_setup(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+    ) -> Result<Vec<SetupSummary>, String> {
+        let id = parse_setup_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        let was_active = setups.active_id() == id;
+        setups.delete(id)?;
+        // Deleting the active setup reassigns active inside the store; re-sync the
+        // output and UI to whatever became active, exactly like a manual switch.
+        if was_active {
+            activate(&app_handle, setups.inner())?;
+        }
+        commit_setups(&app_handle, setups.inner())
+    }
+
+    fn set_active_setup(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+    ) -> Result<SetupSummary, String> {
+        let id = parse_setup_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        setups.set_active(id)?;
+        activate(&app_handle, setups.inner())?;
+        commit_setups(&app_handle, setups.inner())?;
+        Ok(setups.active_summary())
     }
 }
 
-/// Persist the patch and broadcast it to the UI, returning the new fixture list.
-fn commit_patch(app: &AppHandle, patch: &LuxPatch) -> Result<Vec<Fixture>, String> {
-    fixture::save(app, patch);
-    let fixtures = patch.list();
+fn parse_fixture_id(id: &str) -> Result<uuid::Uuid, String> {
+    uuid::Uuid::parse_str(id).map_err(|e| format!("bad fixture id: {e}"))
+}
+
+fn parse_setup_id(id: &str) -> Result<uuid::Uuid, String> {
+    uuid::Uuid::parse_str(id).map_err(|e| format!("bad setup id: {e}"))
+}
+
+/// Persist the store and broadcast the active setup's patch to the UI, returning
+/// the new fixture list. The `setup_id` lets the UI ignore a `PatchSet` from a
+/// setup it has already switched away from.
+fn commit_patch(app: &AppHandle, setups: &LuxSetups) -> Result<Vec<Fixture>, String> {
+    setup::save(app, setups);
+    let fixtures = setups.active_fixtures();
     CmdEvent::PatchSet {
+        setup_id: setups.active_id().to_string(),
         fixtures: fixtures.clone(),
     }
     .emit(app)
     .map_err(|e| format!("Failed to emit patch_set event: {e}"))?;
     Ok(fixtures)
+}
+
+/// Persist the store and broadcast the setup list + active id to the UI.
+fn commit_setups(app: &AppHandle, setups: &LuxSetups) -> Result<Vec<SetupSummary>, String> {
+    setup::save(app, setups);
+    let summaries = setups.summaries();
+    CmdEvent::SetupsChanged {
+        setups: summaries.clone(),
+        active_setup_id: setups.active_id().to_string(),
+    }
+    .emit(app)
+    .map_err(|e| format!("Failed to emit setups_changed event: {e}"))?;
+    Ok(summaries)
+}
+
+/// Apply the consequences of the active setup changing: point the live sACN
+/// output at the new setup's universe, black out the universe so one setup's
+/// levels never bleed onto another's fixtures, and re-broadcast the new patch.
+fn activate(app: &AppHandle, setups: &LuxSetups) -> Result<(), String> {
+    devices::set_active_universe(app, setups.active_universe());
+    let mut buffer = app.state::<LuxBuffer>().inner().clone();
+    buffer.set(vec![0u8; UNIVERSE_SIZE], app.clone())?; // emits BufferSet + renders
+    CmdEvent::PatchSet {
+        setup_id: setups.active_id().to_string(),
+        fixtures: setups.active_fixtures(),
+    }
+    .emit(app)
+    .map_err(|e| format!("Failed to emit patch_set event: {e}"))?;
+    Ok(())
+}
+
+/// Re-send the current buffer to the active output without touching the UI —
+/// used after the live universe number changes so the new universe lights up
+/// with the levels already on screen.
+fn rerender_current(app: &AppHandle) {
+    let buffer = app.state::<LuxBuffer>().buffer.lock().unwrap().clone();
+    if let Err(e) = app.state::<DmxOutput>().render(&buffer) {
+        log::trace!("post-universe-change render failed: {e}");
+    }
 }

--- a/src-tauri/src/devices/mod.rs
+++ b/src-tauri/src/devices/mod.rs
@@ -182,6 +182,21 @@ impl DmxOutput {
         active.sink = sink;
         active.key = device.key();
     }
+
+    /// Rebuild the active sink to transmit on `universe`, when the active
+    /// transport is sACN. The persisted device `key` is deliberately left as the
+    /// detected node, so the tray highlight and device memory stay put — only the
+    /// wire universe follows the active setup.
+    fn retarget_universe(&self, universe: u16) {
+        let mut active = self.inner.lock().unwrap();
+        if active.transport == Transport::Sacn {
+            active.sink = build_sink(&Device {
+                transport: Transport::Sacn,
+                universe,
+                label: String::new(),
+            });
+        }
+    }
 }
 
 /// A sink that drops frames — active when nothing is selected or a transport
@@ -223,12 +238,27 @@ fn sacn_interface_override() -> Option<Ipv4Addr> {
 /// call on the UI thread from the tray handler.
 pub fn switch_to_device<R: Runtime>(app: &AppHandle<R>, device: &Device) {
     app.state::<DmxOutput>().set_device(device);
+    // The active setup owns the logical universe; the tray owns the transport. For
+    // a network node, transmit on the active setup's universe rather than the
+    // node's auto-detected one (they match by default, since a new setup defaults
+    // to universe 1 and a node reporting U1 lands there too).
+    if device.transport == Transport::Sacn {
+        let universe = app.state::<crate::setup::LuxSetups>().active_universe();
+        app.state::<DmxOutput>().retarget_universe(universe);
+    }
     persist_key(app, &device.key());
     let buffer = app.state::<crate::buffer::LuxBuffer>().buffer.lock().unwrap().clone();
     if let Err(e) = app.state::<DmxOutput>().render(&buffer) {
         log::trace!("post-switch render failed: {e}");
     }
     log::info!("active DMX output: {}", device.label);
+}
+
+/// Point the live sACN output at `universe` (a no-op for USB). Called when the
+/// active setup changes or its bound universe is edited, so output follows the
+/// setup without disturbing the tray's device selection.
+pub fn set_active_universe<R: Runtime>(app: &AppHandle<R>, universe: u16) {
+    app.state::<DmxOutput>().retarget_universe(universe);
 }
 
 /// Manual rescan (tray "Rescan"): one detection pass off the UI thread, then

--- a/src-tauri/src/fixture.rs
+++ b/src-tauri/src/fixture.rs
@@ -2,18 +2,18 @@
 //!
 //! A [`Fixture`] is `channels.len()` consecutive DMX slots starting at a 1-based
 //! `address`; each [`ChannelDef`] gives that slot a role (which drives the UI
-//! control + colour) and a label. The set of fixtures is the [`LuxPatch`], held
-//! in Tauri state and persisted to `app_config_dir()/patch.json` — the same
-//! lightweight pattern the tray uses for the selected DMX device. Fixtures are
-//! additive: their controls write the shared `LuxBuffer` through the normal
-//! overlay `set` path, so the raw universe desk and color picker are unaffected.
-
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+//! control + colour) and a label. Fixtures are additive: their controls write the
+//! shared `LuxBuffer` through the normal overlay `set` path, so the raw universe
+//! desk and color picker are unaffected.
+//!
+//! This module owns the fixture *domain* — the types, the preset library, and the
+//! placement validation + add/update/remove operations over a `Vec<Fixture>`. It
+//! is deliberately storage-agnostic: a patch is just a `Vec<Fixture>` that lives
+//! inside whichever [`crate::setup::Setup`] is active, and persistence is the
+//! setup store's job.
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use tauri::{Manager, Runtime};
 
 use crate::buffer::UNIVERSE_SIZE;
 use crate::colors::LuxLabelColor;
@@ -112,6 +112,22 @@ pub fn presets() -> Vec<FixturePreset> {
     ]
 }
 
+/// The default single RGBAW fixture at slot 1 — the original PoC patch, now the
+/// seed for a brand-new "Home" setup on first run.
+pub fn default_fixtures() -> Vec<Fixture> {
+    let channels = presets()
+        .into_iter()
+        .find(|p| p.key == "rgbaw")
+        .map(|p| p.channels)
+        .unwrap_or_default();
+    vec![Fixture {
+        id: uuid::Uuid::new_v4(),
+        name: "RGBAW".into(),
+        address: 1,
+        channels,
+    }]
+}
+
 /// Validate a fixture placement against the rest of the patch. Pure (no lock /
 /// `AppHandle`) so it is unit-testable.
 fn validate_placement(address: u16, len: usize, others: &[Fixture]) -> Result<(), String> {
@@ -142,148 +158,68 @@ fn validate_placement(address: u16, len: usize, others: &[Fixture]) -> Result<()
     Ok(())
 }
 
-/// Tauri-managed set of patched fixtures.
-#[derive(Debug)]
-pub struct LuxPatch {
-    pub fixtures: Arc<Mutex<Vec<Fixture>>>,
-}
+// --- patch operations (over a plain `Vec<Fixture>`) -------------------------
+//
+// The patch lives inside the active setup; these helpers mutate that vec in
+// place after validating placement, and the caller persists the owning store.
 
-impl Default for LuxPatch {
-    fn default() -> Self {
-        // Default patch reproduces the original single RGBAW fixture at slot 1.
-        let channels = presets()
-            .into_iter()
-            .find(|p| p.key == "rgbaw")
-            .map(|p| p.channels)
-            .unwrap_or_default();
-        let fixture = Fixture {
-            id: uuid::Uuid::new_v4(),
-            name: "RGBAW".into(),
-            address: 1,
-            channels,
-        };
-        LuxPatch {
-            fixtures: Arc::new(Mutex::new(vec![fixture])),
-        }
-    }
-}
-
-impl LuxPatch {
-    pub fn list(&self) -> Vec<Fixture> {
-        self.fixtures.lock().unwrap().clone()
-    }
-
-    pub fn add(
-        &self,
-        name: String,
-        address: u16,
-        channels: Vec<ChannelDef>,
-    ) -> Result<Fixture, String> {
-        let mut fixtures = self.fixtures.lock().unwrap();
-        validate_placement(address, channels.len(), &fixtures)?;
-        let fixture = Fixture {
-            id: uuid::Uuid::new_v4(),
-            name,
-            address,
-            channels,
-        };
-        fixtures.push(fixture.clone());
-        Ok(fixture)
-    }
-
-    pub fn update(
-        &self,
-        id: uuid::Uuid,
-        name: String,
-        address: u16,
-        channels: Vec<ChannelDef>,
-    ) -> Result<Fixture, String> {
-        let mut fixtures = self.fixtures.lock().unwrap();
-        // Validate against the *other* fixtures so a fixture can move within or
-        // across its own current slots.
-        let others: Vec<Fixture> = fixtures.iter().filter(|f| f.id != id).cloned().collect();
-        if others.len() == fixtures.len() {
-            return Err(format!("fixture {id} not found"));
-        }
-        validate_placement(address, channels.len(), &others)?;
-        let fixture = Fixture {
-            id,
-            name,
-            address,
-            channels,
-        };
-        if let Some(slot) = fixtures.iter_mut().find(|f| f.id == id) {
-            *slot = fixture.clone();
-        }
-        Ok(fixture)
-    }
-
-    pub fn remove(&self, id: uuid::Uuid) -> Result<(), String> {
-        let mut fixtures = self.fixtures.lock().unwrap();
-        let before = fixtures.len();
-        fixtures.retain(|f| f.id != id);
-        if fixtures.len() == before {
-            return Err(format!("fixture {id} not found"));
-        }
-        Ok(())
-    }
-}
-
-// --- persistence (app_config_dir/patch.json) --------------------------------
-
-fn patch_file<R: Runtime>(app: &tauri::AppHandle<R>) -> Option<PathBuf> {
-    app.path()
-        .app_config_dir()
-        .ok()
-        .map(|dir| dir.join("patch.json"))
-}
-
-/// Load the patch from disk, or the default patch when absent/unreadable. An
-/// empty file (`[]`) is honoured — that's a user who deleted every fixture.
-pub fn load<R: Runtime>(app: &tauri::AppHandle<R>) -> LuxPatch {
-    let Some(path) = patch_file(app) else {
-        return LuxPatch::default();
+/// Add a fixture to `fixtures`, validating placement against the existing ones.
+pub fn add(
+    fixtures: &mut Vec<Fixture>,
+    name: String,
+    address: u16,
+    channels: Vec<ChannelDef>,
+) -> Result<Fixture, String> {
+    validate_placement(address, channels.len(), fixtures)?;
+    let fixture = Fixture {
+        id: uuid::Uuid::new_v4(),
+        name,
+        address,
+        channels,
     };
-    match std::fs::read_to_string(&path) {
-        Ok(json) => match serde_json::from_str::<Vec<Fixture>>(&json) {
-            Ok(fixtures) => LuxPatch {
-                fixtures: Arc::new(Mutex::new(fixtures)),
-            },
-            Err(e) => {
-                log::warn!("patch.json unreadable ({e}); using default patch");
-                LuxPatch::default()
-            }
-        },
-        // Absent file → first run → default patch.
-        Err(_) => LuxPatch::default(),
-    }
+    fixtures.push(fixture.clone());
+    Ok(fixture)
 }
 
-/// Persist the current patch to disk. Best-effort (logs on failure).
-pub fn save<R: Runtime>(app: &tauri::AppHandle<R>, patch: &LuxPatch) {
-    let Some(path) = patch_file(app) else { return };
-    if let Some(dir) = path.parent() {
-        let _ = std::fs::create_dir_all(dir);
+/// Move/relabel the fixture `id` in place. Validation runs against the *other*
+/// fixtures, so a fixture may overlap its own current slots while moving.
+pub fn update(
+    fixtures: &mut [Fixture],
+    id: uuid::Uuid,
+    name: String,
+    address: u16,
+    channels: Vec<ChannelDef>,
+) -> Result<Fixture, String> {
+    let others: Vec<Fixture> = fixtures.iter().filter(|f| f.id != id).cloned().collect();
+    if others.len() == fixtures.len() {
+        return Err(format!("fixture {id} not found"));
     }
-    match serde_json::to_string_pretty(&patch.list()) {
-        Ok(json) => {
-            if let Err(e) = std::fs::write(&path, json) {
-                log::warn!("could not persist patch: {e}");
-            }
-        }
-        Err(e) => log::warn!("could not serialize patch: {e}"),
+    validate_placement(address, channels.len(), &others)?;
+    let fixture = Fixture {
+        id,
+        name,
+        address,
+        channels,
+    };
+    if let Some(slot) = fixtures.iter_mut().find(|f| f.id == id) {
+        *slot = fixture.clone();
     }
+    Ok(fixture)
+}
+
+/// Remove the fixture `id`, reporting an error if it wasn't present.
+pub fn remove(fixtures: &mut Vec<Fixture>, id: uuid::Uuid) -> Result<(), String> {
+    let before = fixtures.len();
+    fixtures.retain(|f| f.id != id);
+    if fixtures.len() == before {
+        return Err(format!("fixture {id} not found"));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn empty() -> LuxPatch {
-        LuxPatch {
-            fixtures: Arc::new(Mutex::new(vec![])),
-        }
-    }
 
     fn six() -> Vec<ChannelDef> {
         presets()
@@ -301,46 +237,54 @@ mod tests {
     }
 
     #[test]
-    fn add_then_list_roundtrips() {
-        let patch = empty();
-        let f = patch.add("Left".into(), 1, six()).unwrap();
-        assert_eq!(patch.list().len(), 1);
+    fn default_fixtures_is_one_rgbaw_at_slot_one() {
+        let f = default_fixtures();
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].address, 1);
+        assert_eq!(f[0].channels.len(), 6);
+    }
+
+    #[test]
+    fn add_then_roundtrips() {
+        let mut fixtures = vec![];
+        let f = add(&mut fixtures, "Left".into(), 1, six()).unwrap();
+        assert_eq!(fixtures.len(), 1);
         assert_eq!(f.address, 1);
     }
 
     #[test]
     fn rejects_overlap_but_allows_adjacent() {
-        let patch = empty();
-        patch.add("Left".into(), 1, six()).unwrap(); // slots 1..=6
-        let err = patch.add("Right".into(), 6, six()).unwrap_err(); // 6..=11 overlaps at slot 6
+        let mut fixtures = vec![];
+        add(&mut fixtures, "Left".into(), 1, six()).unwrap(); // slots 1..=6
+        let err = add(&mut fixtures, "Right".into(), 6, six()).unwrap_err(); // 6..=11 overlaps at 6
         assert!(err.contains("overlaps"), "{err}");
-        patch.add("Right".into(), 7, six()).unwrap(); // 7..=12 is adjacent, fine
-        assert_eq!(patch.list().len(), 2);
+        add(&mut fixtures, "Right".into(), 7, six()).unwrap(); // 7..=12 is adjacent, fine
+        assert_eq!(fixtures.len(), 2);
     }
 
     #[test]
     fn rejects_out_of_range() {
-        let patch = empty();
-        assert!(patch.add("x".into(), 511, six()).is_err()); // 511..=516 > 512
-        assert!(patch.add("x".into(), 0, six()).is_err());
-        assert!(patch.add("x".into(), 1, vec![]).is_err()); // no channels
+        let mut fixtures = vec![];
+        assert!(add(&mut fixtures, "x".into(), 511, six()).is_err()); // 511..=516 > 512
+        assert!(add(&mut fixtures, "x".into(), 0, six()).is_err());
+        assert!(add(&mut fixtures, "x".into(), 1, vec![]).is_err()); // no channels
     }
 
     #[test]
     fn update_can_move_a_fixture_onto_its_own_slots() {
-        let patch = empty();
-        let f = patch.add("Left".into(), 1, six()).unwrap();
-        patch.update(f.id, "Left".into(), 2, six()).unwrap(); // overlaps old self only — ok
-        assert_eq!(patch.list()[0].address, 2);
-        assert!(patch.update(uuid::Uuid::new_v4(), "ghost".into(), 1, six()).is_err());
+        let mut fixtures = vec![];
+        let f = add(&mut fixtures, "Left".into(), 1, six()).unwrap();
+        update(&mut fixtures, f.id, "Left".into(), 2, six()).unwrap(); // overlaps old self only — ok
+        assert_eq!(fixtures[0].address, 2);
+        assert!(update(&mut fixtures, uuid::Uuid::new_v4(), "ghost".into(), 1, six()).is_err());
     }
 
     #[test]
     fn remove_deletes_and_reports_missing() {
-        let patch = empty();
-        let f = patch.add("x".into(), 1, six()).unwrap();
-        patch.remove(f.id).unwrap();
-        assert!(patch.list().is_empty());
-        assert!(patch.remove(f.id).is_err());
+        let mut fixtures = vec![];
+        let f = add(&mut fixtures, "x".into(), 1, six()).unwrap();
+        remove(&mut fixtures, f.id).unwrap();
+        assert!(fixtures.is_empty());
+        assert!(remove(&mut fixtures, f.id).is_err());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod error;
 mod fixture;
 mod logger;
 mod remote;
+mod setup;
 mod sync;
 mod tray;
 
@@ -27,8 +28,9 @@ pub async fn run() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     let builder = setup(tauri::Builder::default(), |app| {
-        // Load the saved fixture patch (or the default RGBAW@1) into state.
-        app.manage(fixture::load(app.handle()));
+        // Load the user's setups (migrating a legacy patch.json, or seeding the
+        // default "Home" setup on first run) into state.
+        app.manage(setup::load(app.handle()));
         remote::connect(app.handle());
         if let Err(e) = tray::build(app) {
             log::error!("tray setup failed: {e}");

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -1,0 +1,608 @@
+//! Named Setups: a user's lighting configurations, each a fixture patch bound to
+//! one DMX universe.
+//!
+//! This generalizes the former single anonymous patch (`patch.json`, a bare
+//! `Vec<Fixture>`) into many named [`Setup`]s wrapped in a versioned
+//! [`SetupStore`] persisted to `app_config_dir()/setups.json`. A user owns
+//! several setups ("Home", "Church", "Work"); exactly one is active at a time,
+//! and the active setup's fixtures are what the fixture commands read and write.
+//!
+//! Identity is captured now — a local `user_id` plus per-setup ids — so cloud
+//! accounts can adopt these setups later without re-keying. On first launch with
+//! a legacy `patch.json`, [`load`] migrates it into a single "Home" setup and
+//! leaves the old file behind as `patch.json.migrated`.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use tauri::{Manager, Runtime};
+
+use crate::fixture::{self, ChannelDef, Fixture};
+
+/// Current on-disk schema version for `setups.json`. Bump when the shape changes
+/// and add a step to [`migrate_version`].
+const STORE_VERSION: u32 = 1;
+
+/// Default sACN/E1.31 universe for a new setup.
+const DEFAULT_UNIVERSE: u16 = 1;
+
+/// A named lighting configuration: a fixture patch bound to one DMX universe.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Setup {
+    #[specta(type = String)]
+    pub id: uuid::Uuid,
+    pub name: String,
+    /// sACN/E1.31 universe this setup transmits on (1..=63999).
+    pub universe: u16,
+    pub fixtures: Vec<Fixture>,
+}
+
+/// The whole persisted store (`app_config_dir()/setups.json`).
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SetupStore {
+    pub version: u32,
+    /// Local placeholder identity until cloud accounts land; lets these setups
+    /// bind to a real user later without re-keying.
+    #[specta(type = String)]
+    pub user_id: uuid::Uuid,
+    #[specta(type = String)]
+    pub active_setup_id: uuid::Uuid,
+    pub setups: Vec<Setup>,
+}
+
+/// A lightweight setup descriptor for the switcher UI — no fixtures, so listing
+/// setups doesn't ship every patch.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SetupSummary {
+    #[specta(type = String)]
+    pub id: uuid::Uuid,
+    pub name: String,
+    pub universe: u16,
+    pub fixture_count: u32,
+    pub active: bool,
+}
+
+fn new_setup(name: impl Into<String>, universe: u16, fixtures: Vec<Fixture>) -> Setup {
+    Setup {
+        id: uuid::Uuid::new_v4(),
+        name: name.into(),
+        universe: normalize_universe(universe),
+        fixtures,
+    }
+}
+
+/// sACN universes are 1..=63999; clamp anything out of range so the wire layer
+/// always gets a valid number.
+fn normalize_universe(universe: u16) -> u16 {
+    universe.clamp(1, 63999)
+}
+
+impl Default for SetupStore {
+    fn default() -> Self {
+        // First run reproduces the original single RGBAW@1 patch, as one setup.
+        SetupStore::single(new_setup(
+            "Home",
+            DEFAULT_UNIVERSE,
+            fixture::default_fixtures(),
+        ))
+    }
+}
+
+impl SetupStore {
+    fn single(setup: Setup) -> Self {
+        SetupStore {
+            version: STORE_VERSION,
+            user_id: uuid::Uuid::new_v4(),
+            active_setup_id: setup.id,
+            setups: vec![setup],
+        }
+    }
+
+    fn summaries(&self) -> Vec<SetupSummary> {
+        self.setups
+            .iter()
+            .map(|s| SetupSummary {
+                id: s.id,
+                name: s.name.clone(),
+                universe: s.universe,
+                fixture_count: s.fixtures.len() as u32,
+                active: s.id == self.active_setup_id,
+            })
+            .collect()
+    }
+
+    /// The active setup. `reconcile` guarantees `active_setup_id` resolves and
+    /// the store is non-empty, so this never panics in practice; the fallback to
+    /// the first setup keeps it total even if those invariants were skipped.
+    fn active(&self) -> &Setup {
+        self.setups
+            .iter()
+            .find(|s| s.id == self.active_setup_id)
+            .or_else(|| self.setups.first())
+            .expect("a store always holds at least one setup")
+    }
+
+    fn active_mut(&mut self) -> &mut Setup {
+        let id = self.active_setup_id;
+        let idx = self
+            .setups
+            .iter()
+            .position(|s| s.id == id)
+            .unwrap_or(0);
+        &mut self.setups[idx]
+    }
+}
+
+// --- managed state ----------------------------------------------------------
+
+/// Tauri-managed store of the user's setups. All mutations go through here; the
+/// caller (`cmd.rs`) persists with [`save`] and re-emits to the UI afterward.
+#[derive(Debug)]
+pub struct LuxSetups {
+    pub store: Arc<Mutex<SetupStore>>,
+}
+
+impl From<SetupStore> for LuxSetups {
+    fn from(store: SetupStore) -> Self {
+        LuxSetups {
+            store: Arc::new(Mutex::new(store)),
+        }
+    }
+}
+
+impl LuxSetups {
+    pub fn summaries(&self) -> Vec<SetupSummary> {
+        self.store.lock().unwrap().summaries()
+    }
+
+    pub fn active_id(&self) -> uuid::Uuid {
+        self.store.lock().unwrap().active_setup_id
+    }
+
+    pub fn active_universe(&self) -> u16 {
+        self.store.lock().unwrap().active().universe
+    }
+
+    pub fn active_fixtures(&self) -> Vec<Fixture> {
+        self.store.lock().unwrap().active().fixtures.clone()
+    }
+
+    pub fn active_summary(&self) -> SetupSummary {
+        let store = self.store.lock().unwrap();
+        let active = store.active();
+        SetupSummary {
+            id: active.id,
+            name: active.name.clone(),
+            universe: active.universe,
+            fixture_count: active.fixtures.len() as u32,
+            active: true,
+        }
+    }
+
+    /// Snapshot of the whole store, for persistence.
+    pub fn snapshot(&self) -> SetupStore {
+        self.store.lock().unwrap().clone()
+    }
+
+    // -- fixture ops on the active setup --
+
+    pub fn add_fixture(
+        &self,
+        name: String,
+        address: u16,
+        channels: Vec<ChannelDef>,
+    ) -> Result<(), String> {
+        let mut store = self.store.lock().unwrap();
+        fixture::add(&mut store.active_mut().fixtures, name, address, channels).map(|_| ())
+    }
+
+    pub fn update_fixture(
+        &self,
+        id: uuid::Uuid,
+        name: String,
+        address: u16,
+        channels: Vec<ChannelDef>,
+    ) -> Result<(), String> {
+        let mut store = self.store.lock().unwrap();
+        fixture::update(&mut store.active_mut().fixtures, id, name, address, channels).map(|_| ())
+    }
+
+    pub fn remove_fixture(&self, id: uuid::Uuid) -> Result<(), String> {
+        let mut store = self.store.lock().unwrap();
+        fixture::remove(&mut store.active_mut().fixtures, id)
+    }
+
+    // -- setup CRUD --
+
+    /// Create a new (empty) setup and return its id. Does not switch to it.
+    pub fn create(&self, name: String, universe: u16) -> Result<uuid::Uuid, String> {
+        let name = clean_name(name)?;
+        let setup = new_setup(name, universe, Vec::new());
+        let id = setup.id;
+        self.store.lock().unwrap().setups.push(setup);
+        Ok(id)
+    }
+
+    pub fn rename(&self, id: uuid::Uuid, name: String) -> Result<(), String> {
+        let name = clean_name(name)?;
+        let mut store = self.store.lock().unwrap();
+        let setup = store
+            .setups
+            .iter_mut()
+            .find(|s| s.id == id)
+            .ok_or_else(|| format!("setup {id} not found"))?;
+        setup.name = name;
+        Ok(())
+    }
+
+    pub fn set_universe(&self, id: uuid::Uuid, universe: u16) -> Result<(), String> {
+        let mut store = self.store.lock().unwrap();
+        let setup = store
+            .setups
+            .iter_mut()
+            .find(|s| s.id == id)
+            .ok_or_else(|| format!("setup {id} not found"))?;
+        setup.universe = normalize_universe(universe);
+        Ok(())
+    }
+
+    /// Delete a setup. Refuses to delete the only setup; if the active setup is
+    /// removed, the first remaining one becomes active.
+    pub fn delete(&self, id: uuid::Uuid) -> Result<(), String> {
+        let mut store = self.store.lock().unwrap();
+        if store.setups.len() <= 1 {
+            return Err("can't delete the only setup".into());
+        }
+        if !store.setups.iter().any(|s| s.id == id) {
+            return Err(format!("setup {id} not found"));
+        }
+        store.setups.retain(|s| s.id != id);
+        if store.active_setup_id == id {
+            store.active_setup_id = store.setups[0].id;
+        }
+        Ok(())
+    }
+
+    pub fn set_active(&self, id: uuid::Uuid) -> Result<(), String> {
+        let mut store = self.store.lock().unwrap();
+        if !store.setups.iter().any(|s| s.id == id) {
+            return Err(format!("setup {id} not found"));
+        }
+        store.active_setup_id = id;
+        Ok(())
+    }
+}
+
+fn clean_name(name: String) -> Result<String, String> {
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return Err("setup name can't be empty".into());
+    }
+    Ok(name)
+}
+
+// --- persistence (app_config_dir/setups.json) -------------------------------
+
+fn config_dir<R: Runtime>(app: &tauri::AppHandle<R>) -> Option<PathBuf> {
+    app.path().app_config_dir().ok()
+}
+
+/// Load the store from disk, migrating a legacy `patch.json` if that's all that
+/// exists, and falling back to the default store on first run or unreadable data.
+pub fn load<R: Runtime>(app: &tauri::AppHandle<R>) -> LuxSetups {
+    match config_dir(app) {
+        Some(dir) => load_from_dir(&dir).into(),
+        None => SetupStore::default().into(),
+    }
+}
+
+/// The filesystem orchestration behind [`load`], split out so it can be exercised
+/// against a real temp directory in tests without a Tauri app handle.
+fn load_from_dir(dir: &Path) -> SetupStore {
+    let path = dir.join("setups.json");
+
+    if path.exists() {
+        match std::fs::read_to_string(&path) {
+            Ok(json) => match parse_store(&json) {
+                Ok(mut store) => {
+                    migrate_version(&mut store);
+                    reconcile(&mut store);
+                    return store;
+                }
+                // A present-but-corrupt store is backed up, never silently
+                // overwritten, and we do *not* fall back to the legacy patch.
+                Err(e) => {
+                    log::warn!("setups.json unreadable ({e}); backing it up and starting fresh");
+                    backup_corrupt(&path);
+                    return SetupStore::default();
+                }
+            },
+            Err(e) => {
+                log::warn!("could not read setups.json ({e}); using default store");
+                return SetupStore::default();
+            }
+        }
+    }
+
+    // No store yet — migrate a legacy patch.json if one is present.
+    let legacy = dir.join("patch.json");
+    if legacy.exists() {
+        let json = std::fs::read_to_string(&legacy).unwrap_or_default();
+        let store = migrate_from_legacy(&json);
+        write_store(&path, &store);
+        // Keep the old file as a backup rather than deleting user data.
+        let _ = std::fs::rename(&legacy, dir.join("patch.json.migrated"));
+        log::info!("migrated patch.json -> setups.json (setup \"Home\")");
+        return store;
+    }
+
+    // First run.
+    SetupStore::default()
+}
+
+/// Persist the current store. Best-effort (logs on failure).
+pub fn save<R: Runtime>(app: &tauri::AppHandle<R>, setups: &LuxSetups) {
+    let Some(dir) = config_dir(app) else { return };
+    write_store(&dir.join("setups.json"), &setups.snapshot());
+}
+
+fn write_store(path: &Path, store: &SetupStore) {
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    match serde_json::to_string_pretty(store) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(path, json) {
+                log::warn!("could not persist setups: {e}");
+            }
+        }
+        Err(e) => log::warn!("could not serialize setups: {e}"),
+    }
+}
+
+/// Move a corrupt store aside to `setups.json.corrupt-N` (first free N) so the
+/// user's data is preserved for inspection instead of being clobbered.
+fn backup_corrupt(path: &Path) {
+    for n in 0..1000 {
+        let candidate = PathBuf::from(format!("{}.corrupt-{n}", path.display()));
+        if !candidate.exists() {
+            if let Err(e) = std::fs::rename(path, &candidate) {
+                log::warn!("could not back up corrupt setups.json: {e}");
+            }
+            return;
+        }
+    }
+    log::warn!("too many corrupt setups.json backups; leaving the file in place");
+}
+
+// --- pure helpers (unit-tested without the filesystem) ----------------------
+
+fn parse_store(json: &str) -> Result<SetupStore, serde_json::Error> {
+    serde_json::from_str::<SetupStore>(json)
+}
+
+/// Wrap a legacy bare `Vec<Fixture>` patch into a single "Home" setup.
+/// Unreadable legacy JSON degrades to an empty patch rather than losing the app.
+fn migrate_from_legacy(json: &str) -> SetupStore {
+    let fixtures = serde_json::from_str::<Vec<Fixture>>(json).unwrap_or_default();
+    SetupStore::single(new_setup("Home", DEFAULT_UNIVERSE, fixtures))
+}
+
+/// Bring an older store up to the current schema version. No-op at v1; the hook
+/// is here so the next bump has an obvious home.
+fn migrate_version(store: &mut SetupStore) {
+    // future: match store.version { 1 => { /* v1 -> v2 */ }, _ => {} }
+    store.version = STORE_VERSION;
+}
+
+/// Repair invariants a hand-edited or partially-written store could violate: at
+/// least one setup exists, and `active_setup_id` points at a real one.
+fn reconcile(store: &mut SetupStore) {
+    if store.setups.is_empty() {
+        let setup = new_setup("Home", DEFAULT_UNIVERSE, fixture::default_fixtures());
+        store.active_setup_id = setup.id;
+        store.setups.push(setup);
+        return;
+    }
+    if !store.setups.iter().any(|s| s.id == store.active_setup_id) {
+        store.active_setup_id = store.setups[0].id;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_store_is_one_home_setup_with_rgbaw() {
+        let s = SetupStore::default();
+        assert_eq!(s.version, STORE_VERSION);
+        assert_eq!(s.setups.len(), 1);
+        assert_eq!(s.setups[0].name, "Home");
+        assert_eq!(s.setups[0].universe, 1);
+        assert_eq!(s.active_setup_id, s.setups[0].id);
+        assert_eq!(s.setups[0].fixtures.len(), 1);
+        assert_eq!(s.setups[0].fixtures[0].channels.len(), 6);
+    }
+
+    #[test]
+    fn migrates_legacy_patch_into_home_setup() {
+        let legacy = r#"[
+            {"id":"00000000-0000-0000-0000-000000000001","name":"Left","address":1,
+             "channels":[{"role":"Red","label":"Red"}]},
+            {"id":"00000000-0000-0000-0000-000000000002","name":"Right","address":2,
+             "channels":[{"role":"Blue","label":"Blue"}]}
+        ]"#;
+        let store = migrate_from_legacy(legacy);
+        assert_eq!(store.setups.len(), 1);
+        assert_eq!(store.setups[0].name, "Home");
+        assert_eq!(store.setups[0].fixtures.len(), 2);
+        assert_eq!(store.active_setup_id, store.setups[0].id);
+        assert_eq!(store.version, STORE_VERSION);
+    }
+
+    #[test]
+    fn migrating_unreadable_legacy_yields_empty_home() {
+        let store = migrate_from_legacy("not json at all");
+        assert_eq!(store.setups.len(), 1);
+        assert_eq!(store.setups[0].name, "Home");
+        assert!(store.setups[0].fixtures.is_empty());
+    }
+
+    #[test]
+    fn reconcile_fixes_dangling_active_id() {
+        let mut store = SetupStore::default();
+        store.active_setup_id = uuid::Uuid::new_v4(); // points at nothing
+        reconcile(&mut store);
+        assert_eq!(store.active_setup_id, store.setups[0].id);
+    }
+
+    #[test]
+    fn reconcile_reseeds_empty_store() {
+        let mut store = SetupStore::default();
+        store.setups.clear();
+        reconcile(&mut store);
+        assert_eq!(store.setups.len(), 1);
+        assert!(store.setups.iter().any(|s| s.id == store.active_setup_id));
+    }
+
+    #[test]
+    fn store_round_trips_through_json() {
+        let store = SetupStore::default();
+        let json = serde_json::to_string(&store).unwrap();
+        let back = parse_store(&json).unwrap();
+        assert_eq!(back.setups.len(), store.setups.len());
+        assert_eq!(back.active_setup_id, store.active_setup_id);
+        assert_eq!(back.user_id, store.user_id);
+        assert_eq!(back.version, store.version);
+    }
+
+    #[test]
+    fn create_rename_delete_and_switch() {
+        let setups: LuxSetups = SetupStore::default().into();
+        let home = setups.active_id();
+
+        let church = setups.create("Church".into(), 2).unwrap();
+        assert_eq!(setups.summaries().len(), 2);
+
+        setups.rename(church, "Sanctuary".into()).unwrap();
+        assert!(setups.summaries().iter().any(|s| s.name == "Sanctuary"));
+
+        setups.set_active(church).unwrap();
+        assert_eq!(setups.active_id(), church);
+        assert_eq!(setups.active_universe(), 2);
+
+        // Deleting the active setup reassigns active to a remaining one.
+        setups.delete(church).unwrap();
+        assert_eq!(setups.active_id(), home);
+
+        // Can't delete the last remaining setup.
+        assert!(setups.delete(home).is_err());
+    }
+
+    #[test]
+    fn fixture_ops_target_the_active_setup() {
+        let setups: LuxSetups = SetupStore::default().into();
+        // Default Home holds the RGBAW fixture on slots 1..=6; add another at 7.
+        let dimmer = vec![ChannelDef {
+            role: crate::colors::LuxLabelColor::Brightness,
+            label: "Dimmer".into(),
+        }];
+        setups.add_fixture("Spot".into(), 7, dimmer).unwrap();
+        assert_eq!(setups.active_fixtures().len(), 2);
+
+        // A freshly-created setup starts empty and is unaffected.
+        let work = setups.create("Work".into(), 1).unwrap();
+        setups.set_active(work).unwrap();
+        assert!(setups.active_fixtures().is_empty());
+    }
+
+    #[test]
+    fn create_rejects_blank_name_and_clamps_universe() {
+        let setups: LuxSetups = SetupStore::default().into();
+        assert!(setups.create("   ".into(), 1).is_err());
+        let id = setups.create("Edge".into(), 0).unwrap(); // 0 clamps up to 1
+        setups.set_active(id).unwrap();
+        assert_eq!(setups.active_universe(), 1);
+    }
+
+    // -- `load_from_dir` against a real (temp) directory --
+
+    /// A fresh, uniquely-named temp directory; the caller removes it when done.
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("lux-test-{tag}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn load_from_dir_first_run_is_default_without_writing() {
+        let dir = temp_dir("firstrun");
+        let store = load_from_dir(&dir);
+        assert_eq!(store.setups.len(), 1);
+        assert_eq!(store.setups[0].name, "Home");
+        // Matches the original behaviour: nothing is written until a mutation.
+        assert!(!dir.join("setups.json").exists());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_from_dir_migrates_a_real_legacy_patch() {
+        let dir = temp_dir("migrate");
+        std::fs::write(
+            dir.join("patch.json"),
+            r#"[{"id":"00000000-0000-0000-0000-000000000001","name":"Left","address":1,
+                "channels":[{"role":"Red","label":"Red"}]}]"#,
+        )
+        .unwrap();
+
+        let store = load_from_dir(&dir);
+        assert_eq!(store.setups.len(), 1);
+        assert_eq!(store.setups[0].name, "Home");
+        assert_eq!(store.setups[0].fixtures.len(), 1);
+        assert_eq!(store.setups[0].fixtures[0].name, "Left");
+
+        // setups.json is written; the legacy file is preserved as a backup.
+        assert!(dir.join("setups.json").exists());
+        assert!(!dir.join("patch.json").exists());
+        assert!(dir.join("patch.json.migrated").exists());
+
+        // Idempotent: a second load reads the new store, not the (gone) legacy.
+        let again = load_from_dir(&dir);
+        assert_eq!(again.active_setup_id, store.active_setup_id);
+        assert_eq!(again.setups[0].fixtures.len(), 1);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_from_dir_reads_back_an_existing_store() {
+        let dir = temp_dir("existing");
+        let original: LuxSetups = SetupStore::default().into();
+        original.create("Church".into(), 5).unwrap();
+        write_store(&dir.join("setups.json"), &original.snapshot());
+
+        let store = load_from_dir(&dir);
+        assert_eq!(store.setups.len(), 2);
+        assert!(store.setups.iter().any(|s| s.name == "Church" && s.universe == 5));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_from_dir_backs_up_a_corrupt_store() {
+        let dir = temp_dir("corrupt");
+        std::fs::write(dir.join("setups.json"), "{ not valid json").unwrap();
+
+        let store = load_from_dir(&dir);
+        assert_eq!(store.setups[0].name, "Home"); // fell back to default
+        // The bad file is moved aside, never clobbered, and not re-read.
+        assert!(dir.join("setups.json.corrupt-0").exists());
+        assert!(!dir.join("setups.json").exists());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -53,6 +53,36 @@ export const cmd = {
   remove_fixture(id: string): Promise<Fixture[]> {
     return invoke("cmd.remove_fixture", { id });
   },
+
+  /** @throws {string} */
+  list_setups(): Promise<SetupSummary[]> {
+    return invoke("cmd.list_setups");
+  },
+
+  /** @throws {string} */
+  create_setup(name: string, universe: number): Promise<SetupSummary[]> {
+    return invoke("cmd.create_setup", { name, universe });
+  },
+
+  /** @throws {string} */
+  rename_setup(id: string, name: string): Promise<SetupSummary[]> {
+    return invoke("cmd.rename_setup", { id, name });
+  },
+
+  /** @throws {string} */
+  set_setup_universe(id: string, universe: number): Promise<SetupSummary[]> {
+    return invoke("cmd.set_setup_universe", { id, universe });
+  },
+
+  /** @throws {string} */
+  delete_setup(id: string): Promise<SetupSummary[]> {
+    return invoke("cmd.delete_setup", { id });
+  },
+
+  /** @throws {string} */
+  set_active_setup(id: string): Promise<SetupSummary> {
+    return invoke("cmd.set_active_setup", { id });
+  },
 };
 
 export const sync = {
@@ -72,7 +102,7 @@ export const sync = {
   },
 };
 
-export type CmdEvent = { type: "channelDataSet"; channels: LuxChannel[] } | { type: "patchSet"; fixtures: Fixture[] };
+export type CmdEvent = { type: "channelDataSet"; channels: LuxChannel[] } | { type: "patchSet"; setup_id: string; fixtures: Fixture[] } | { type: "setupsChanged"; setups: SetupSummary[]; active_setup_id: string };
 
 export type SyncEvent = { type: "bufferSet"; buffer: number[] };
 
@@ -81,7 +111,8 @@ export const events = {
     async listen(callback: (event: CmdEvent) => void): Promise<() => void> {
       const unlisten = await Promise.all([
         listen<{ channels: LuxChannel[] }>("cmd:channelDataSet", (event) => callback({ type: "channelDataSet", ...event.payload })),
-        listen<{ fixtures: Fixture[] }>("cmd:patchSet", (event) => callback({ type: "patchSet", ...event.payload })),
+        listen<{ setup_id: string; fixtures: Fixture[] }>("cmd:patchSet", (event) => callback({ type: "patchSet", ...event.payload })),
+        listen<{ setups: SetupSummary[]; active_setup_id: string }>("cmd:setupsChanged", (event) => callback({ type: "setupsChanged", ...event.payload })),
       ]);
       return () => unlisten.forEach((un) => un());
     },
@@ -142,3 +173,15 @@ export type LuxChannels = {
 export type LuxLabelColor = "Red" | "Green" | "Blue" | "Amber" | "White" | "Brightness" | 
 /**  Raw universe channels (7..=512) with no fixed colour role. */
 "Generic";
+
+/**
+ *  A lightweight setup descriptor for the switcher UI — no fixtures, so listing
+ *  setups doesn't ship every patch.
+ */
+export type SetupSummary = {
+	id: string,
+	name: string,
+	universe: number,
+	fixtureCount: number,
+	active: boolean,
+};

--- a/src/components/setup-switcher.tsx
+++ b/src/components/setup-switcher.tsx
@@ -1,0 +1,220 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Check, ChevronsUpDown, Plus, Settings2, Trash2 } from "lucide-react";
+import { createTauRPCProxy, type SetupSummary } from "@/bindings";
+import useSetups from "@/hooks/useSetups";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+const cmd = () => createTauRPCProxy().cmd;
+
+/**
+ * Switch between the user's setups and manage them (rename / rebind universe /
+ * create / delete). Switching is the common action, so it's a plain dropdown;
+ * the editing lives behind a "manage" popover to keep the nav uncluttered.
+ */
+export default function SetupSwitcher() {
+  const setups = useSetups();
+  const active = setups?.find((s) => s.active) ?? null;
+
+  const [manageOpen, setManageOpen] = useState(false);
+  const [editName, setEditName] = useState("");
+  const [editUniverse, setEditUniverse] = useState(1);
+  const [newName, setNewName] = useState("");
+  const [newUniverse, setNewUniverse] = useState(1);
+
+  if (!setups || !active) {
+    return (
+      <Button variant="outline" size="sm" disabled>
+        Setup
+      </Button>
+    );
+  }
+
+  const switchTo = (id: string) => {
+    if (id === active.id) return;
+    cmd()
+      .set_active_setup(id)
+      .catch((e) => toast.error(String(e)));
+  };
+
+  // Seed the edit fields from the active setup only as the popover opens, so a
+  // background `setupsChanged` can't clobber what the user is typing.
+  const onManageOpenChange = (open: boolean) => {
+    setManageOpen(open);
+    if (open) {
+      setEditName(active.name);
+      setEditUniverse(active.universe);
+      setNewName("");
+      setNewUniverse(1);
+    }
+  };
+
+  const saveCurrent = async () => {
+    const name = editName.trim();
+    if (!name) return;
+    try {
+      if (name !== active.name) await cmd().rename_setup(active.id, name);
+      if (editUniverse !== active.universe)
+        await cmd().set_setup_universe(active.id, editUniverse);
+      setManageOpen(false);
+    } catch (e) {
+      toast.error(String(e));
+    }
+  };
+
+  const removeCurrent = async () => {
+    try {
+      await cmd().delete_setup(active.id);
+      setManageOpen(false);
+    } catch (e) {
+      toast.error(String(e));
+    }
+  };
+
+  const createAndSwitch = async () => {
+    const name = newName.trim();
+    if (!name) return;
+    try {
+      const before = setups;
+      const after: SetupSummary[] = await cmd().create_setup(name, newUniverse);
+      const created = after.find((s) => !before.some((b) => b.id === s.id));
+      if (created) await cmd().set_active_setup(created.id);
+      setManageOpen(false);
+    } catch (e) {
+      toast.error(String(e));
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="gap-1.5">
+            <span className="max-w-32 truncate">{active.name}</span>
+            <ChevronsUpDown className="size-3.5 text-muted-foreground" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          <DropdownMenuLabel>Setups</DropdownMenuLabel>
+          {setups.map((s) => (
+            <DropdownMenuItem
+              key={s.id}
+              onSelect={() => switchTo(s.id)}
+              className="gap-2"
+            >
+              <Check
+                className={cn("size-4", s.active ? "opacity-100" : "opacity-0")}
+              />
+              <span className="flex-1 truncate">{s.name}</span>
+              <span className="text-xs text-muted-foreground">
+                U{s.universe} · {s.fixtureCount}fx
+              </span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Popover open={manageOpen} onOpenChange={onManageOpenChange}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            aria-label="Manage setups"
+          >
+            <Settings2 className="size-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-72">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <p className="text-xs font-medium text-muted-foreground">
+                Current setup
+              </p>
+              <Input
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+                placeholder="Name"
+              />
+              <label className="flex items-center justify-between gap-2 text-xs font-medium text-muted-foreground">
+                Universe
+                <Input
+                  type="number"
+                  min={1}
+                  max={63999}
+                  className="h-8 w-24"
+                  value={editUniverse}
+                  onChange={(e) => setEditUniverse(Number(e.target.value))}
+                />
+              </label>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  className="flex-1"
+                  onClick={saveCurrent}
+                  disabled={!editName.trim()}
+                >
+                  Save
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={removeCurrent}
+                  disabled={setups.length <= 1}
+                  aria-label="Delete this setup"
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="h-px bg-border" />
+
+            <div className="flex flex-col gap-2">
+              <p className="text-xs font-medium text-muted-foreground">
+                New setup
+              </p>
+              <Input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="e.g. Church"
+              />
+              <label className="flex items-center justify-between gap-2 text-xs font-medium text-muted-foreground">
+                Universe
+                <Input
+                  type="number"
+                  min={1}
+                  max={63999}
+                  className="h-8 w-24"
+                  value={newUniverse}
+                  onChange={(e) => setNewUniverse(Number(e.target.value))}
+                />
+              </label>
+              <Button
+                size="sm"
+                onClick={createAndSwitch}
+                disabled={!newName.trim()}
+              >
+                <Plus className="mr-1 size-4" /> Create &amp; switch
+              </Button>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/hooks/useSetups.ts
+++ b/src/hooks/useSetups.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { trace } from "@tauri-apps/plugin-log";
+import { createTauRPCProxy, type SetupSummary } from "@/bindings";
+
+/**
+ * The user's setups and which one is active. Fetches on mount and stays live via
+ * the `setupsChanged` event the backend emits on create/rename/delete/switch.
+ * `null` while the first fetch is in flight.
+ */
+export default function useSetups() {
+  const [setups, setSetups] = useState<SetupSummary[] | null>(null);
+
+  useEffect(() => {
+    const taurpc = createTauRPCProxy();
+    let active = true;
+
+    taurpc.cmd
+      .list_setups()
+      .then((s) => {
+        if (active) setSetups(s);
+      })
+      .catch((e) => trace(`list_setups failed: ${e}`));
+
+    const unlisten = taurpc.cmd.event.on((event) => {
+      if (event.type !== "setupsChanged") return;
+      setSetups(event.setups);
+    });
+
+    return () => {
+      active = false;
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  return setups;
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
 import { Toaster } from "@/components/ui/sonner";
 import { Updater } from "@/components/updater";
+import SetupSwitcher from "@/components/setup-switcher";
 
 export const Route = createRootRoute({
   component: RootLayout,
@@ -13,7 +14,9 @@ function RootLayout() {
   return (
     <>
       <div className="flex min-h-screen flex-col sm:px-12">
-        <nav className="flex items-center gap-5 border-b border-border/60 px-5 py-3">
+        <nav className="flex items-center gap-4 border-b border-border/60 px-5 py-3">
+          <SetupSwitcher />
+          <div className="h-5 w-px bg-border/60" />
           <Link to="/" activeOptions={{ exact: true }} className={navLink}>
             Fixtures
           </Link>


### PR DESCRIPTION
Generalizes the single anonymous fixture patch into many named **Setups** ("Home", "Church", "Work") — the load-bearing first brick for accounts/cloud-sync and remote-across-locations later. Local-only and single-user for now; it just mints the stable ids those later layers will key off. Spec: `.claude/specs/multi-setup.md`.

## Data model

- `Setup { id, name, universe, fixtures }` wrapped in a versioned `SetupStore { version, userId, activeSetupId, setups }`, persisted to `app_config_dir()/setups.json`. The standalone `LuxPatch` is gone — the active setup's `fixtures` is the single source of truth.
- A local `userId` plus per-setup ids are minted now so cloud accounts can adopt these setups later without re-keying. The universe stays a numeric attribute (sACN universe number), not its own entity.

## Migration

- A legacy bare-array `patch.json` is wrapped into a single "Home" setup on first launch and kept as `patch.json.migrated` (lossless backup, never deleted).
- A corrupt `setups.json` is moved aside to `setups.json.corrupt-N`, never silently clobbered.
- First run (neither file) seeds the default RGBAW@1 "Home" setup — identical to v0.6.0's default.

## IPC

- `get/add/update/remove_fixture` keep their signatures but now operate on the **active** setup (no fixture-editing UI churn).
- New: `list_setups`, `create_setup`, `rename_setup`, `set_setup_universe`, `delete_setup`, `set_active_setup`.
- `PatchSet` now carries `setupId`; new `SetupsChanged { setups, activeSetupId }` event. `src/bindings.ts` regenerated; drift guard green.

## Behavior

- Switching a setup blacks out the universe (so one setup's levels never bleed onto another's fixtures) and retargets the live sACN output to the setup's universe. The tray still owns the **transport** (which box); the setup owns the **universe** (the wire), and the persisted device key stays the detected node so the tray highlight doesn't desync. Identical to today for the common one-node / universe-1 case.
- New `SetupSwitcher` in the nav: switch, create, rename, rebind universe, delete (guarded against deleting the last setup).

## Verification

- `cargo test` green — 27 tests incl. new migration/reconcile/CRUD tests and the bindings drift guard.
- `eslint`, `tsc --noEmit`, and `vite build` all clean.
- **Manual check still worth doing** before merge: launch on a profile with a real `patch.json` to confirm the migration + backup, and (with an sACN node) confirm switching retargets the universe.

## Deferred (per spec)

Accounts/Cognito + DynamoDB sync, per-setup saved scenes, multiple universes per setup, and channel-desk metadata persistence are out of scope for this brick.