### PR TITLE
ci: cache the Rust dependency build in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,16 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      # Cache the compiled dependency tree. ~90% of this build is dependencies
+      # compiled from scratch, twice (once per arch), under the deliberately
+      # slow release profile (codegen-units = 1 + fat LTO — Tauri's recommended
+      # smallest-binary config, kept as-is). rust-cache restores those dep
+      # artifacts keyed on Cargo.lock, so only the workspace crates + the final
+      # LTO link recompile. The cache is scoped to the workspace-root target/.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
       - run: bun install
         working-directory: apps/desktop
 


### PR DESCRIPTION
## What

Adds `Swatinem/rust-cache@v2` to `release.yml` (before `tauri-action`), scoped to the workspace-root `target/`. **No change to the release profile.**

## Why

Measured the v0.8.0 build ([job 83557565770](https://github.com/johncarmack1984/lux/actions/runs/28206268372/job/83557565770)) — 15 min total, and the breakdown is lopsided:

| Phase | Duration |
|---|---|
| **Rust compile, both arches (cgu=1 + fat LTO)** | **~13.4 min (≈90%)** |
| Notarization (Apple round-trip) | 31s |
| Bundle + sign + DMG + updater + upload | ~1 min |

It's almost entirely dependency compilation, done twice (universal = aarch64 + x86_64). The release profile (`codegen-units = 1`, `lto = true`, `opt-level = "s"`, `panic = "abort"`) is [Tauri's recommended smallest-binary config](https://v2.tauri.app/concept/size/) and matches Rust community guidance for a shipped production binary — so it stays. The speed comes from not recompiling unchanged deps, which costs nothing in artifact quality.

## Expected effect

Warm cache should restore the dep tree and leave only the workspace crates + the final LTO link (×2) to compile — plausibly **~15 min → ~6–8 min**.

## Measurement reality (honest)

The build only runs on a release tag, and rust-cache keys on `Cargo.lock`:
- The **first** release after this merges is a **cold cache** — same time, plus ~1–2 min to *populate* the cache.
- The **second** release (warm cache) is where the speedup shows.
- Heavy dep churn (frequent `Cargo.lock` changes) reduces hit rate; rust-cache's restore-key fallback still reuses unchanged deps, so it degrades gracefully.

Baseline to compare against: **13.4 min compile / 15 min job**. Universal build stays (Intel support required).