### PR TITLE
feat: sync-status indicator, pull-on-focus, and offline-retry backoff

### DIFF
--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -15,16 +15,62 @@
 //!   the local setups into the account.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::Duration;
 
 use reqwest::{Client, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 use tauri::{AppHandle, Manager};
 use uuid::Uuid;
 
 use crate::account::LuxAccount;
+use crate::cmd::CmdEvent;
 use crate::fixture::Fixture;
 use crate::setup::{LuxSetups, PendingDelete, Setup};
+
+// --- sync status (drives the UI indicator) -----------------------------------
+
+/// Coarse cloud-sync state for the nav indicator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum SyncState {
+    /// Signed out, or signed in with nothing left to sync.
+    #[default]
+    Idle,
+    /// A push or pull is in flight.
+    Syncing,
+    /// The last cycle completed and everything is flushed.
+    Synced,
+    /// The last attempt couldn't reach the cloud; a backoff retry is running.
+    Offline,
+}
+
+/// Tauri-managed sync state plus the cloud layer's concurrency guards.
+#[derive(Default)]
+pub struct LuxSync {
+    state: Mutex<SyncState>,
+    /// Held while a pull/push cycle runs, so focus-triggered syncs coalesce
+    /// instead of stacking up.
+    in_flight: AtomicBool,
+    /// Held while a backoff retry loop is alive, so only one runs at a time.
+    retrying: AtomicBool,
+}
+
+impl LuxSync {
+    /// The current state, for the `sync_status` command and event payloads.
+    pub fn snapshot(&self) -> SyncState {
+        *self.state.lock().unwrap()
+    }
+
+    /// Move to `state` and emit the change to the UI.
+    fn set(&self, app: &AppHandle, state: SyncState) {
+        *self.state.lock().unwrap() = state;
+        let _ = CmdEvent::SyncStatusChanged { state }.emit(app);
+    }
+}
 
 #[derive(Debug)]
 enum SyncError {
@@ -319,34 +365,101 @@ fn syncable(app: &AppHandle) -> bool {
     account.signed_in() && account.sync_url().is_some()
 }
 
+/// True when nothing is waiting to reach the cloud (no dirty setups, no pending
+/// delete tombstones).
+fn fully_flushed(app: &AppHandle) -> bool {
+    let setups = app.state::<LuxSetups>();
+    setups.dirty_for_push().is_empty() && setups.pending_deletes().is_empty()
+}
+
+/// Close out a push/pull cycle: `Synced` if everything reached the cloud, else
+/// `Offline` plus a background backoff retry so it keeps trying on its own.
+fn finish_cycle(app: &AppHandle) {
+    if fully_flushed(app) {
+        app.state::<LuxSync>().set(app, SyncState::Synced);
+    } else {
+        app.state::<LuxSync>().set(app, SyncState::Offline);
+        schedule_retry(app);
+    }
+}
+
 /// Flush local changes to the cloud in the background (called after a local
-/// mutation). No-op unless signed in with sync configured.
+/// mutation). No-op unless signed in, sync configured, and something to push.
 pub fn schedule_push(app: &AppHandle) {
-    if !syncable(app) {
+    if !syncable(app) || fully_flushed(app) {
         return;
     }
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        let client = Client::new();
         let (Some(base), Some(mut token)) = (
             app.state::<LuxAccount>().sync_url(),
             app.state::<LuxAccount>().current_id_token(),
         ) else {
             return;
         };
+        app.state::<LuxSync>().set(&app, SyncState::Syncing);
+        let client = Client::new();
         push_all(&app, &client, &base, &mut token).await;
+        finish_cycle(&app);
     });
 }
 
-/// Pull + reconcile + push in the background (called on sign-in and startup
-/// restore). No-op unless signed in with sync configured.
+/// Pull + reconcile + push in the background (called on sign-in, startup restore,
+/// and window focus). No-op unless signed in with sync configured. Coalesces: if
+/// a cycle is already running this is a no-op — that cycle ends with a push that
+/// picks up anything newly dirty.
 pub fn schedule_sync(app: &AppHandle) {
     if !syncable(app) {
         return;
     }
+    if app.state::<LuxSync>().in_flight.swap(true, Ordering::SeqCst) {
+        return;
+    }
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
+        app.state::<LuxSync>().set(&app, SyncState::Syncing);
         pull_and_push(&app).await;
+        finish_cycle(&app);
+        app.state::<LuxSync>().in_flight.store(false, Ordering::SeqCst);
+    });
+}
+
+/// Keep retrying the push with exponential backoff until everything is flushed,
+/// the user signs out, or sync is disabled. Only one retry loop runs at a time,
+/// and a fresh local mutation's push is picked up by the same loop (it re-reads
+/// the dirty set each pass).
+fn schedule_retry(app: &AppHandle) {
+    if app.state::<LuxSync>().retrying.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        const BACKOFF_SECS: [u64; 5] = [5, 15, 30, 60, 120];
+        let mut attempt = 0usize;
+        loop {
+            if !syncable(&app) || fully_flushed(&app) {
+                break;
+            }
+            let wait = BACKOFF_SECS[attempt.min(BACKOFF_SECS.len() - 1)];
+            tokio::time::sleep(Duration::from_secs(wait)).await;
+            if !syncable(&app) {
+                break;
+            }
+            let client = Client::new();
+            let (Some(base), Some(mut token)) = (
+                app.state::<LuxAccount>().sync_url(),
+                app.state::<LuxAccount>().current_id_token(),
+            ) else {
+                break;
+            };
+            push_all(&app, &client, &base, &mut token).await;
+            if fully_flushed(&app) {
+                app.state::<LuxSync>().set(&app, SyncState::Synced);
+                break;
+            }
+            attempt += 1;
+        }
+        app.state::<LuxSync>().retrying.store(false, Ordering::SeqCst);
     });
 }
 

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -89,6 +89,10 @@ pub trait CmdMethods {
         password: String,
     ) -> Result<AuthStatus, String>;
     fn sign_out(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
+    // Cloud sync — current status for the indicator, and a manual pull (fired on
+    // window focus so remote edits land without waiting for a restart).
+    fn sync_status(&self, app_handle: AppHandle) -> Result<crate::cloud::SyncState, String>;
+    fn sync_now(&self, app_handle: AppHandle) -> Result<(), String>;
 }
 #[derive(ttipc::Event)]
 pub enum CmdEvent {
@@ -105,6 +109,9 @@ pub enum CmdEvent {
     },
     AuthChanged {
         status: AuthStatus,
+    },
+    SyncStatusChanged {
+        state: crate::cloud::SyncState,
     },
 }
 
@@ -307,6 +314,15 @@ impl CmdMethods for CmdEndpoint {
         let status = app_handle.state::<LuxAccount>().sign_out();
         emit_auth_changed(&app_handle, status.clone())?;
         Ok(status)
+    }
+
+    fn sync_status(&self, app_handle: AppHandle) -> Result<crate::cloud::SyncState, String> {
+        Ok(app_handle.state::<crate::cloud::LuxSync>().snapshot())
+    }
+
+    fn sync_now(&self, app_handle: AppHandle) -> Result<(), String> {
+        crate::cloud::schedule_sync(&app_handle);
+        Ok(())
     }
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ pub async fn run() {
         .manage(default_buffer)
         .manage(default_channels)
         .manage(DmxOutput::default())
+        .manage(cloud::LuxSync::default())
         .invoke_handler(taurpc)
         .run(tauri::generate_context!())
         .expect("error while running tauri application")

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -108,6 +108,16 @@ export const cmd = {
   sign_out(): Promise<AuthStatus> {
     return invoke("cmd.sign_out");
   },
+
+  /** @throws {string} */
+  sync_status(): Promise<SyncState> {
+    return invoke("cmd.sync_status");
+  },
+
+  /** @throws {string} */
+  sync_now(): Promise<null> {
+    return invoke("cmd.sync_now");
+  },
 };
 
 export const sync = {
@@ -127,7 +137,7 @@ export const sync = {
   },
 };
 
-export type CmdEvent = { type: "channelDataSet"; channels: LuxChannel[] } | { type: "patchSet"; setup_id: string; fixtures: Fixture[] } | { type: "setupsChanged"; setups: SetupSummary[]; active_setup_id: string } | { type: "authChanged"; status: AuthStatus };
+export type CmdEvent = { type: "channelDataSet"; channels: LuxChannel[] } | { type: "patchSet"; setup_id: string; fixtures: Fixture[] } | { type: "setupsChanged"; setups: SetupSummary[]; active_setup_id: string } | { type: "authChanged"; status: AuthStatus } | { type: "syncStatusChanged"; state: SyncState };
 
 export type SyncEvent = { type: "bufferSet"; buffer: number[] };
 
@@ -139,6 +149,7 @@ export const events = {
         listen<{ setup_id: string; fixtures: Fixture[] }>("cmd:patchSet", (event) => callback({ type: "patchSet", ...event.payload })),
         listen<{ setups: SetupSummary[]; active_setup_id: string }>("cmd:setupsChanged", (event) => callback({ type: "setupsChanged", ...event.payload })),
         listen<{ status: AuthStatus }>("cmd:authChanged", (event) => callback({ type: "authChanged", ...event.payload })),
+        listen<{ state: SyncState }>("cmd:syncStatusChanged", (event) => callback({ type: "syncStatusChanged", ...event.payload })),
       ]);
       return () => unlisten.forEach((un) => un());
     },
@@ -221,3 +232,14 @@ export type SetupSummary = {
 	fixtureCount: number,
 	active: boolean,
 };
+
+/**  Coarse cloud-sync state for the nav indicator. */
+export type SyncState = 
+/**  Signed out, or signed in with nothing left to sync. */
+"idle" | 
+/**  A push or pull is in flight. */
+"syncing" | 
+/**  The last cycle completed and everything is flushed. */
+"synced" | 
+/**  The last attempt couldn't reach the cloud; a backoff retry is running. */
+"offline";

--- a/apps/desktop/src/components/sync-indicator.tsx
+++ b/apps/desktop/src/components/sync-indicator.tsx
@@ -1,0 +1,42 @@
+import { Cloud, CloudOff, RefreshCw } from "lucide-react";
+import useAuth from "@/hooks/useAuth";
+import useSyncStatus from "@/hooks/useSyncStatus";
+
+/**
+ * A small cloud-sync indicator for the nav, shown only when signed in. Reflects
+ * the backend `SyncState`: a spinner while syncing, a cloud when synced, and a
+ * struck-through cloud (with a hint) when offline. Idle renders nothing, so the
+ * nav stays quiet when there's nothing to report.
+ */
+export default function SyncIndicator() {
+  const auth = useAuth();
+  const state = useSyncStatus();
+
+  if (!auth?.signedIn) return null;
+
+  switch (state) {
+    case "syncing":
+      return (
+        <span title="Syncing…" className="text-muted-foreground">
+          <RefreshCw className="size-4 animate-spin" aria-label="Syncing" />
+        </span>
+      );
+    case "offline":
+      return (
+        <span
+          title="Offline — your changes will sync when the connection returns"
+          className="text-amber-500"
+        >
+          <CloudOff className="size-4" aria-label="Offline" />
+        </span>
+      );
+    case "synced":
+      return (
+        <span title="Synced" className="text-muted-foreground">
+          <Cloud className="size-4" aria-label="Synced" />
+        </span>
+      );
+    default:
+      return null;
+  }
+}

--- a/apps/desktop/src/hooks/useSyncOnFocus.ts
+++ b/apps/desktop/src/hooks/useSyncOnFocus.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { trace } from "@tauri-apps/plugin-log";
+import { createTauRPCProxy } from "@/bindings";
+
+/** Minimum gap between focus-triggered pulls, so rapid focus toggles don't spam. */
+const MIN_INTERVAL_MS = 15_000;
+
+/**
+ * Pull the account's setups whenever the window regains focus or becomes
+ * visible, so edits made on another device land without waiting for a restart.
+ * Throttled to {@link MIN_INTERVAL_MS}; the backend also coalesces concurrent
+ * syncs and no-ops when signed out, so this is safe to leave always-on.
+ */
+export default function useSyncOnFocus() {
+  useEffect(() => {
+    const taurpc = createTauRPCProxy();
+    let last = 0;
+
+    const pull = () => {
+      const now = Date.now();
+      if (now - last < MIN_INTERVAL_MS) return;
+      last = now;
+      taurpc.cmd.sync_now().catch((e) => trace(`sync_now failed: ${e}`));
+    };
+    const onVisible = () => {
+      if (document.visibilityState === "visible") pull();
+    };
+
+    window.addEventListener("focus", pull);
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      window.removeEventListener("focus", pull);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, []);
+}

--- a/apps/desktop/src/hooks/useSyncStatus.ts
+++ b/apps/desktop/src/hooks/useSyncStatus.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { trace } from "@tauri-apps/plugin-log";
+import { createTauRPCProxy, type SyncState } from "@/bindings";
+
+/**
+ * The current cloud-sync state (idle / syncing / synced / offline). Fetches on
+ * mount and stays live via the `syncStatusChanged` event the backend emits as a
+ * push/pull cycle progresses. `null` until the first fetch resolves.
+ */
+export default function useSyncStatus() {
+  const [state, setState] = useState<SyncState | null>(null);
+
+  useEffect(() => {
+    const taurpc = createTauRPCProxy();
+    let active = true;
+
+    taurpc.cmd
+      .sync_status()
+      .then((s) => {
+        if (active) setState(s);
+      })
+      .catch((e) => trace(`sync_status failed: ${e}`));
+
+    const unlisten = taurpc.cmd.event.on((event) => {
+      if (event.type !== "syncStatusChanged") return;
+      setState(event.state);
+    });
+
+    return () => {
+      active = false;
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  return state;
+}

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -3,6 +3,8 @@ import { Toaster } from "@/components/ui/sonner";
 import { Updater } from "@/components/updater";
 import SetupSwitcher from "@/components/setup-switcher";
 import AccountMenu from "@/components/account-menu";
+import SyncIndicator from "@/components/sync-indicator";
+import useSyncOnFocus from "@/hooks/useSyncOnFocus";
 
 export const Route = createRootRoute({
   component: RootLayout,
@@ -12,6 +14,7 @@ const navLink =
   "text-sm font-medium text-muted-foreground transition-colors hover:text-foreground [&.active]:text-foreground";
 
 function RootLayout() {
+  useSyncOnFocus();
   return (
     <>
       <div className="flex min-h-screen flex-col sm:px-12">
@@ -24,7 +27,8 @@ function RootLayout() {
           <Link to="/universe" className={navLink}>
             Universe
           </Link>
-          <div className="ml-auto">
+          <div className="ml-auto flex items-center gap-3">
+            <SyncIndicator />
             <AccountMenu />
           </div>
         </nav>


### PR DESCRIPTION
Finishes the cloud-sync brick — the deferred **Phase 4** polish from [[lux-accounts-sync-spec]].

## What

- **Sync-status indicator** in the nav (next to the account menu): a spinner while syncing, a cloud when synced, a struck-through cloud when offline; hidden when signed out / idle. Driven by a new `SyncStatusChanged` event off the push/pull cycle.
- **Pull-on-window-focus** — regaining focus (or visibility) triggers a throttled `sync_now`, so edits made on another device land without restarting. An in-flight guard coalesces rapid focus toggles.
- **Offline-retry backoff** — a bounded exponential backoff (5/15/30/60/120s) keeps re-flushing dirty pushes until they reach the cloud, the user signs out, or sync is disabled. Only one retry loop runs at a time.

## Shape

- Backend: `LuxSync` managed state (`SyncState` + concurrency guards) in `cloud.rs`; `sync_status` / `sync_now` commands + `SyncStatusChanged` event in `cmd.rs`; status transitions threaded through `schedule_push`/`schedule_sync`/the retry loop.
- Frontend: `useSyncStatus`, `useSyncOnFocus`, `SyncIndicator`, wired into `__root.tsx`.

## Verified

`REGEN_BINDINGS=1 cargo test -p lux` — 38 unit tests + the bindings drift guard pass; `eslint`, `tsc --noEmit`, and `vite build` all clean.

Deferred (not in scope): full per-user local stores (a second account on one device still drops the prior user's *unsynced* setups — a bigger data-model change, tracked separately). The cross-account-leak invariant is already handled.