### PR TITLE
ci: cache Rust compilation with sccache

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -75,6 +75,10 @@ jobs:
 
   rust:
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v7
 
@@ -105,12 +109,19 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      # Restore the compiled dependency tree (keyed on Cargo.lock); saved on main
-      # pushes, restored on PRs. Debug profile here, so this is a fast check — not
-      # the slow release build.
+      # Compilation cache, content-addressed per crate: a Cargo.lock bump — which
+      # invalidates rust-cache's whole target/ — still hits for every unchanged
+      # crate (the common PR case with lux's large AWS-SDK + Tauri trees). Backed
+      # by the GitHub Actions cache.
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      # sccache owns compilation caching now, so rust-cache just keeps the cargo
+      # registry/index warm — cache-targets: false skips the big target/ dir, so
+      # this frequent job's GHA-cache footprint stays small.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "."
+          cache-targets: "false"
 
       # Full workspace suite: desktop unit tests (incl. the cloud reconcile logic)
       # plus tests/bindings.rs, which regenerates the IPC bindings and fails if
@@ -118,3 +129,7 @@ jobs:
       # sync. #[ignore]'d live-AWS round-trips are skipped (no credentials needed).
       - name: cargo test
         run: cargo test --workspace --locked
+
+      - name: sccache stats
+        if: ${{ always() }}
+        run: sccache --show-stats

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
       id-token: write # AWS OIDC, to read the updater signing key
     env:
       TAG: ${{ github.event.inputs.tag || needs.release-please.outputs.tag_name }}
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -128,6 +131,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      # Per-crate compilation cache (GitHub Actions backend), supplementing
+      # rust-cache: it still hits across a Cargo.lock bump for the universal
+      # build's per-arch dependency compilation, though the final fat-LTO link
+      # itself isn't cacheable.
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       # Cache the compiled dependency tree. ~90% of this build is dependencies
       # compiled from scratch, twice (once per arch), under the deliberately
@@ -185,3 +194,7 @@ jobs:
           projectPath: apps/desktop
           tagName: ${{ env.TAG }}
           args: --target universal-apple-darwin
+
+      - name: sccache stats
+        if: ${{ always() }}
+        run: sccache --show-stats


### PR DESCRIPTION
Adds **sccache** as the Rust compilation cache on both cargo CI jobs.

## Why

`Swatinem/rust-cache` keys the whole `target/` on `Cargo.lock`, so **any** dependency bump invalidates it and forces a full cold recompile of lux's large dependency trees (full AWS SDK + Tauri). sccache caches each crate's compilation content-addressed (inputs + flags + rustc version), so a `Cargo.lock` change still hits for every crate that didn't actually change — the common PR case, and where the time goes.

## What

- **`desktop` `rust` gate** (the frequent, non-LTO job, where this matters most): `RUSTC_WRAPPER=sccache` with the GitHub Actions cache backend. rust-cache drops to **registry-only** (`cache-targets: false`) since sccache now owns compilation caching — keeps this job's GHA-cache footprint small.
- **`release` `build-macos`**: sccache added alongside rust-cache. The final fat-LTO link isn't cacheable, but the universal build's per-arch dependency compilation hits across a lock bump.
- `CARGO_INCREMENTAL=0` (incremental output isn't cacheable) and `sccache --show-stats` after each build so hit rates show up in the logs.

## Backend note

Using the **GitHub Actions cache** backend — zero infra, works immediately. Its 10 GB/repo cap with LRU eviction is the only limit; if it starts thrashing (the release `target/` cache is large), the clean upgrade is **sccache → S3** via the existing OIDC pattern (no cap, durable, no contention with rust-cache's GHA usage).

> The win shows from the **second** run onward — the first populates the cache.
