### PR TITLE
chore: add rust-toolchain.toml (stable channel)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+# Track the current stable Rust toolchain for local dev and CI.
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
Adds rust-toolchain.toml (stable). Actions already current; repo uses Bun, so no Node pins to change.