### PR TITLE
ci: add PR preflight checking @tauri-apps JS<->crate version match

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,44 @@
+name: desktop
+
+# Fast PR preflight for the desktop app. Today it runs the one check that the
+# full Tauri build enforces but only on release tags: @tauri-apps/* JS packages
+# must share their major/minor with their Rust crate counterparts. Catching that
+# drift here (seconds) instead of in the release build (which only runs on a tag)
+# closes the gap that broke the 0.8.0 release. Path-filtered to the inputs that
+# can actually introduce a mismatch.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/desktop/package.json'
+      - 'apps/desktop/bun.lockb'
+      - 'Cargo.lock'
+      - 'apps/desktop/scripts/check-tauri-versions.mjs'
+      - '.github/workflows/desktop.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/desktop/package.json'
+      - 'apps/desktop/bun.lockb'
+      - 'Cargo.lock'
+      - 'apps/desktop/scripts/check-tauri-versions.mjs'
+      - '.github/workflows/desktop.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  tauri-versions:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/desktop
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install
+
+      - name: check @tauri-apps JS <-> crate version match
+        run: bun run check:tauri-versions

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint src",
+    "check:tauri-versions": "bun scripts/check-tauri-versions.mjs",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/apps/desktop/scripts/check-tauri-versions.mjs
+++ b/apps/desktop/scripts/check-tauri-versions.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+// Fail if any installed @tauri-apps/* JS package's major.minor differs from its
+// Rust crate counterpart in the workspace Cargo.lock.
+//
+// This is the same match `tauri build` enforces — but that check only runs
+// inside a full build, which only happens on a release tag (release.yml). So a
+// JS<->crate minor drift (e.g. a regenerated lockfile floating a plugin crate
+// past its JS pin) stays invisible until the release build fails. Running it on
+// PRs catches the drift in seconds. See lux's "match every @tauri-apps JS
+// package's minor to its Rust crate's minor" gotcha (PRs #32, #42, #69).
+//
+// Mapping: @tauri-apps/api -> `tauri`; @tauri-apps/plugin-X -> `tauri-plugin-X`.
+// Everything else under @tauri-apps (the CLI and its platform binaries) has no
+// runtime crate to compare against and is skipped.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const desktopDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = join(desktopDir, "..", "..");
+const tauriModules = join(desktopDir, "node_modules", "@tauri-apps");
+
+// Resolved crate versions from Cargo.lock ([[package]] blocks of name + version).
+const crateVersion = new Map();
+for (const block of readFileSync(join(repoRoot, "Cargo.lock"), "utf8").split("[[package]]")) {
+  const name = block.match(/\nname = "([^"]+)"/)?.[1];
+  const version = block.match(/\nversion = "([^"]+)"/)?.[1];
+  if (name && version) crateVersion.set(name, version);
+}
+
+const minor = (v) => v.split(".").slice(0, 2).join(".");
+const crateFor = (pkg) =>
+  pkg === "api" ? "tauri" : pkg.startsWith("plugin-") ? `tauri-${pkg}` : null;
+
+const rows = [];
+for (const pkg of readdirSync(tauriModules)) {
+  const crate = crateFor(pkg);
+  if (!crate) continue;
+  const crateVer = crateVersion.get(crate);
+  if (!crateVer) continue; // crate not in the dependency tree — nothing to compare
+  const jsVer = JSON.parse(
+    readFileSync(join(tauriModules, pkg, "package.json"), "utf8"),
+  ).version;
+  rows.push({ crate, crateVer, js: `@tauri-apps/${pkg}`, jsVer, ok: minor(jsVer) === minor(crateVer) });
+}
+
+rows.sort((a, b) => a.crate.localeCompare(b.crate));
+const pad = (s, n) => String(s).padEnd(n);
+for (const r of rows) {
+  console.log(`${r.ok ? "✓" : "✗"} ${pad(r.crate, 26)} 🦀 ${pad(r.crateVer, 9)} ${pad(r.js, 31)} ⱼₛ ${r.jsVer}`);
+}
+
+const bad = rows.filter((r) => !r.ok);
+if (bad.length) {
+  console.error(
+    `\n✗ ${bad.length} Tauri JS<->crate major/minor mismatch(es). Bump each JS pin in ` +
+      `apps/desktop/package.json so its minor matches the crate, then \`bun install\`:\n` +
+      bad.map((r) => `    ${r.js} (${r.jsVer}) -> ~${minor(r.crateVer)}  to match ${r.crate} ${r.crateVer}`).join("\n"),
+  );
+  process.exit(1);
+}
+console.log(`\n✓ all ${rows.length} @tauri-apps packages match their Rust crate minors`);


### PR DESCRIPTION
## What

A fast PR check that fails when any `@tauri-apps/*` JS package's major/minor differs from its Rust crate counterpart — the same rule `tauri build` enforces, but surfaced on PRs instead of only inside the release build.

## Why

The 0.8.0 release build failed because the workspace `Cargo.lock` regenerating (during the reorg) floated `tauri-plugin-log` to 2.8 and `tauri-plugin-updater` to 2.10 past their JS pins (`~2.7.1` / `~2.9.0`). That check only runs inside the full `tauri build`, which only runs on a release tag — so the drift was invisible until the release failed (then fixed in #69). This closes that gap for ~zero CI time.

## How

- `apps/desktop/scripts/check-tauri-versions.mjs` — compares resolved versions: crate versions from the root `Cargo.lock` vs the installed `@tauri-apps/*` `package.json`s. Maps `@tauri-apps/api → tauri` and `@tauri-apps/plugin-X → tauri-plugin-X`; skips JS packages with no Rust crate in the tree (positioner/sql/window-state) — exactly as `tauri build` does.
- `bun run check:tauri-versions` script wired in `package.json`.
- `.github/workflows/desktop.yml` — path-filtered to the inputs that can introduce a mismatch (`package.json`, `bun.lockb`, `Cargo.lock`, the script, the workflow).

Verified locally: passes on the current tree (5 packages aligned), and fails with exit 1 + an actionable message when a version is forced to a wrong minor. This PR touches the filtered paths, so the new check runs on itself.