### PR TITLE
docs: bring README up to v0.10 (universe, setups, sync, releases)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 # Lux
 
-A desktop app for driving DMX stage lighting, built as a native
-[Tauri](https://tauri.app) app: a Rust core that talks to the hardware and a
-Vite + TanStack Router + shadcn/ui front end to drive it. Lux controls an
-[Enttec OpenDMX USB](https://www.enttec.com/product/dmx-usb-interfaces/open-dmx-usb/)
-interface two ways: directly from the desktop UI, and remotely from a Discord
-bot over AWS IoT.
+A desktop app for driving DMX stage lighting, built as a native [Tauri](https://tauri.app) app: a Rust core that talks to the hardware and a Vite + TanStack Router + shadcn/ui front end to drive it. Lux runs a full 512-channel DMX universe with user-defined fixtures, patched into named setups (home / church / work) that sync to your account and work offline.
 
-The Rust side keeps a DMX channel buffer continuously synced to the hardware (`apps/desktop/src-tauri/src/{buffer,channels,sync}.rs`) behind a device abstraction (`apps/desktop/src-tauri/src/devices/`); the UI talks to it over **[tauri-typed-ipc](https://github.com/johncarmack1984/tauri-typed-ipc)** (a type-safe IPC crate I wrote), so the Rust↔TypeScript command layer is type-safe end to end.
+Output goes three ways: an [Enttec OpenDMX USB](https://www.enttec.com/product/dmx-usb-interfaces/open-dmx-usb/) interface, network DMX over sACN / Art-Net (nodes auto-discovered), and remote control from a Discord bot over AWS IoT.
+
+The Rust side keeps the universe continuously synced to the hardware (`apps/desktop/src-tauri/src/{buffer,channels,sync}.rs`) behind a device abstraction (`apps/desktop/src-tauri/src/devices/`); the UI talks to it over [tauri-typed-ipc](https://github.com/johncarmack1984/tauri-typed-ipc) (a type-safe IPC crate I wrote), so the Rust↔TypeScript command layer is type-safe end to end.
 
 ## Demo
 
@@ -29,11 +26,13 @@ bun run tauri dev
 
 ## Features
 
-- ✅ Drives channels 1-6 of an Enttec OpenDMX USB (one RGBAW fixture)
-- ✅ Network DMX over sACN and Art-Net (nodes auto-discovered)
-- ✅ Continuous DMX512 render/sync loop with correct break / mark-after-break framing
-- ✅ Remote control from Discord over AWS IoT
-- ✅ Type-safe Rust↔TS commands via tauri-typed-ipc
+- Full 512-channel universe: user-defined fixtures, patching, role-aware color mixing
+- Enttec OpenDMX USB output, plus network DMX over sACN and Art-Net (nodes auto-discovered)
+- Continuous DMX512 render/sync loop with correct break / mark-after-break framing
+- Named setups, cloud-synced per account, offline-first
+- Remote control from Discord over AWS IoT
+- Type-safe Rust↔TS commands via tauri-typed-ipc
+- Signed, notarized, self-updating macOS releases
 
 ## Screenshot
 


### PR DESCRIPTION
README still described the v0.4-era app (channels 1-6, one fixture, two output paths). Now: 512-channel universe with custom fixtures and patching, named setups with offline-first account sync, three output paths, signed/notarized self-updating releases. Drops the vestigial checkmarks; iOS intentionally not claimed (in progress).