### PR TITLE
ci: run terraform plan/apply in CI via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,3 +198,36 @@ jobs:
       - name: sccache stats
         if: ${{ always() }}
         run: sccache --show-stats
+
+  # Apply the infra when a release is cut — i.e. when the release-please
+  # version-bump PR is merged (release_created). This is the ONLY place
+  # `terraform apply` runs; never on a laptop. The lux-terraform-apply role's
+  # trust is scoped to refs/heads/main, so only this main-branch run can assume
+  # it. Skipped on workflow_dispatch (manual macOS rebuilds) and on pushes that
+  # don't cut a release. An infra PR therefore merges first and applies here with
+  # the next release — its diff was reviewed as the terraform.yml PR plan.
+  terraform-apply:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC: assume the apply role
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::735853783919:role/lux-terraform-apply
+          aws-region: us-west-1
+
+      - uses: hashicorp/setup-terraform@v4
+
+      - name: init
+        run: terraform init -input=false
+
+      - name: apply
+        run: terraform apply -auto-approve -no-color -input=false

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,8 +1,12 @@
 name: terraform
 
-# fmt + validate the infra root on PRs and pushes to main. No AWS credentials:
-# CI initializes providers without a backend (`terraform init -backend=false`)
-# and validates — no plan, no state access, no OIDC.
+# Infra runs in CI, not on a laptop. On PRs: fmt + validate, then a real `plan`
+# (read-only, via the lux-terraform-plan OIDC role) written to the run summary so
+# the diff is reviewable before merge. The matching `apply` does NOT run here —
+# it runs at release time, when the release-please version-bump PR is merged (see
+# the terraform-apply job in release.yml), via the separate lux-terraform-apply
+# role that only a workflow on main can assume. So an infra change merges first
+# and applies with the next release; its diff was the PR plan.
 
 on:
   pull_request:
@@ -37,3 +41,38 @@ jobs:
 
       - name: validate
         run: terraform validate -no-color
+
+  plan:
+    # PRs only: show the real diff. Read-only role + -lock=false (no state
+    # mutation, no lock contention). Apply is release-gated in release.yml.
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC: assume the read-only plan role
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::735853783919:role/lux-terraform-plan
+          aws-region: us-west-1
+
+      - uses: hashicorp/setup-terraform@v4
+
+      - name: init
+        run: terraform init -input=false
+
+      - name: plan
+        run: |
+          set -o pipefail
+          {
+            echo '### terraform plan'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          terraform plan -no-color -input=false -lock=false | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/infra/generated.tf
+++ b/infra/generated.tf
@@ -58,7 +58,7 @@ resource "aws_lambda_function" "lux_discord_bot" {
     variables = {
       AWS_IOT_ENDPOINT   = data.aws_iot_endpoint.ats.endpoint_address
       LUX_DEVICE_ID      = var.device_id
-      DISCORD_PUBLIC_KEY = var.discord_public_key
+      DISCORD_PUBLIC_KEY = data.aws_secretsmanager_secret_version.discord_public_key.secret_string
     }
   }
   ephemeral_storage {

--- a/infra/iot.tf
+++ b/infra/iot.tf
@@ -8,9 +8,13 @@ variable "device_id" {
   default     = "lux-1"
 }
 
-variable "discord_public_key" {
-  description = "Discord application public key (hex); the bot verifies request signatures with it."
-  type        = string
+# Discord application public key (hex); the bot Lambda verifies request
+# signatures with it. Sourced from Secrets Manager (lux/discord-public-key) so
+# plan/apply read it in CI via OIDC — no value committed to this public repo and
+# no gitignored tfvars. secret_string is a sensitive attribute, so it's redacted
+# in plan output.
+data "aws_secretsmanager_secret_version" "discord_public_key" {
+  secret_id = "lux/discord-public-key"
 }
 
 data "aws_caller_identity" "current" {}

--- a/infra/terraform-ci.tf
+++ b/infra/terraform-ci.tf
@@ -1,0 +1,209 @@
+# CI-driven Terraform: the lux repo's GitHub Actions plan (on PRs) and apply (on
+# a release-please version-bump merge) via OIDC — no local AWS creds, no local
+# `terraform apply`. Two roles so PR runs can never mutate:
+#   - lux-terraform-plan  : ReadOnlyAccess, assumable from any ref (PR plans).
+#   - lux-terraform-apply : curated least-privilege write, main branch only.
+# The roles are bootstrapped once with a local apply (chicken-and-egg: CI can't
+# create the role it assumes); thereafter all changes flow through CI. Reuses the
+# GitHub OIDC provider data source from release-signing.tf.
+
+locals {
+  aws_account_id  = "735853783919"
+  tf_state_bucket = "john-carmack-terraform-state"
+  tf_state_prefix = "lux/"
+  github_repo_sub = "repo:johncarmack1984/lux"
+  managed_role_arns = [
+    "arn:aws:iam::735853783919:role/lux*",
+    "arn:aws:iam::735853783919:role/cargo-lambda-role-*",
+  ]
+}
+
+# --- plan role: read-only, any ref (PR plans run with -lock=false) -----------
+
+resource "aws_iam_role" "terraform_plan" {
+  name = "lux-terraform-plan"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = data.aws_iam_openid_connect_provider.github.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = { "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com" }
+        StringLike   = { "token.actions.githubusercontent.com:sub" = "${local.github_repo_sub}:*" }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_plan_readonly" {
+  role       = aws_iam_role.terraform_plan.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# --- apply role: curated write, main branch only -----------------------------
+
+resource "aws_iam_role" "terraform_apply" {
+  name = "lux-terraform-apply"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = data.aws_iam_openid_connect_provider.github.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          # Only a workflow running on main (the release apply) may assume this.
+          "token.actions.githubusercontent.com:sub" = "${local.github_repo_sub}:ref:refs/heads/main"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "terraform_apply" {
+  name = "lux-terraform-apply"
+  role = aws_iam_role.terraform_apply.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "TerraformStateBackend"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = "arn:aws:s3:::${local.tf_state_bucket}/${local.tf_state_prefix}*"
+      },
+      {
+        Sid       = "TerraformStateList"
+        Effect    = "Allow"
+        Action    = "s3:ListBucket"
+        Resource  = "arn:aws:s3:::${local.tf_state_bucket}"
+        Condition = { StringLike = { "s3:prefix" = ["${local.tf_state_prefix}*"] } }
+      },
+      {
+        Sid    = "ManageLuxIamRoles"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateRole", "iam:GetRole", "iam:DeleteRole", "iam:UpdateRole",
+          "iam:UpdateAssumeRolePolicy", "iam:TagRole", "iam:UntagRole", "iam:ListRoleTags",
+          "iam:PutRolePolicy", "iam:GetRolePolicy", "iam:DeleteRolePolicy",
+          "iam:ListRolePolicies", "iam:ListAttachedRolePolicies",
+          "iam:AttachRolePolicy", "iam:DetachRolePolicy", "iam:ListInstanceProfilesForRole",
+        ]
+        Resource = local.managed_role_arns
+      },
+      {
+        Sid       = "PassLuxLambdaRoles"
+        Effect    = "Allow"
+        Action    = "iam:PassRole"
+        Resource  = local.managed_role_arns
+        Condition = { StringEquals = { "iam:PassedToService" = "lambda.amazonaws.com" } }
+      },
+      {
+        Sid      = "ReadIamForDataSourcesAndAttachments"
+        Effect   = "Allow"
+        Action   = ["iam:GetOpenIDConnectProvider", "iam:ListOpenIDConnectProviders", "iam:GetPolicy", "iam:GetPolicyVersion"]
+        Resource = "*"
+      },
+      {
+        Sid    = "ManageLuxLambda"
+        Effect = "Allow"
+        Action = [
+          "lambda:CreateFunction", "lambda:GetFunction", "lambda:GetFunctionConfiguration",
+          "lambda:UpdateFunctionCode", "lambda:UpdateFunctionConfiguration", "lambda:DeleteFunction",
+          "lambda:ListVersionsByFunction", "lambda:AddPermission", "lambda:RemovePermission",
+          "lambda:GetPolicy", "lambda:CreateFunctionUrlConfig", "lambda:GetFunctionUrlConfig",
+          "lambda:UpdateFunctionUrlConfig", "lambda:DeleteFunctionUrlConfig",
+          "lambda:TagResource", "lambda:UntagResource", "lambda:ListTags",
+        ]
+        Resource = "arn:aws:lambda:*:${local.aws_account_id}:function:lux*"
+      },
+      {
+        Sid    = "ManageLuxLogGroups"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup", "logs:DeleteLogGroup", "logs:PutRetentionPolicy",
+          "logs:TagLogGroup", "logs:UntagLogGroup", "logs:ListTagsForResource",
+          "logs:ListTagsLogGroup", "logs:TagResource", "logs:UntagResource",
+        ]
+        Resource = [
+          "arn:aws:logs:*:${local.aws_account_id}:log-group:/aws/lambda/lux*",
+          "arn:aws:logs:*:${local.aws_account_id}:log-group:/aws/lambda/lux*:*",
+        ]
+      },
+      {
+        Sid      = "DescribeLogGroups"
+        Effect   = "Allow"
+        Action   = "logs:DescribeLogGroups"
+        Resource = "*"
+      },
+      {
+        Sid    = "ManageLuxIot"
+        Effect = "Allow"
+        Action = [
+          "iot:CreateThing", "iot:DescribeThing", "iot:DeleteThing", "iot:ListThingPrincipals",
+          "iot:CreateKeysAndCertificate", "iot:DescribeCertificate", "iot:UpdateCertificate",
+          "iot:DeleteCertificate", "iot:CreatePolicy", "iot:GetPolicy", "iot:DeletePolicy",
+          "iot:ListPolicyVersions", "iot:ListTargetsForPolicy", "iot:AttachPolicy", "iot:DetachPolicy",
+          "iot:ListAttachedPolicies", "iot:AttachThingPrincipal", "iot:DetachThingPrincipal",
+          "iot:TagResource", "iot:UntagResource", "iot:ListTagsForResource",
+        ]
+        Resource = "arn:aws:iot:*:${local.aws_account_id}:*"
+      },
+      {
+        Sid      = "IotDescribeEndpoint"
+        Effect   = "Allow"
+        Action   = "iot:DescribeEndpoint"
+        Resource = "*"
+      },
+      {
+        Sid    = "ManageLuxDynamoDb"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:CreateTable", "dynamodb:DescribeTable", "dynamodb:DeleteTable", "dynamodb:UpdateTable",
+          "dynamodb:DescribeContinuousBackups", "dynamodb:UpdateContinuousBackups",
+          "dynamodb:DescribeTimeToLive", "dynamodb:UpdateTimeToLive",
+          "dynamodb:ListTagsOfResource", "dynamodb:TagResource", "dynamodb:UntagResource",
+        ]
+        Resource = "arn:aws:dynamodb:*:${local.aws_account_id}:table/lux-sync"
+      },
+      {
+        Sid    = "ManageLuxCognito"
+        Effect = "Allow"
+        Action = [
+          "cognito-idp:CreateUserPool", "cognito-idp:DescribeUserPool", "cognito-idp:UpdateUserPool",
+          "cognito-idp:DeleteUserPool", "cognito-idp:CreateUserPoolClient", "cognito-idp:DescribeUserPoolClient",
+          "cognito-idp:UpdateUserPoolClient", "cognito-idp:DeleteUserPoolClient",
+          "cognito-idp:GetUserPoolMfaConfig", "cognito-idp:SetUserPoolMfaConfig",
+          "cognito-idp:TagResource", "cognito-idp:UntagResource", "cognito-idp:ListTagsForResource",
+        ]
+        # CreateUserPool has no resource at create time; the pool id isn't known
+        # a priori, so this is scoped to the account/region's user pools.
+        Resource = "*"
+      },
+      {
+        Sid      = "ReadLuxSecrets"
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+        Resource = "arn:aws:secretsmanager:*:${local.aws_account_id}:secret:lux/*"
+      },
+      {
+        Sid      = "CallerIdentity"
+        Effect   = "Allow"
+        Action   = "sts:GetCallerIdentity"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+output "terraform_plan_role_arn" {
+  description = "role-to-assume for the terraform PR plan job (read-only)."
+  value       = aws_iam_role.terraform_plan.arn
+}
+
+output "terraform_apply_role_arn" {
+  description = "role-to-assume for the terraform apply job (main only)."
+  value       = aws_iam_role.terraform_apply.arn
+}

--- a/infra/terraform-ci.tf
+++ b/infra/terraform-ci.tf
@@ -41,6 +41,23 @@ resource "aws_iam_role_policy_attachment" "terraform_plan_readonly" {
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
+# The plan reads lux/discord-public-key via a data source, so the plan role
+# needs GetSecretValue on just that one (public-key) secret — ReadOnlyAccess
+# deliberately excludes secret values. The apply role already covers it via its
+# broader secret:lux/* grant.
+resource "aws_iam_role_policy" "terraform_plan_discord_key" {
+  name = "read-discord-public-key"
+  role = aws_iam_role.terraform_plan.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+      Resource = "arn:aws:secretsmanager:*:${local.aws_account_id}:secret:lux/discord-public-key*"
+    }]
+  })
+}
+
 # --- apply role: curated write, main branch only -----------------------------
 
 resource "aws_iam_role" "terraform_apply" {


### PR DESCRIPTION
Moves Terraform off the laptop: **`plan` on PRs, `apply` on release** — both in CI via OIDC, no local AWS creds.

## How it works

- **PRs** → `terraform.yml` runs `validate` + a real `plan` (read-only `lux-terraform-plan` role, `-lock=false`) and writes the diff to the run summary, so changes are reviewable before merge.
- **Apply** → a `terraform-apply` job in `release.yml`, gated on `release_created`, runs `terraform apply` when the **release-please version-bump PR is merged** (i.e. when a release is cut). It's the *only* place apply runs.
- An infra PR therefore **merges first and applies with the next release**; its diff was the PR plan. (Flagged here so it isn't surprising.)

## Two roles (`infra/terraform-ci.tf`)

| role | perms | trust |
|---|---|---|
| `lux-terraform-plan` | `ReadOnlyAccess` | any ref of this repo (PRs can plan) |
| `lux-terraform-apply` | **curated least-privilege** | `refs/heads/main` only — only a release apply can assume it |

The apply policy is scoped per-service to lux's resources (IAM on `role/lux*` + the `cargo-lambda-role-*`, Lambda/Logs on `lux*`, DynamoDB `lux-sync`, Cognito, IoT in-account, Secrets Manager read on `lux/*`, and S3 state on the `lux/` prefix only).

## Policy validated (read-only, nothing mutated)

Verified with `iam:SimulateCustomPolicy` against the real resource ARNs:
- **15/15 allowed** — every action a real plan+apply needs.
- **3/3 implicitDeny** — a non-lux role, a non-lux table, and another project's state prefix are all denied, proving the scoping actually constrains.

## ⚠️ One-time bootstrap required (chicken-and-egg)

CI can't create the role it then assumes, so the two roles must be created **once** by an admin:

```
cd infra && terraform apply   # creates lux-terraform-plan + lux-terraform-apply (4 to add, 0 change, 0 destroy)
```

Until that runs, **this PR's own `plan` job fails** (the plan role doesn't exist yet) — expected. After the bootstrap, re-run the job (it'll pass) and merge. From then on every infra change flows through CI.
