### PR TITLE
ci: load the release-bot App key from AWS Secrets Manager via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write # AWS OIDC, to read the release-bot App key from Secrets Manager
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -31,15 +32,36 @@ jobs:
       # start new workflow runs, so a release PR opened by it — and the
       # Cargo.lock-sync push below — leave the `desktop` PR gate stuck "awaiting
       # approval". An App-token-authored PR/push triggers it normally.
-      # Falls back to GITHUB_TOKEN until RELEASE_APP_CLIENT_ID (variable) and
-      # RELEASE_APP_PRIVATE_KEY (secret) are set, so this is safe to land first.
+      # The App's Client ID is the RELEASE_APP_CLIENT_ID variable; its private
+      # key is read from AWS Secrets Manager via OIDC (no key stored in GitHub),
+      # matching how the macOS build below loads its signing material. All gated
+      # on that variable, falling back to GITHUB_TOKEN when it's unset.
+      - name: Configure AWS credentials (OIDC)
+        if: ${{ vars.RELEASE_APP_CLIENT_ID != '' }}
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::735853783919:role/lux-release-signing
+          aws-region: us-west-1
+
+      - name: Load release-bot App private key
+        if: ${{ vars.RELEASE_APP_CLIENT_ID != '' }}
+        # Multi-line PEM into $GITHUB_ENV via a heredoc; never echoed, so the key
+        # stays out of the logs (same posture as the macOS signing secrets).
+        run: |
+          key=$(aws secretsmanager get-secret-value --secret-id lux/release-app-private-key --query SecretString --output text)
+          {
+            echo "RELEASE_APP_PRIVATE_KEY<<__EOF__"
+            printf '%s\n' "$key"
+            echo "__EOF__"
+          } >> "$GITHUB_ENV"
+
       - name: Mint release token (GitHub App)
         id: app-token
         if: ${{ vars.RELEASE_APP_CLIENT_ID != '' }}
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          private-key: ${{ env.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7
         with:

--- a/infra/release-signing.tf
+++ b/infra/release-signing.tf
@@ -1,6 +1,8 @@
-# Lets the lux repo's GitHub Actions read the Tauri updater signing key from
-# Secrets Manager at release time via OIDC — no long-lived AWS keys in GitHub.
-# The key itself lives only in AWS Secrets Manager (created out-of-band).
+# Lets the lux repo's GitHub Actions read release-time secrets from Secrets
+# Manager via OIDC — no long-lived AWS keys in GitHub. The secrets themselves
+# live only in AWS Secrets Manager (created out-of-band): the Tauri updater
+# signing key, the Apple signing material, and the release-bot GitHub App
+# private key (release-please mints an installation token from it).
 
 data "aws_iam_openid_connect_provider" "github" {
   url = "https://token.actions.githubusercontent.com"
@@ -12,6 +14,10 @@ data "aws_secretsmanager_secret" "updater_signing_key" {
 
 data "aws_secretsmanager_secret" "apple_signing" {
   name = "lux/apple-signing"
+}
+
+data "aws_secretsmanager_secret" "release_app_private_key" {
+  name = "lux/release-app-private-key"
 }
 
 resource "aws_iam_role" "release_signing" {
@@ -46,6 +52,7 @@ resource "aws_iam_role_policy" "read_updater_signing_key" {
       Resource = [
         data.aws_secretsmanager_secret.updater_signing_key.arn,
         data.aws_secretsmanager_secret.apple_signing.arn,
+        data.aws_secretsmanager_secret.release_app_private_key.arn,
       ]
     }]
   })


### PR DESCRIPTION
Completes the GitHub App auth for release-please (follow-up to #81). Instead of storing the App private key as a GitHub Actions secret, the `release-please` job now reads it from **AWS Secrets Manager via OIDC** — the same pattern the macOS build already uses for the updater + Apple signing material, so no long-lived key lives in GitHub.

## What changed

- **`release.yml`**: the `release-please` job gains `id-token: write`, assumes the existing `lux-release-signing` role (OIDC), loads `lux/release-app-private-key` from Secrets Manager into `$GITHUB_ENV` (heredoc, never echoed), and feeds it to `actions/create-github-app-token@v3` as `private-key`. The App **Client ID** stays in the `RELEASE_APP_CLIENT_ID` variable. All AWS steps + the token mint are gated on that variable and fall back to `GITHUB_TOKEN` when it's unset.
- **`release-signing.tf`**: adds the `lux/release-app-private-key` data source and grants the role `secretsmanager:GetSecretValue` on it.

## Already done outside this PR

- Secret `lux/release-app-private-key` created in Secrets Manager (us-west-1, out-of-band — the key never enters TF state).
- The IAM policy change is **already `terraform apply`-d** (CI is validate-only); this commit just keeps the IaC in sync. Verified the role now lists all three secret ARNs.
- `RELEASE_APP_CLIENT_ID` variable is set.

## After merge

The next release-please run authors the release PR as the App, so the `desktop` gate runs automatically — no more "awaiting approval". This does **not** retroactively re-author the current #82 (it was created by `GITHUB_TOKEN` before the App was configured); that one needs a close + fresh run, or just approve/merge it to ship 0.10.0.

> A local `actionlint` flags `client-id` as unknown — stale bundled action schema; the live `v3` action.yml defines it (and deprecates `app-id`). Not a CI gate here.
