### PR TITLE
feat: in-app DMX output picker in the manage-setups popover

### DIFF
--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -3,7 +3,7 @@ use crate::{
     buffer::{Buffer, LuxBuffer, UNIVERSE_SIZE},
     channel::LuxChannel,
     channels::LuxChannels,
-    devices::{self, DmxOutput},
+    devices::{self, DmxDeviceInfo, DmxOutput},
     fixture::{self, ChannelDef, Fixture, FixturePreset},
     setup::{self, LuxSetups, SetupSummary},
     sync::*,
@@ -93,6 +93,15 @@ pub trait CmdMethods {
     // window focus so remote edits land without waiting for a restart).
     fn sync_status(&self, app_handle: AppHandle) -> Result<crate::cloud::SyncState, String>;
     fn sync_now(&self, app_handle: AppHandle) -> Result<(), String>;
+    // DMX output — the in-app device picker (the only output selector on mobile,
+    // where there's no tray). Mirrors the desktop tray's device menu.
+    fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String>;
+    fn set_dmx_device(
+        &self,
+        app_handle: AppHandle,
+        key: String,
+    ) -> Result<Vec<DmxDeviceInfo>, String>;
+    fn rescan_dmx_devices(&self, app_handle: AppHandle) -> Result<(), String>;
 }
 #[derive(ttipc::Event)]
 pub enum CmdEvent {
@@ -112,6 +121,9 @@ pub enum CmdEvent {
     },
     SyncStatusChanged {
         state: crate::cloud::SyncState,
+    },
+    DmxDevicesChanged {
+        devices: Vec<DmxDeviceInfo>,
     },
 }
 
@@ -324,6 +336,26 @@ impl CmdMethods for CmdEndpoint {
         crate::cloud::schedule_sync(&app_handle);
         Ok(())
     }
+
+    fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String> {
+        Ok(devices::device_list(&app_handle))
+    }
+
+    fn set_dmx_device(
+        &self,
+        app_handle: AppHandle,
+        key: String,
+    ) -> Result<Vec<DmxDeviceInfo>, String> {
+        devices::select_device(&app_handle, &key)?;
+        emit_dmx_devices_changed(&app_handle);
+        Ok(devices::device_list(&app_handle))
+    }
+
+    fn rescan_dmx_devices(&self, app_handle: AppHandle) -> Result<(), String> {
+        // Spawns a detection pass; the refreshed list arrives via DmxDevicesChanged.
+        devices::rescan(&app_handle);
+        Ok(())
+    }
 }
 
 fn parse_fixture_id(id: &str) -> Result<uuid::Uuid, String> {
@@ -390,6 +422,16 @@ fn emit_auth_changed(app: &AppHandle, status: AuthStatus) -> Result<(), String> 
     CmdEvent::AuthChanged { status }
         .emit(app)
         .map_err(|e| format!("Failed to emit auth_changed event: {e}"))
+}
+
+/// Build the current DMX device list and broadcast it so the in-app output
+/// picker reflects detection/selection changes. Generic over the runtime: the
+/// auto-detect path calls it from [`crate::devices::apply_detection`].
+pub fn emit_dmx_devices_changed<R: tauri::Runtime>(app: &AppHandle<R>) {
+    let _ = CmdEvent::DmxDevicesChanged {
+        devices: devices::device_list(app),
+    }
+    .emit(app);
 }
 
 /// Apply the consequences of the active setup changing: point the live sACN

--- a/apps/desktop/src-tauri/src/devices/mod.rs
+++ b/apps/desktop/src-tauri/src/devices/mod.rs
@@ -18,6 +18,8 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use serde::{Deserialize, Serialize};
+use specta::Type;
 use tauri::{AppHandle, Manager, Runtime};
 
 /// A DMX output: take the fixture's channel bytes (lux uses 6: RGBAW + master)
@@ -59,6 +61,18 @@ impl Device {
             Transport::Sacn => format!("sacn:{}", self.universe),
         }
     }
+}
+
+/// A detected output as the front-end picker sees it: stable `key`, display
+/// `label`, and whether it's the active output. The desktop tray reads
+/// [`Device`] directly; this is the serializable view for the in-app picker,
+/// which is the only output selector on mobile (there's no tray).
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct DmxDeviceInfo {
+    pub key: String,
+    pub label: String,
+    pub active: bool,
 }
 
 /// Detect available outputs: FTDI/USB (Enttec) and Art-Net/sACN network nodes.
@@ -169,15 +183,12 @@ impl DmxOutput {
         self.inner.lock().unwrap().transport.needs_keepalive()
     }
 
-    // Read by the desktop tray to render its device menu. Mobile has no tray yet,
-    // so these are unused there until the in-app output picker lands — keep them
-    // present (the picker will read the same state) rather than gate them out.
-    #[cfg_attr(mobile, allow(dead_code))]
+    // The active key + detected list, read by the desktop tray's device menu and
+    // the in-app output picker (the only selector on mobile, where there's no tray).
     pub fn active_key(&self) -> String {
         self.inner.lock().unwrap().key.clone()
     }
 
-    #[cfg_attr(mobile, allow(dead_code))]
     pub fn devices(&self) -> Vec<Device> {
         self.devices.lock().unwrap().clone()
     }
@@ -276,10 +287,40 @@ pub fn set_active_universe<R: Runtime>(app: &AppHandle<R>, universe: u16) {
     app.state::<DmxOutput>().retarget_universe(universe);
 }
 
-/// Manual rescan (tray "Rescan"): one detection pass off the UI thread, then
-/// auto-select and rebuild the menu. Tray-triggered today, so unused on mobile
-/// until the in-app output picker calls it.
-#[cfg_attr(mobile, allow(dead_code))]
+/// The detected outputs as the in-app picker sees them, with the active one
+/// flagged. Backs the `list_dmx_devices` command and the `DmxDevicesChanged`
+/// event payload.
+pub fn device_list<R: Runtime>(app: &AppHandle<R>) -> Vec<DmxDeviceInfo> {
+    let out = app.state::<DmxOutput>();
+    let active = out.active_key();
+    out.devices()
+        .into_iter()
+        .map(|d| {
+            let key = d.key();
+            DmxDeviceInfo {
+                active: key == active,
+                label: d.label,
+                key,
+            }
+        })
+        .collect()
+}
+
+/// Make the detected device identified by `key` the active output. Errors if no
+/// detected device has that key (e.g. it was unplugged since the last scan).
+pub fn select_device<R: Runtime>(app: &AppHandle<R>, key: &str) -> Result<(), String> {
+    let device = app
+        .state::<DmxOutput>()
+        .devices()
+        .into_iter()
+        .find(|d| d.key() == key)
+        .ok_or_else(|| format!("no DMX device with key {key:?}"))?;
+    switch_to_device(app, &device);
+    Ok(())
+}
+
+/// Manual rescan (the tray's "Rescan" and the in-app picker's): one detection
+/// pass off the UI thread, then auto-select and refresh the tray menu + picker.
 pub fn rescan<R: Runtime>(app: &AppHandle<R>) {
     let app = app.clone();
     std::thread::spawn(move || apply_detection(&app, detect_devices()));
@@ -319,6 +360,8 @@ fn apply_detection<R: Runtime>(app: &AppHandle<R>, devices: Vec<Device>) {
         if let Err(e) = crate::tray::refresh(&app) {
             log::warn!("tray refresh failed: {e}");
         }
+        // Keep the in-app output picker in sync with detection on every platform.
+        crate::cmd::emit_dmx_devices_changed(&app);
     });
 }
 

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -118,6 +118,21 @@ export const cmd = {
   sync_now(): Promise<null> {
     return invoke("cmd.sync_now");
   },
+
+  /** @throws {string} */
+  list_dmx_devices(): Promise<DmxDeviceInfo[]> {
+    return invoke("cmd.list_dmx_devices");
+  },
+
+  /** @throws {string} */
+  set_dmx_device(key: string): Promise<DmxDeviceInfo[]> {
+    return invoke("cmd.set_dmx_device", { key });
+  },
+
+  /** @throws {string} */
+  rescan_dmx_devices(): Promise<null> {
+    return invoke("cmd.rescan_dmx_devices");
+  },
 };
 
 export const sync = {
@@ -137,7 +152,7 @@ export const sync = {
   },
 };
 
-export type CmdEvent = { type: "channelDataSet"; channels: LuxChannel[] } | { type: "patchSet"; setup_id: string; fixtures: Fixture[] } | { type: "setupsChanged"; setups: SetupSummary[]; active_setup_id: string } | { type: "authChanged"; status: AuthStatus } | { type: "syncStatusChanged"; state: SyncState };
+export type CmdEvent = { type: "channelDataSet"; channels: LuxChannel[] } | { type: "patchSet"; setup_id: string; fixtures: Fixture[] } | { type: "setupsChanged"; setups: SetupSummary[]; active_setup_id: string } | { type: "authChanged"; status: AuthStatus } | { type: "syncStatusChanged"; state: SyncState } | { type: "dmxDevicesChanged"; devices: DmxDeviceInfo[] };
 
 export type SyncEvent = { type: "bufferSet"; buffer: number[] };
 
@@ -150,6 +165,7 @@ export const events = {
         listen<{ setups: SetupSummary[]; active_setup_id: string }>("cmd:setupsChanged", (event) => callback({ type: "setupsChanged", ...event.payload })),
         listen<{ status: AuthStatus }>("cmd:authChanged", (event) => callback({ type: "authChanged", ...event.payload })),
         listen<{ state: SyncState }>("cmd:syncStatusChanged", (event) => callback({ type: "syncStatusChanged", ...event.payload })),
+        listen<{ devices: DmxDeviceInfo[] }>("cmd:dmxDevicesChanged", (event) => callback({ type: "dmxDevicesChanged", ...event.payload })),
       ]);
       return () => unlisten.forEach((un) => un());
     },
@@ -190,6 +206,18 @@ export type ChannelDef = {
 	/**  Semantic role — drives the colour swatch / control affordance. */
 	role: LuxLabelColor,
 	label: string,
+};
+
+/**
+ *  A detected output as the front-end picker sees it: stable `key`, display
+ *  `label`, and whether it's the active output. The desktop tray reads
+ *  [`Device`] directly; this is the serializable view for the in-app picker,
+ *  which is the only output selector on mobile (there's no tray).
+ */
+export type DmxDeviceInfo = {
+	key: string,
+	label: string,
+	active: boolean,
 };
 
 /**  A patched fixture: `channels.len()` consecutive slots from `address` (1-based). */

--- a/apps/desktop/src/components/setup-switcher.tsx
+++ b/apps/desktop/src/components/setup-switcher.tsx
@@ -1,8 +1,16 @@
 import { useState } from "react";
 import { toast } from "sonner";
-import { Check, ChevronsUpDown, Plus, Settings2, Trash2 } from "lucide-react";
+import {
+  Check,
+  ChevronsUpDown,
+  Plus,
+  RefreshCw,
+  Settings2,
+  Trash2,
+} from "lucide-react";
 import { createTauRPCProxy, type SetupSummary } from "@/bindings";
 import useSetups from "@/hooks/useSetups";
+import useDmxDevices from "@/hooks/useDmxDevices";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -29,12 +37,14 @@ const cmd = () => createTauRPCProxy().cmd;
 export default function SetupSwitcher() {
   const setups = useSetups();
   const active = setups?.find((s) => s.active) ?? null;
+  const dmxDevices = useDmxDevices();
 
   const [manageOpen, setManageOpen] = useState(false);
   const [editName, setEditName] = useState("");
   const [editUniverse, setEditUniverse] = useState(1);
   const [newName, setNewName] = useState("");
   const [newUniverse, setNewUniverse] = useState(1);
+  const [rescanning, setRescanning] = useState(false);
 
   if (!setups || !active) {
     return (
@@ -97,6 +107,24 @@ export default function SetupSwitcher() {
     } catch (e) {
       toast.error(String(e));
     }
+  };
+
+  const selectDevice = (key: string) => {
+    cmd()
+      .set_dmx_device(key)
+      .catch((e) => toast.error(String(e)));
+  };
+
+  // Detection runs ~3s on the backend and reports back via `dmxDevicesChanged`;
+  // show the spinner across that window rather than block on the call's return.
+  const rescanDevices = async () => {
+    setRescanning(true);
+    try {
+      await cmd().rescan_dmx_devices();
+    } catch (e) {
+      toast.error(String(e));
+    }
+    setTimeout(() => setRescanning(false), 3500);
   };
 
   return (
@@ -211,6 +239,55 @@ export default function SetupSwitcher() {
               >
                 <Plus className="mr-1 size-4" /> Create &amp; switch
               </Button>
+            </div>
+
+            <div className="h-px bg-border" />
+
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <p className="text-xs font-medium text-muted-foreground">
+                  DMX output
+                </p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 gap-1 px-2 text-xs text-muted-foreground"
+                  onClick={rescanDevices}
+                  disabled={rescanning}
+                >
+                  <RefreshCw
+                    className={cn("size-3", rescanning && "animate-spin")}
+                  />
+                  Rescan
+                </Button>
+              </div>
+              {dmxDevices === null ? (
+                <p className="text-xs text-muted-foreground">Scanning…</p>
+              ) : dmxDevices.length === 0 ? (
+                <p className="text-xs text-muted-foreground">No outputs found.</p>
+              ) : (
+                <div className="flex flex-col gap-0.5">
+                  {dmxDevices.map((d) => (
+                    <button
+                      key={d.key}
+                      type="button"
+                      onClick={() => selectDevice(d.key)}
+                      className={cn(
+                        "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent",
+                        d.active && "bg-accent/50",
+                      )}
+                    >
+                      <Check
+                        className={cn(
+                          "size-4 shrink-0",
+                          d.active ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      <span className="flex-1 truncate">{d.label}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         </PopoverContent>

--- a/apps/desktop/src/hooks/useDmxDevices.tsx
+++ b/apps/desktop/src/hooks/useDmxDevices.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { trace } from "@tauri-apps/plugin-log";
+import { createTauRPCProxy, type DmxDeviceInfo } from "@/bindings";
+
+/**
+ * The detected DMX outputs and which one is active. Fetches on mount and stays
+ * live via the `dmxDevicesChanged` event the backend emits on auto-detect,
+ * rescan, or a manual pick. `null` while the first fetch is in flight.
+ *
+ * This backs the in-app output picker — the only output selector on mobile,
+ * where there's no system tray.
+ */
+export default function useDmxDevices() {
+  const [devices, setDevices] = useState<DmxDeviceInfo[] | null>(null);
+
+  useEffect(() => {
+    const taurpc = createTauRPCProxy();
+    let active = true;
+
+    taurpc.cmd
+      .list_dmx_devices()
+      .then((d) => {
+        if (active) setDevices(d);
+      })
+      .catch((e) => trace(`list_dmx_devices failed: ${e}`));
+
+    const unlisten = taurpc.cmd.event.on((event) => {
+      if (event.type !== "dmxDevicesChanged") return;
+      setDevices(event.devices);
+    });
+
+    return () => {
+      active = false;
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  return devices;
+}


### PR DESCRIPTION
Surfaces DMX output-device selection in the UI, not just the desktop tray. The tray has been the only output selector, and there's no system tray on mobile — so the iOS (and eventually Android) build had no way to choose between the USB interface and a network sACN node. This adds an in-app picker to the manage-setups popover, next to where a setup's universe is configured.

## Backend

- New IPC: `list_dmx_devices`, `set_dmx_device(key)`, `rescan_dmx_devices`, plus a `DmxDevicesChanged` event emitted on auto-detect, rescan, and manual selection — so the tray and the picker share one source of truth and stay in sync.
- `DmxDeviceInfo` DTO (key / label / active) projected from the existing `Device` + `DmxOutput` state. Detection and the render path are unchanged.

## Frontend

- `useDmxDevices` hook (fetch on mount, live via `dmxDevicesChanged`), mirroring `useSetups`.
- A "DMX output" section in the setup-switcher's manage popover: a selectable device list (active one checked) and a Rescan control.

## Verification

- `cargo test --workspace --locked` green, including the bindings drift guard; `src/bindings.ts` regenerated via `REGEN_BINDINGS=1`.
- Frontend `typecheck` + `lint` + `build` clean.
- Reuses the existing setup-list UI pattern and the proven `useSetups` hook shape; no new dependencies.

Cross-platform — ships to desktop too (a non-tray way to pick output). The mobile rendering lands when this rides onto the iOS build (#78).
