### PR TITLE
ci: authenticate release-please as a GitHub App so the release PR's CI runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,31 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # Authenticate as a GitHub App (when configured) instead of the default
+      # GITHUB_TOKEN. GitHub deliberately won't let GITHUB_TOKEN-authored events
+      # start new workflow runs, so a release PR opened by it — and the
+      # Cargo.lock-sync push below — leave the `desktop` PR gate stuck "awaiting
+      # approval". An App-token-authored PR/push triggers it normally.
+      # Falls back to GITHUB_TOKEN until RELEASE_APP_ID (variable) and
+      # RELEASE_APP_PRIVATE_KEY (secret) are set, so this is safe to land first.
+      - name: Mint release token (GitHub App)
+        id: app-token
+        if: ${{ vars.RELEASE_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       # release-please uses release-type "simple", which bumps the version in
       # apps/desktop/src-tauri/Cargo.toml but leaves the `lux` entry in the root

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,14 @@ jobs:
       # start new workflow runs, so a release PR opened by it — and the
       # Cargo.lock-sync push below — leave the `desktop` PR gate stuck "awaiting
       # approval". An App-token-authored PR/push triggers it normally.
-      # Falls back to GITHUB_TOKEN until RELEASE_APP_ID (variable) and
+      # Falls back to GITHUB_TOKEN until RELEASE_APP_CLIENT_ID (variable) and
       # RELEASE_APP_PRIVATE_KEY (secret) are set, so this is safe to land first.
       - name: Mint release token (GitHub App)
         id: app-token
-        if: ${{ vars.RELEASE_APP_ID != '' }}
-        uses: actions/create-github-app-token@v2
+        if: ${{ vars.RELEASE_APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7


### PR DESCRIPTION
Release-please opens its PR (and pushes the Cargo.lock sync) as `github-actions[bot]` using the default `GITHUB_TOKEN`. GitHub deliberately blocks `GITHUB_TOKEN`-authored events from triggering new workflow runs (loop-prevention), so the `desktop` PR gate sits **"awaiting approval"** on every release PR (e.g. #80).

Fix: mint a GitHub App installation token (`actions/create-github-app-token@v3`, using its `client-id` input — `app-id` is deprecated as of v3) in the `release-please` job and use it for both the `checkout` (so the lock-sync `git push` is App-authored) and the release-please action (so the PR is App-authored). App-token-authored events trigger workflows normally.

Safe to land first — the token step is gated on the `RELEASE_APP_CLIENT_ID` variable and everything falls back to `GITHUB_TOKEN` via `steps.app-token.outputs.token || github.token`, so behavior is unchanged until the App is configured, then it upgrades automatically.

## Required one-time setup (before this takes effect)

1. Create a GitHub App at https://github.com/settings/apps → **New GitHub App**. Name e.g. `johncarmack-release-bot` (must be globally unique); homepage URL can be the repo; **uncheck Webhook → Active**.
2. Under **Repository permissions** grant exactly: **Contents → Read and write** and **Pull requests → Read and write**. Set "Where can this be installed?" to **Only on this account**, then create.
3. On the App page, **Generate a private key** (downloads a `.pem`).
4. **Install App** → install on your account → select the `lux` repo.
5. On the App's **General** page, copy the **Client ID** (the `Iv23li…`-style value) — *not* the numeric "App ID".
6. In **lux → Settings → Secrets and variables → Actions** add: a **variable** `RELEASE_APP_CLIENT_ID` = the Client ID, and a **secret** `RELEASE_APP_PRIVATE_KEY` = the full `.pem` contents (including the BEGIN/END lines).

After that, the next release PR runs its CI automatically.

## About #80 (the current 0.10.0 PR)

This change can't retroactively fix #80 — it was already authored by `GITHUB_TOKEN`. For that one, click **Approve workflows to run**, or just merge it: the release PR only bumps version/changelog/lock, and `main` already passed the full `desktop` gate with this exact code. The App fix applies from 0.11.0 onward.

> Note: a local `actionlint` may flag `client-id` as an unknown input — its bundled action schema predates the v3 input. GitHub reads the real `v3` action.yml at runtime (verified: `client-id` is defined there and `app-id` carries `deprecationMessage: "Use 'client-id' instead."`).
