### PR TITLE
feat(sync): shared wire contract + realtime change nudges over IoT WebSocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tungstenite"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0f7efedeac57d9b26170f72965ecfd31473ca52ca7a64e925b0b6f5f079886"
+dependencies = [
+ "atomic-waker",
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite",
+]
+
+[[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
+ "tokio",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1564,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dbus"
@@ -3388,11 +3426,13 @@ dependencies = [
  "aws-config",
  "aws-sdk-cognitoidentityprovider",
  "aws-smithy-http-client",
+ "base64 0.22.1",
  "dotenvy",
  "enttecopendmx",
  "keyring",
  "libftd2xx 0.33.1",
  "log",
+ "lux-wire",
  "pem",
  "reqwest",
  "rumqttc",
@@ -3416,6 +3456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lux-auth"
+version = "0.1.0"
+dependencies = [
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+]
+
+[[package]]
 name = "lux-bot"
 version = "0.1.0"
 dependencies = [
@@ -3431,13 +3480,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "lux-iot-authorizer"
+version = "0.1.0"
+dependencies = [
+ "lambda_runtime",
+ "lux-auth",
+ "lux-wire",
+ "rustls 0.23.41",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lux-sync-api"
 version = "0.1.0"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
- "jsonwebtoken",
+ "aws-sdk-iotdataplane",
  "lambda_http",
+ "lux-auth",
+ "lux-wire",
  "reqwest",
  "rustls 0.23.41",
  "serde",
@@ -3445,6 +3511,14 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lux-wire"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4054,6 +4128,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4402,8 +4486,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4428,12 +4522,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4620,10 +4733,12 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0feff8d882bff0b2fddaf99355a10336d43dd3ed44204f85ece28cf9626ab519"
 dependencies = [
+ "async-tungstenite",
  "bytes",
  "fixedbitset",
  "flume",
  "futures-util",
+ "http 1.4.2",
  "log",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -4633,6 +4748,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
+ "ws_stream_tungstenite",
 ]
 
 [[package]]
@@ -6449,6 +6565,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.2",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls 0.23.41",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7400,6 +7535,26 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "ws_stream_tungstenite"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c9c55940d22313a53398bfeb9438c5f519de475fa37ed7ff068f8c1ca8eb45"
+dependencies = [
+ "async-tungstenite",
+ "async_io_stream",
+ "bitflags 2.13.0",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+ "pharos",
+ "rustc_version",
+ "tokio",
+ "tracing",
+ "tungstenite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 resolver = "2"
 members = [
     "apps/desktop/src-tauri",
+    "crates/lux-auth",
+    "crates/lux-wire",
     "services/bot",
+    "services/iot-authorizer",
     "services/sync-api",
 ]
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A desktop app for driving DMX stage lighting, built as a native [Tauri](https://
 
 Output goes three ways: an [Enttec OpenDMX USB](https://www.enttec.com/product/dmx-usb-interfaces/open-dmx-usb/) interface, network DMX over sACN / Art-Net (nodes auto-discovered), and remote control from a Discord bot over AWS IoT.
 
-The Rust side keeps the universe continuously synced to the hardware (`apps/desktop/src-tauri/src/{buffer,channels,sync}.rs`) behind a device abstraction (`apps/desktop/src-tauri/src/devices/`); the UI talks to it over [tauri-typed-ipc](https://github.com/johncarmack1984/tauri-typed-ipc) (a type-safe IPC crate I wrote), so the Rust↔TypeScript command layer is type-safe end to end.
+The Rust side keeps the universe continuously synced to the hardware (`apps/desktop/src-tauri/src/{buffer,channels,sync}.rs`) behind a device abstraction (`apps/desktop/src-tauri/src/devices/`); the UI talks to it over [tauri-typed-ipc](https://github.com/johncarmack1984/tauri-typed-ipc) (a type-safe IPC crate I wrote), so the Rust↔TypeScript command layer is type-safe end to end. The desktop↔cloud wire is typed the same way: both sides share one contract crate (`crates/lux-wire`). More in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Demo
 
@@ -29,7 +29,7 @@ bun run tauri dev
 - Full 512-channel universe: user-defined fixtures, patching, role-aware color mixing
 - Enttec OpenDMX USB output, plus network DMX over sACN and Art-Net (nodes auto-discovered)
 - Continuous DMX512 render/sync loop with correct break / mark-after-break framing
-- Named setups, cloud-synced per account, offline-first
+- Named setups, cloud-synced per account, offline-first — other devices pick up changes live over an open IoT WebSocket (nudged pull)
 - Remote control from Discord over AWS IoT
 - Type-safe Rust↔TS commands via tauri-typed-ipc
 - Signed, notarized, self-updating macOS releases

--- a/apps/desktop/src-tauri/.env.example
+++ b/apps/desktop/src-tauri/.env.example
@@ -17,3 +17,11 @@ COGNITO_USER_POOL_ID=
 COGNITO_APP_CLIENT_ID=
 COGNITO_REGION=
 LUX_SYNC_URL=
+
+# Change-nudge channel (realtime sync): an open MQTT-over-WebSocket connection
+# to AWS IoT Core that pulls setups the moment another device writes. Values
+# from `terraform -chdir=infra output` (nudge_endpoint / nudge_authorizer; the
+# endpoint is the same ATS host as AWS_IOT_ENDPOINT). Leave unset to run
+# without nudges — sign-in/startup/focus pulls still sync everything.
+LUX_NUDGE_ENDPOINT=
+LUX_NUDGE_AUTHORIZER=lux-sync-auth

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -57,7 +57,15 @@ uuid = { version = "1.18.1", features = [
 # Cloud-sync HTTP client to the lux-sync-api Function URL; shares the workspace
 # reqwest (rustls-no-provider, riding the app's process-default ring provider).
 reqwest.workspace = true
-rumqttc = "0.25"
+# The desktop↔sync-api wire contract — the same crate the Lambda serializes
+# with, so the two sides cannot drift (see crates/lux-wire).
+lux-wire = { path = "../../../crates/lux-wire" }
+# base64url payload decode of our own Cognito ID token (topic addressing only —
+# verification stays server-side in the IoT authorizer / sync-api).
+base64 = "0.22"
+# `websocket` for the change-nudge channel: MQTT over WebSocket to IoT Core
+# (remote control keeps using native MQTT + mutual TLS below).
+rumqttc = { version = "0.25", features = ["websocket"] }
 # rumqttc pulls rustls 0.23, which panics at runtime unless exactly one crypto
 # provider feature is enabled. The workspace pins ring; add the app's extra
 # features here (no cmake / aws-lc-sys C build).

--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -43,7 +43,7 @@ const DEFAULT_SYNC_URL: &str = "https://ql2e5b4hdjnfsns467vesieul40vbvsb.lambda-
 
 /// Read `key` from the environment, falling back to a baked-in default. An unset
 /// *or empty* value yields the default, so a blank `.env` line can't disable it.
-fn env_or(key: &str, default: &str) -> String {
+pub(crate) fn env_or(key: &str, default: &str) -> String {
     std::env::var(key)
         .ok()
         .filter(|s| !s.is_empty())
@@ -260,8 +260,10 @@ pub fn restore_on_startup(app: &AppHandle) {
                 };
                 let _ = CmdEvent::AuthChanged { status }.emit(&app);
                 log::info!("restored signed-in session from keychain");
-                // Pull any setups changed on other devices since last run.
+                // Pull any setups changed on other devices since last run, and
+                // start listening for change nudges going forward.
                 crate::cloud::schedule_sync(&app);
+                crate::nudge::start(&app);
             }
             Err(e) => log::warn!("could not restore session ({e}); staying signed out"),
         }
@@ -276,7 +278,7 @@ pub fn restore_on_startup(app: &AppHandle) {
 /// iOS apps can't read the system CA store, so rustls parses zero roots and the
 /// SDK aborts (`debug_assert` in debug, empty trust store in release). Bundling
 /// the webpki roots makes TLS verification identical on every platform.
-fn webpki_pem_bundle() -> &'static [u8] {
+pub(crate) fn webpki_pem_bundle() -> &'static [u8] {
     static BUNDLE: OnceLock<Vec<u8>> = OnceLock::new();
     BUNDLE.get_or_init(|| {
         let mut pem = Vec::new();

--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
+use lux_wire::{ListSetupsResponse, SetupRecord, TombstoneResponse, UpsertSetupBody, WriteResponse};
 use reqwest::{Client, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -28,7 +29,6 @@ use uuid::Uuid;
 
 use crate::account::LuxAccount;
 use crate::cmd::CmdEvent;
-use crate::fixture::Fixture;
 use crate::setup::{LuxSetups, PendingDelete, Setup};
 
 // --- sync status (drives the UI indicator) -----------------------------------
@@ -91,44 +91,12 @@ impl std::fmt::Display for SyncError {
     }
 }
 
-// --- wire types (match sync-api/src/store.rs) --------------------------------
-
-#[derive(Deserialize)]
-struct ListResponse {
-    setups: Vec<CloudSetup>,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct CloudSetup {
-    id: String,
-    name: String,
-    universe: u16,
-    /// Opaque on the wire; deserialized into `Vec<Fixture>` by `cloud_to_setup`.
-    fixtures: serde_json::Value,
-    updated_at: i64,
-    #[serde(default)]
-    deleted: bool,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct UpsertBody<'a> {
-    name: &'a str,
-    universe: u16,
-    fixtures: &'a Vec<Fixture>,
-    base_updated_at: Option<i64>,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct WriteResponse {
-    updated_at: i64,
-}
+// The wire types live in `lux-wire` — the same crate the sync-api Lambda
+// serializes with, so the two sides cannot drift (the review's P0).
 
 // --- pure merge logic (unit-tested) -----------------------------------------
 
-fn cloud_to_setup(c: &CloudSetup) -> Option<Setup> {
+fn cloud_to_setup(c: &SetupRecord) -> Option<Setup> {
     Some(Setup {
         id: Uuid::parse_str(&c.id).ok()?,
         name: c.name.clone(),
@@ -143,8 +111,8 @@ fn cloud_to_setup(c: &CloudSetup) -> Option<Setup> {
 /// `updatedAt`. Local-only never-synced setups are kept (to be pushed); remote
 /// tombstones remove; remote-only setups are added; a dirty local edit on the
 /// latest base is kept and re-pushed, but loses to a newer remote change.
-fn reconcile(local: Vec<Setup>, remote: &[CloudSetup]) -> Vec<Setup> {
-    let remote_by_id: HashMap<Uuid, &CloudSetup> = remote
+fn reconcile(local: Vec<Setup>, remote: &[SetupRecord]) -> Vec<Setup> {
+    let remote_by_id: HashMap<Uuid, &SetupRecord> = remote
         .iter()
         .filter_map(|c| Uuid::parse_str(&c.id).ok().map(|id| (id, c)))
         .collect();
@@ -188,14 +156,14 @@ fn reconcile(local: Vec<Setup>, remote: &[CloudSetup]) -> Vec<Setup> {
 
 // --- HTTP (one call each; owned token so the future is self-contained) -------
 
-async fn list(client: &Client, base: &str, token: String) -> Result<Vec<CloudSetup>, SyncError> {
+async fn list(client: &Client, base: &str, token: String) -> Result<Vec<SetupRecord>, SyncError> {
     let resp = client
-        .get(format!("{base}/setups"))
+        .get(format!("{base}/{}", lux_wire::SETUPS_SEGMENT))
         .bearer_auth(token)
         .send()
         .await
         .map_err(|e| SyncError::Other(e.to_string()))?;
-    let body: ListResponse = read_json(resp).await?;
+    let body: ListSetupsResponse = read_json(resp).await?;
     Ok(body.setups)
 }
 
@@ -205,14 +173,15 @@ async fn upsert(
     token: String,
     setup: &Setup,
 ) -> Result<WriteResponse, SyncError> {
-    let body = UpsertBody {
-        name: &setup.name,
+    let body = UpsertSetupBody {
+        name: setup.name.clone(),
         universe: setup.universe,
-        fixtures: &setup.fixtures,
+        fixtures: serde_json::to_value(&setup.fixtures)
+            .map_err(|e| SyncError::Other(e.to_string()))?,
         base_updated_at: setup.updated_at,
     };
     let resp = client
-        .put(format!("{base}/setups/{}", setup.id))
+        .put(format!("{base}/{}/{}", lux_wire::SETUPS_SEGMENT, setup.id))
         .bearer_auth(token)
         .json(&body)
         .send()
@@ -227,9 +196,9 @@ async fn tombstone(
     token: String,
     delete: &PendingDelete,
 ) -> Result<(), SyncError> {
-    let mut url = format!("{base}/setups/{}", delete.setup_id);
+    let mut url = format!("{base}/{}/{}", lux_wire::SETUPS_SEGMENT, delete.setup_id);
     if let Some(base_updated_at) = delete.base_updated_at {
-        url.push_str(&format!("?baseUpdatedAt={base_updated_at}"));
+        url.push_str(&format!("?{}={base_updated_at}", lux_wire::BASE_UPDATED_AT_QUERY));
     }
     let resp = client
         .delete(url)
@@ -237,7 +206,7 @@ async fn tombstone(
         .send()
         .await
         .map_err(|e| SyncError::Other(e.to_string()))?;
-    let _: serde_json::Value = read_json(resp).await?;
+    let _: TombstoneResponse = read_json(resp).await?;
     Ok(())
 }
 
@@ -478,12 +447,13 @@ mod tests {
         }
     }
 
-    fn cloud_setup(id: u128, name: &str, updated_at: i64, deleted: bool) -> CloudSetup {
-        CloudSetup {
+    fn cloud_setup(id: u128, name: &str, updated_at: i64, deleted: bool) -> SetupRecord {
+        SetupRecord {
             id: Uuid::from_u128(id).to_string(),
             name: name.into(),
             universe: 1,
             fixtures: serde_json::json!([]),
+            rev: 1,
             updated_at,
             deleted,
         }

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -317,13 +317,16 @@ impl CmdMethods for CmdEndpoint {
     ) -> Result<AuthStatus, String> {
         let status = app_handle.state::<LuxAccount>().sign_in(email, password)?;
         emit_auth_changed(&app_handle, status.clone())?;
-        // Pull the account's setups (claiming local ones on first sign-in).
+        // Pull the account's setups (claiming local ones on first sign-in),
+        // then listen for change nudges from their other devices.
         crate::cloud::schedule_sync(&app_handle);
+        crate::nudge::start(&app_handle);
         Ok(status)
     }
 
     fn sign_out(&self, app_handle: AppHandle) -> Result<AuthStatus, String> {
         let status = app_handle.state::<LuxAccount>().sign_out();
+        crate::nudge::stop(&app_handle);
         emit_auth_changed(&app_handle, status.clone())?;
         Ok(status)
     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod devices;
 mod error;
 mod fixture;
 mod logger;
+mod nudge;
 mod remote;
 mod setup;
 mod sync;
@@ -61,7 +62,8 @@ pub async fn run() {
         .manage(default_buffer)
         .manage(default_channels)
         .manage(DmxOutput::default())
-        .manage(cloud::LuxSync::default());
+        .manage(cloud::LuxSync::default())
+        .manage(nudge::LuxNudge::default());
     // The self-updater is desktop-only (mobile updates ship through the App
     // Store), so add its plugin only when building for desktop.
     #[cfg(desktop)]

--- a/apps/desktop/src-tauri/src/nudge.rs
+++ b/apps/desktop/src-tauri/src/nudge.rs
@@ -1,0 +1,253 @@
+//! Change-nudge listener: one open MQTT-over-WebSocket connection to AWS IoT
+//! Core, so this device pulls immediately when another of the user's devices
+//! writes a setup — vegify's sync model (server-authoritative, nudged pull),
+//! with IoT Core standing in for vegify's standing server as the connection
+//! holder.
+//!
+//! The sync-api publishes a tiny frame to `lux/sync/user/<sub>` after each
+//! committed write (`lux_wire::nudge`). The frame is opaque by design and never
+//! parsed here: **any** frame means "pull now", and the pull
+//! ([`crate::cloud::schedule_sync`], already single-flight) stays the
+//! authoritative sync. Missed frames are healed by the existing safety nets —
+//! pull on sign-in/startup/focus plus the on-(re)connect pull below — so
+//! delivery is deliberately best-effort (QoS 0).
+//!
+//! Auth mirrors the sync-api's posture: the handshake carries the Cognito ID
+//! token in the `x-lux-token` header; the `lux-sync-auth` IoT custom authorizer
+//! verifies it and scopes the connection's policy to the *verified* user's own
+//! topic. The token is re-read (and on auth failures refreshed) on every
+//! reconnect attempt, vegify-style, with capped exponential backoff (1s→30s).
+//!
+//! Endpoint config follows the remote.rs contract — env-configured, else no-op
+//! (`LUX_NUDGE_ENDPOINT` / `LUX_NUDGE_AUTHORIZER`; a baked production default
+//! can land in `DEFAULT_NUDGE_ENDPOINT` once read from `terraform output
+//! iot_endpoint`). Runs while signed in; [`stop`] on sign-out.
+
+use std::time::Duration;
+
+use base64::Engine;
+use rumqttc::{
+    AsyncClient, ConnectionError, Event, MqttOptions, Packet, QoS, TlsConfiguration, Transport,
+};
+use tauri::{AppHandle, Manager};
+use tokio::sync::watch;
+use uuid::Uuid;
+
+use crate::account::{env_or, webpki_pem_bundle, LuxAccount};
+
+/// Production IoT data endpoint (`terraform output iot_endpoint`). Not a secret
+/// (same class as the baked Cognito/sync constants in account.rs — the
+/// authorizer only honors verified tokens). Empty = nudges disabled unless the
+/// env var is set.
+const DEFAULT_NUDGE_ENDPOINT: &str = "";
+/// Name of the IoT custom authorizer registered in infra/nudge.tf.
+const DEFAULT_NUDGE_AUTHORIZER: &str = "lux-sync-auth";
+
+struct Config {
+    endpoint: String,
+    authorizer: String,
+}
+
+fn load_config() -> Option<Config> {
+    let _ = dotenvy::dotenv();
+    let endpoint = env_or("LUX_NUDGE_ENDPOINT", DEFAULT_NUDGE_ENDPOINT);
+    if endpoint.is_empty() {
+        return None;
+    }
+    Some(Config {
+        endpoint,
+        authorizer: env_or("LUX_NUDGE_AUTHORIZER", DEFAULT_NUDGE_AUTHORIZER),
+    })
+}
+
+/// Tauri-managed listener lifecycle. The watch value is a generation counter:
+/// [`start`] bumps it and spawns a listener bound to the new generation, so a
+/// stale listener (previous sign-in, or a sign-out via [`stop`]) sees the bump
+/// and exits — at most one listener is ever live.
+pub struct LuxNudge {
+    generation: watch::Sender<u64>,
+}
+
+impl Default for LuxNudge {
+    fn default() -> Self {
+        Self {
+            generation: watch::channel(0).0,
+        }
+    }
+}
+
+/// Start (or restart) the nudge listener for the signed-in user. Called after
+/// sign-in and after a startup session restore; no-op when nudges aren't
+/// configured or nobody is signed in.
+pub fn start(app: &AppHandle) {
+    let Some(cfg) = load_config() else {
+        log::info!("nudge channel not configured; realtime sync nudges disabled (set LUX_NUDGE_ENDPOINT to enable)");
+        return;
+    };
+    if !app.state::<LuxAccount>().signed_in() {
+        return;
+    }
+
+    let state = app.state::<LuxNudge>();
+    let mut generation = state.generation.subscribe();
+    state.generation.send_modify(|g| *g += 1);
+    let my_generation = *generation.borrow_and_update();
+
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let mut backoff_secs = 1u64;
+        let mut refresh_first = false;
+        loop {
+            if *generation.borrow() != my_generation {
+                return; // superseded by a newer listener or a sign-out
+            }
+            let account = app.state::<LuxAccount>();
+            if !account.signed_in() {
+                return;
+            }
+            // Fresh token every attempt (vegify's contract); after an auth-shaped
+            // failure, refresh it first — the previous one likely expired.
+            let token = if refresh_first {
+                account
+                    .refresh_id_token()
+                    .await
+                    .ok()
+                    .or_else(|| account.current_id_token())
+            } else {
+                account.current_id_token()
+            };
+            drop(account);
+            let Some(token) = token else { return };
+            let Some(sub) = jwt_sub(&token) else {
+                log::warn!(
+                    "nudge: could not read sub from the id token; disabling for this session"
+                );
+                return;
+            };
+            refresh_first =
+                run_connection(&app, &cfg, token, &sub, &mut generation, &mut backoff_secs).await;
+            if *generation.borrow() != my_generation {
+                return;
+            }
+            tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+            backoff_secs = (backoff_secs * 2).min(30);
+        }
+    });
+}
+
+/// Stop the listener (sign-out). Idempotent; a later [`start`] resumes.
+pub fn stop(app: &AppHandle) {
+    app.state::<LuxNudge>().generation.send_modify(|g| *g += 1);
+}
+
+/// One connection lifetime: connect, subscribe, forward frames to the sync
+/// engine until the connection drops or the listener is superseded. Returns
+/// whether the failure looked auth-shaped (broker refused the connect), so the
+/// caller refreshes the token before retrying.
+async fn run_connection(
+    app: &AppHandle,
+    cfg: &Config,
+    token: String,
+    sub: &str,
+    generation: &mut watch::Receiver<u64>,
+    backoff_secs: &mut u64,
+) -> bool {
+    // Random per-session suffix: one user's devices must not share a client id
+    // (IoT disconnects duplicates). The authorizer's policy allows the prefix.
+    let client_id = format!(
+        "{}{}",
+        lux_wire::nudge::client_id_prefix(sub),
+        &Uuid::new_v4().simple().to_string()[..8]
+    );
+    let url = format!(
+        "wss://{}/mqtt?x-amz-customauthorizer-name={}",
+        cfg.endpoint, cfg.authorizer
+    );
+    let mut opts = MqttOptions::new(client_id, url, 443);
+    opts.set_keep_alive(Duration::from_secs(30));
+    // Trust the bundled webpki roots, not the platform store (unreadable on
+    // iOS — same lesson as the account layer's AWS SDK client).
+    opts.set_transport(Transport::Wss(TlsConfiguration::Simple {
+        ca: webpki_pem_bundle().to_vec(),
+        alpn: None,
+        client_auth: None,
+    }));
+    let header_token = token.clone();
+    opts.set_request_modifier(move |mut request| {
+        let value = header_token.clone();
+        async move {
+            if let Ok(v) = value.parse() {
+                request.headers_mut().insert(lux_wire::nudge::TOKEN_KEY, v);
+            }
+            request
+        }
+    });
+
+    let (client, mut eventloop) = AsyncClient::new(opts, 10);
+    if let Err(e) = client
+        .subscribe(lux_wire::nudge::user_topic(sub), QoS::AtMostOnce)
+        .await
+    {
+        log::warn!("nudge: could not queue subscribe: {e}");
+        return false;
+    }
+
+    loop {
+        tokio::select! {
+            _ = generation.changed() => {
+                let _ = client.disconnect().await;
+                return false; // superseded — the outer loop exits
+            }
+            event = eventloop.poll() => match event {
+                Ok(Event::Incoming(Packet::SubAck(_))) => {
+                    log::info!("nudge channel connected; listening for setup changes");
+                    *backoff_secs = 1;
+                    // On-(re)connect pull: cover anything nudged while offline.
+                    crate::cloud::schedule_sync(app);
+                }
+                Ok(Event::Incoming(Packet::Publish(_))) => {
+                    // Opaque frame — never parsed; any frame means "pull now".
+                    log::debug!("nudge received; scheduling sync");
+                    crate::cloud::schedule_sync(app);
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::info!("nudge connection error (will reconnect): {e}");
+                    return matches!(e, ConnectionError::ConnectionRefused(_));
+                }
+            }
+        }
+    }
+}
+
+/// The `sub` claim from our own ID token's payload. Unverified base64 decode on
+/// purpose: this only *addresses* the topic we ask for — the IoT authorizer
+/// independently verifies the token and scopes the granted policy to the sub it
+/// verified, so a wrong value here can only produce a denied subscribe.
+fn jwt_sub(token: &str) -> Option<String> {
+    let payload = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    Some(claims.get("sub")?.as_str()?.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jwt_sub_reads_the_payload_claim() {
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"sub":"abc-123","token_use":"id"}"#);
+        let token = format!("eyJhbGciOiJSUzI1NiJ9.{payload}.sig");
+        assert_eq!(jwt_sub(&token).as_deref(), Some("abc-123"));
+    }
+
+    #[test]
+    fn jwt_sub_rejects_garbage() {
+        assert_eq!(jwt_sub("not-a-jwt"), None);
+        assert_eq!(jwt_sub("a.b.c"), None);
+    }
+}

--- a/crates/lux-auth/Cargo.toml
+++ b/crates/lux-auth/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "lux-auth"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# Server-side Cognito ID-token verification, shared by the Lambdas that gate on
+# a user's identity (services/sync-api, services/iot-authorizer). The desktop
+# never depends on this crate — it holds tokens, it doesn't verify them.
+
+[dependencies]
+jsonwebtoken = "10"
+reqwest = { workspace = true }
+serde = { workspace = true }

--- a/crates/lux-auth/src/lib.rs
+++ b/crates/lux-auth/src/lib.rs
@@ -1,10 +1,14 @@
-//! Cognito ID-token verification.
+//! Cognito ID-token verification, shared by every Lambda that gates on a
+//! user's identity (the sync API and the IoT nudge authorizer).
 //!
-//! The user pool's public signing keys (JWKS) are fetched once at cold start and
-//! used to verify the RS256 signature, issuer, audience, and expiry of every
-//! incoming token. The caller's `sub` is the only identity we trust — it keys
-//! the per-user DynamoDB partition, so a forged or another-pool token can never
-//! reach someone else's data.
+//! The user pool's public signing keys (JWKS) are fetched once at cold start
+//! and used to verify the RS256 signature, issuer, audience, and expiry of
+//! every incoming token. The caller's `sub` is the only identity we trust — it
+//! keys the per-user DynamoDB partition and the per-user nudge topic, so a
+//! forged or another-pool token can never reach someone else's data.
+//!
+//! Callers on reqwest's `rustls-no-provider` build must install a process
+//! crypto provider before [`Verifier::new`] performs the JWKS fetch.
 
 use std::collections::HashMap;
 
@@ -79,10 +83,13 @@ impl Verifier {
         validation.set_issuer(&[&self.issuer]);
         validation.set_audience(&[&self.client_id]);
 
-        let data = decode::<Claims>(token, key, &validation)
-            .map_err(|e| format!("invalid token: {e}"))?;
+        let data =
+            decode::<Claims>(token, key, &validation).map_err(|e| format!("invalid token: {e}"))?;
         if data.claims.token_use != "id" {
-            return Err(format!("expected an ID token, got {}", data.claims.token_use));
+            return Err(format!(
+                "expected an ID token, got {}",
+                data.claims.token_use
+            ));
         }
         Ok(data.claims)
     }

--- a/crates/lux-wire/Cargo.toml
+++ b/crates/lux-wire/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lux-wire"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# The desktop↔sync-api wire contract, declared once and depended on by both
+# sides (apps/desktop/src-tauri and services/sync-api), so the schema cannot
+# drift between them. Pure types + tiny helpers: serde only, no AWS, no HTTP.
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -1,0 +1,240 @@
+//! The desktop↔sync-api wire contract, declared once.
+//!
+//! Both sides of the wire depend on this crate — `services/sync-api`
+//! deserializes what `apps/desktop` serializes and vice versa — so the schema
+//! cannot drift between them. (Before this crate each side hand-maintained its
+//! own mirror of these shapes; that was the last unguarded wire in the app.)
+//!
+//! The JSON is byte-for-byte the pre-crate wire — camelCase keys, `Option`s
+//! serialized as `null` — and the golden tests at the bottom pin every shape,
+//! so editing a type here is a conscious, reviewable wire change rather than a
+//! silent one. Old clients keep working: nothing here removes or renames a
+//! field they rely on.
+//!
+//! [`nudge`] holds the other half of the spine: the tiny change-notification
+//! frame and the MQTT topic scheme the sync-api publishes it on.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The path segment both sides build `…/setups[/{id}]` routes from.
+pub const SETUPS_SEGMENT: &str = "setups";
+
+/// Query parameter carrying the optimistic-concurrency base on `DELETE`.
+pub const BASE_UPDATED_AT_QUERY: &str = "baseUpdatedAt";
+
+/// One setup as it crosses the wire (an element of [`ListSetupsResponse`]).
+///
+/// `fixtures` is deliberately opaque here: the server round-trips it as JSON
+/// and only the desktop gives it a concrete type, so fixture-schema evolution
+/// never requires a server deploy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetupRecord {
+    pub id: String,
+    pub name: String,
+    pub universe: u16,
+    pub fixtures: Value,
+    /// Server-side write counter. Informational on the client today; the
+    /// last-writer-wins authority is `updated_at`.
+    pub rev: i64,
+    /// Server-assigned epoch millis of the last write (never a client clock).
+    pub updated_at: i64,
+    /// Soft-delete tombstone; the client drops these during reconcile.
+    #[serde(default)]
+    pub deleted: bool,
+}
+
+/// Response to `GET /setups`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListSetupsResponse {
+    pub setups: Vec<SetupRecord>,
+}
+
+/// Request body for `PUT /setups/{id}`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpsertSetupBody {
+    pub name: String,
+    pub universe: u16,
+    /// The desktop's `Vec<Fixture>`, opaque on the wire (see [`SetupRecord`]).
+    pub fixtures: Value,
+    /// The client's last-known server `updated_at` for this setup — the
+    /// optimistic-concurrency token. `None` means "create; fail if it exists".
+    #[serde(default)]
+    pub base_updated_at: Option<i64>,
+}
+
+/// Response to a successful `PUT /setups/{id}`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WriteResponse {
+    pub updated_at: i64,
+    pub rev: i64,
+}
+
+/// Response to a successful `DELETE /setups/{id}`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TombstoneResponse {
+    pub updated_at: i64,
+    pub deleted: bool,
+}
+
+/// Error body for every non-2xx reply.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+pub mod nudge {
+    //! The change-nudge channel: tiny events, opaque to clients.
+    //!
+    //! After each committed write the sync-api publishes
+    //! [`setups_changed_frame`] to the writer's [`user_topic`]. The frame is
+    //! deliberately content-free — **clients must not parse it**; any frame on
+    //! the topic means "pull now", and the HTTP pull stays the authoritative
+    //! sync. (This copies vegify's sync model, the house standard: the typed
+    //! contract guards the pull payload, never the nudge.) Delivery is
+    //! best-effort by design: a missed frame is healed by the existing
+    //! pull-on-focus/reconnect safety nets.
+
+    /// `{"changed":"setups"}` — the only frame currently published. Opaque by
+    /// design; see the module docs.
+    pub fn setups_changed_frame() -> String {
+        serde_json::json!({ "changed": "setups" }).to_string()
+    }
+
+    /// The per-user nudge topic. The IoT custom authorizer scopes each
+    /// connection's policy to the *verified* Cognito `sub`, so a user can only
+    /// ever subscribe to their own changes.
+    pub fn user_topic(sub: &str) -> String {
+        format!("lux/sync/user/{sub}")
+    }
+
+    /// MQTT client-id prefix for a user's nudge connections. Each app session
+    /// appends a random suffix so one user's devices never kick each other off
+    /// (IoT disconnects duplicate client ids); the authorizer allows
+    /// `<prefix>*` for the verified sub only.
+    pub fn client_id_prefix(sub: &str) -> String {
+        format!("lux-sync-{sub}-")
+    }
+
+    /// Name of the handshake header (and query param) carrying the Cognito ID
+    /// token — the IoT authorizer's `token_key_name`.
+    pub const TOKEN_KEY: &str = "x-lux-token";
+}
+
+// --- golden tests: the wire's own drift gate ---------------------------------
+//
+// Each test pins the exact JSON a type produces/accepts. If one of these fails,
+// you are changing the wire — make sure every deployed client and the Lambda
+// agree before you ship it, then update the golden here in the same commit.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn setup_record_shape() {
+        let record = SetupRecord {
+            id: "7f0175a6-3b64-4a2a-9e1c-000000000001".into(),
+            name: "Home".into(),
+            universe: 1,
+            fixtures: json!([{ "kind": "rgbaw" }]),
+            rev: 3,
+            updated_at: 1719000000000,
+            deleted: false,
+        };
+        assert_eq!(
+            serde_json::to_string(&record).unwrap(),
+            r#"{"id":"7f0175a6-3b64-4a2a-9e1c-000000000001","name":"Home","universe":1,"fixtures":[{"kind":"rgbaw"}],"rev":3,"updatedAt":1719000000000,"deleted":false}"#
+        );
+    }
+
+    #[test]
+    fn setup_record_tolerates_missing_deleted() {
+        let record: SetupRecord = serde_json::from_value(json!({
+            "id": "a", "name": "n", "universe": 1, "fixtures": [], "rev": 0,
+            "updatedAt": 1
+        }))
+        .unwrap();
+        assert!(!record.deleted);
+    }
+
+    #[test]
+    fn list_response_shape() {
+        let body = ListSetupsResponse { setups: vec![] };
+        assert_eq!(serde_json::to_string(&body).unwrap(), r#"{"setups":[]}"#);
+    }
+
+    #[test]
+    fn upsert_body_shape() {
+        // `baseUpdatedAt: null` (not omitted) is what shipped clients send —
+        // pinned here on purpose.
+        let create = UpsertSetupBody {
+            name: "Home".into(),
+            universe: 7,
+            fixtures: json!([]),
+            base_updated_at: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&create).unwrap(),
+            r#"{"name":"Home","universe":7,"fixtures":[],"baseUpdatedAt":null}"#
+        );
+
+        let update: UpsertSetupBody = serde_json::from_str(
+            r#"{"name":"Home","universe":7,"fixtures":[],"baseUpdatedAt":42}"#,
+        )
+        .unwrap();
+        assert_eq!(update.base_updated_at, Some(42));
+
+        // A body without the field at all (very old client) still parses.
+        let bare: UpsertSetupBody =
+            serde_json::from_str(r#"{"name":"Home","universe":7,"fixtures":[]}"#).unwrap();
+        assert_eq!(bare.base_updated_at, None);
+    }
+
+    #[test]
+    fn write_response_shape() {
+        let body = WriteResponse {
+            updated_at: 42,
+            rev: 2,
+        };
+        assert_eq!(
+            serde_json::to_string(&body).unwrap(),
+            r#"{"updatedAt":42,"rev":2}"#
+        );
+    }
+
+    #[test]
+    fn tombstone_response_shape() {
+        let body = TombstoneResponse {
+            updated_at: 42,
+            deleted: true,
+        };
+        assert_eq!(
+            serde_json::to_string(&body).unwrap(),
+            r#"{"updatedAt":42,"deleted":true}"#
+        );
+    }
+
+    #[test]
+    fn error_response_shape() {
+        let body = ErrorResponse {
+            error: "conflict".into(),
+        };
+        assert_eq!(
+            serde_json::to_string(&body).unwrap(),
+            r#"{"error":"conflict"}"#
+        );
+    }
+
+    #[test]
+    fn nudge_frame_and_topics() {
+        assert_eq!(nudge::setups_changed_frame(), r#"{"changed":"setups"}"#);
+        assert_eq!(nudge::user_topic("abc-123"), "lux/sync/user/abc-123");
+        assert_eq!(nudge::client_id_prefix("abc-123"), "lux-sync-abc-123-");
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,25 @@
+# Architecture
+
+Lux is a Tauri 2 app (Rust core + Vite/React UI) with serverless AWS satellites. Local control is authoritative; the cloud only moves config and nudges — live DMX output never depends on the network.
+
+## Runtime shape
+
+- **Desktop / iOS app** (`apps/desktop`): the Rust core owns the DMX universe and renders it to hardware (Enttec OpenDMX USB, sACN/E1.31, Art-Net) behind the `devices/` sink abstraction. The UI drives the core over [tauri-typed-ipc](https://github.com/johncarmack1984/tauri-typed-ipc).
+- **sync-api** (`services/sync-api`): Lambda Function URL. Verifies the Cognito JWT in-handler; the caller's verified `sub` — never a request field — keys their DynamoDB partition, so cross-tenant access is impossible.
+- **iot-authorizer** (`services/iot-authorizer`): IoT custom authorizer for the change-nudge channel; same JWT verification, returns a policy scoped to the verified user's own topic.
+- **bot** (`services/bot`): Discord-interactions Lambda (ed25519-verified) publishing remote-control commands to AWS IoT; the app dials out over MQTT + mutual TLS and subscribes — no public ingress to the light host, nothing always-on.
+- **infra** (`infra/`): Terraform, run by CI via OIDC — read-only plan on PRs, curated least-privilege apply on release merges.
+
+## Type spines
+
+Every wire is declared once and drift-guarded — a mismatch is a compile/CI failure, never a runtime surprise:
+
+- UI ↔ Rust: ttipc-generated `src/bindings.ts`, committed and drift-gated by `src-tauri/tests/bindings.rs` (plain `cargo test` fails when stale).
+- Desktop ↔ sync-api: `crates/lux-wire`, depended on by both sides; golden tests pin the exact JSON. No hand-maintained mirrors anywhere.
+- Cognito verification shared by the identity-gated Lambdas: `crates/lux-auth`.
+
+## Sync model (server-authoritative, nudged pull)
+
+Setups are edited locally (offline-first) and pushed with optimistic concurrency; the server assigns `updatedAt` (last-writer-wins) and deletes are soft tombstones. Pulls reconcile on sign-in, startup, window focus, and reconnect, with exponential-backoff retry while offline.
+
+After each committed write the sync-api publishes a tiny opaque frame to the writer's own topic (`lux/sync/user/<sub>`). Each signed-in device keeps one open MQTT-over-WebSocket connection to IoT Core (`nudge.rs`), authorized per-user by the `lux-sync-auth` custom authorizer, and treats **any** frame as "pull now" — the frame is never parsed; the HTTP pull stays the authoritative sync. IoT Core is the connection holder, so the estate stays serverless while getting standing-connection push.

--- a/infra/accounts.tf
+++ b/infra/accounts.tf
@@ -163,6 +163,8 @@ resource "aws_lambda_function" "lux_sync_api" {
       COGNITO_APP_CLIENT_ID = aws_cognito_user_pool_client.lux_app.id
       COGNITO_REGION        = data.aws_region.current.region
       DYNAMODB_TABLE        = aws_dynamodb_table.lux_sync.name
+      # Change nudges (nudge.tf): where to publish after a committed write.
+      IOT_ENDPOINT = data.aws_iot_endpoint.ats.endpoint_address
     }
   }
 }

--- a/infra/nudge.tf
+++ b/infra/nudge.tf
@@ -1,0 +1,118 @@
+# Change-nudge channel: after each committed write the lux-sync-api Lambda
+# publishes a tiny opaque frame to the writer's own topic (lux/sync/user/<sub>);
+# the desktop keeps an open MQTT-over-WebSocket connection to IoT Core and pulls
+# on any frame. IoT Core is the connection holder — the serverless stand-in for
+# vegify's standing server in the house sync model — and the custom authorizer
+# below verifies the app's Cognito ID token and scopes each connection to the
+# verified user's own topic: the same token-derived tenant isolation as the
+# sync-api's DynamoDB partition key.
+
+# --- The authorizer Lambda (services/iot-authorizer) ---
+
+# Least-privilege role: logs only — the authorizer just verifies a JWT and
+# returns a policy document.
+resource "aws_iam_role" "lux_iot_authorizer" {
+  name = "lux-iot-authorizer"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lux_iot_authorizer_logs" {
+  role       = aws_iam_role.lux_iot_authorizer.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_cloudwatch_log_group" "lux_iot_authorizer" {
+  name              = "/aws/lambda/lux-iot-authorizer"
+  retention_in_days = 14
+}
+
+# Terraform owns the function's *config*; cargo-lambda ships the code (the same
+# placeholder + ignore_changes pattern as the bot and sync-api).
+data "archive_file" "iot_authorizer_placeholder" {
+  type        = "zip"
+  output_path = "${path.module}/.iot-authorizer-placeholder.zip"
+  source {
+    content  = "placeholder — real code is shipped by cargo-lambda"
+    filename = "bootstrap"
+  }
+}
+
+resource "aws_lambda_function" "lux_iot_authorizer" {
+  function_name = "lux-iot-authorizer"
+  role          = aws_iam_role.lux_iot_authorizer.arn
+  runtime       = "provided.al2023"
+  handler       = "bootstrap"
+  architectures = ["x86_64"]
+  memory_size   = 128
+  timeout       = 5
+
+  filename = data.archive_file.iot_authorizer_placeholder.output_path
+  lifecycle {
+    ignore_changes = [filename, source_code_hash]
+  }
+
+  environment {
+    variables = {
+      COGNITO_USER_POOL_ID  = aws_cognito_user_pool.lux.id
+      COGNITO_APP_CLIENT_ID = aws_cognito_user_pool_client.lux_app.id
+      COGNITO_REGION        = data.aws_region.current.region
+    }
+  }
+}
+
+# IoT (not a user) invokes the authorizer.
+resource "aws_lambda_permission" "lux_iot_authorizer_invoke" {
+  statement_id  = "AllowIoTCustomAuthorizer"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lux_iot_authorizer.function_name
+  principal     = "iot.amazonaws.com"
+  source_arn    = aws_iot_authorizer.lux_sync.arn
+}
+
+# --- The authorizer registration ---
+
+# Signing is disabled: the desktop is a public client and can't hold a signing
+# key, so the Lambda's JWT verification is the gate — the same posture as the
+# sync-api's public Function URL with in-handler JWT. token_key_name must match
+# lux_wire::nudge::TOKEN_KEY (the app's handshake header).
+resource "aws_iot_authorizer" "lux_sync" {
+  name                    = "lux-sync-auth"
+  authorizer_function_arn = aws_lambda_function.lux_iot_authorizer.arn
+  signing_disabled        = true
+  status                  = "ACTIVE"
+  token_key_name          = "x-lux-token"
+}
+
+# --- The sync-api may publish nudges to any user's topic ---
+
+resource "aws_iam_role_policy" "lux_sync_api_nudge" {
+  name = "lux-sync-api-iot-nudge"
+  role = aws_iam_role.lux_sync_api.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "iot:Publish"
+      Resource = "${local.arn_prefix}:topic/lux/sync/user/*"
+    }]
+  })
+}
+
+# --- Outputs: write these into the app's env (src-tauri/.env) ---
+
+output "nudge_endpoint" {
+  description = "LUX_NUDGE_ENDPOINT for the app — the same ATS data endpoint as AWS_IOT_ENDPOINT."
+  value       = data.aws_iot_endpoint.ats.endpoint_address
+}
+
+output "nudge_authorizer" {
+  description = "LUX_NUDGE_AUTHORIZER for the app."
+  value       = aws_iot_authorizer.lux_sync.name
+}

--- a/infra/terraform-ci.tf
+++ b/infra/terraform-ci.tf
@@ -164,6 +164,8 @@ resource "aws_iam_role_policy" "terraform_apply" {
           "iot:DeleteCertificate", "iot:CreatePolicy", "iot:GetPolicy", "iot:DeletePolicy",
           "iot:ListPolicyVersions", "iot:ListTargetsForPolicy", "iot:AttachPolicy", "iot:DetachPolicy",
           "iot:ListAttachedPolicies", "iot:AttachThingPrincipal", "iot:DetachThingPrincipal",
+          # The nudge channel's custom authorizer (nudge.tf).
+          "iot:CreateAuthorizer", "iot:DescribeAuthorizer", "iot:UpdateAuthorizer", "iot:DeleteAuthorizer",
           "iot:TagResource", "iot:UntagResource", "iot:ListTagsForResource",
         ]
         Resource = "arn:aws:iot:*:${local.aws_account_id}:*"

--- a/services/iot-authorizer/Cargo.toml
+++ b/services/iot-authorizer/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "lux-iot-authorizer"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# AWS IoT custom authorizer for the change-nudge channel. The desktop connects
+# to IoT Core over MQTT-over-WebSocket carrying its Cognito ID token; IoT hands
+# the token to this Lambda, which verifies it (lux-auth) and returns an IoT
+# policy scoped to that user's own nudge topic and client-id prefix (lux-wire).
+# Built and deployed with cargo-lambda, like the sibling services.
+
+[dependencies]
+lux-auth = { path = "../../crates/lux-auth" }
+lux-wire = { path = "../../crates/lux-wire" }
+lambda_runtime = "1"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# rustls with no baked-in crypto provider; main() installs ring as the process
+# default before lux-auth's JWKS fetch performs any TLS (mirrors sync-api).
+rustls = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/services/iot-authorizer/src/main.rs
+++ b/services/iot-authorizer/src/main.rs
@@ -1,0 +1,222 @@
+//! lux-iot-authorizer — IoT Core custom authorizer for the change-nudge channel.
+//!
+//! The desktop keeps an open MQTT-over-WebSocket connection to IoT Core so the
+//! sync-api can nudge it when another device writes (see `lux_wire::nudge`).
+//! IoT invokes this Lambda on every connect with the Cognito ID token the app
+//! put in the `x-lux-token` handshake header (the authorizer's
+//! `token_key_name`); we verify it exactly as the sync-api does (`lux-auth`)
+//! and answer with an IoT policy scoped to the *verified* user's own topic and
+//! client-id prefix — the same token-derived tenant isolation as the DynamoDB
+//! partition key. A bad token gets `isAuthenticated: false`, never a policy.
+//!
+//! The authorizer is registered with signing disabled: the desktop is a public
+//! client and can't hold a signing key, so the JWT check here is the gate —
+//! the same posture as the sync-api's public Function URL with in-handler JWT.
+
+use std::collections::HashMap;
+
+use lambda_runtime::{run, service_fn, Error, LambdaEvent};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+/// The slice of IoT's custom-authorizer request we read. Everything is
+/// optional-with-default: IoT varies the shape by protocol, and a missing
+/// field should read as "no token found", not a deserialization failure.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthEvent {
+    /// Set by IoT when the client passed the token under `token_key_name`.
+    #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    protocol_data: Option<ProtocolData>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProtocolData {
+    #[serde(default)]
+    http: Option<HttpData>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HttpData {
+    #[serde(default)]
+    headers: HashMap<String, String>,
+    #[serde(default)]
+    query_string: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .without_time()
+        .init();
+
+    // reqwest uses rustls with no baked provider; install ring as the process
+    // default before the JWKS fetch below performs any TLS.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let pool_id = env("COGNITO_USER_POOL_ID");
+    let client_id = env("COGNITO_APP_CLIENT_ID");
+    let region = env("COGNITO_REGION");
+
+    let verifier = lux_auth::Verifier::new(&region, &pool_id, &client_id)
+        .await
+        .expect("failed to fetch Cognito JWKS");
+    let verifier = &verifier;
+
+    run(service_fn(move |event: LambdaEvent<Value>| async move {
+        Ok::<Value, Error>(authorize(verifier, event))
+    }))
+    .await
+}
+
+fn env(key: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| panic!("{key} must be set"))
+}
+
+fn authorize(verifier: &lux_auth::Verifier, event: LambdaEvent<Value>) -> Value {
+    // Region + account for the policy ARNs, from our own function ARN
+    // (arn:aws:lambda:<region>:<account>:function:<name>).
+    let arn: Vec<&str> = event.context.invoked_function_arn.split(':').collect();
+    let (Some(region), Some(account)) = (arn.get(3), arn.get(4)) else {
+        tracing::error!("malformed invoked_function_arn; denying");
+        return deny();
+    };
+
+    let parsed: AuthEvent = match serde_json::from_value(event.payload) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("unreadable authorizer event ({e}); denying");
+            return deny();
+        }
+    };
+
+    let Some(token) = extract_token(&parsed) else {
+        tracing::info!("no token on connect; denying");
+        return deny();
+    };
+
+    let sub = match verifier.verify(&token) {
+        Ok(claims) => claims.sub,
+        Err(e) => {
+            tracing::info!("token rejected ({e}); denying");
+            return deny();
+        }
+    };
+
+    let prefix = format!("arn:aws:iot:{region}:{account}");
+    let topic = lux_wire::nudge::user_topic(&sub);
+    let client_prefix = lux_wire::nudge::client_id_prefix(&sub);
+
+    json!({
+        "isAuthenticated": true,
+        // principalId must be alphanumeric; Cognito subs are UUIDs with hyphens.
+        "principalId": sub.chars().filter(char::is_ascii_alphanumeric).collect::<String>(),
+        // Hourly forced re-auth: matches the ID token's validity, and the
+        // client's reconnect brings a fresh token + an on-connect pull.
+        "disconnectAfterInSeconds": 3600,
+        "refreshAfterInSeconds": 3600,
+        "policyDocuments": [{
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "iot:Connect",
+                    "Resource": format!("{prefix}:client/{client_prefix}*"),
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": "iot:Subscribe",
+                    "Resource": format!("{prefix}:topicfilter/{topic}"),
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": "iot:Receive",
+                    "Resource": format!("{prefix}:topic/{topic}"),
+                },
+            ],
+        }],
+    })
+}
+
+/// The token, wherever IoT surfaced it: the extracted top-level field when the
+/// client used `token_key_name`, else the raw handshake header or query param.
+fn extract_token(event: &AuthEvent) -> Option<String> {
+    if let Some(token) = event.token.clone().filter(|t| !t.is_empty()) {
+        return Some(token);
+    }
+    let http = event.protocol_data.as_ref()?.http.as_ref()?;
+    if let Some((_, v)) = http
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(lux_wire::nudge::TOKEN_KEY))
+    {
+        if !v.is_empty() {
+            return Some(v.clone());
+        }
+    }
+    // JWTs are URL-safe (base64url + dots), so a plain key=value scan suffices.
+    http.query_string
+        .as_deref()?
+        .trim_start_matches('?')
+        .split('&')
+        .filter_map(|pair| pair.split_once('='))
+        .find(|(k, _)| k.eq_ignore_ascii_case(lux_wire::nudge::TOKEN_KEY))
+        .map(|(_, v)| v.to_owned())
+        .filter(|v| !v.is_empty())
+}
+
+fn deny() -> Value {
+    json!({
+        "isAuthenticated": false,
+        "principalId": "denied",
+        "disconnectAfterInSeconds": 300,
+        "refreshAfterInSeconds": 300,
+        "policyDocuments": [],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(payload: Value) -> AuthEvent {
+        serde_json::from_value(payload).unwrap()
+    }
+
+    #[test]
+    fn token_from_top_level_field() {
+        let e = event(json!({ "token": "abc" }));
+        assert_eq!(extract_token(&e).as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn token_from_handshake_header_any_case() {
+        let e = event(json!({
+            "protocolData": { "http": { "headers": { "X-Lux-Token": "abc" } } }
+        }));
+        assert_eq!(extract_token(&e).as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn token_from_query_string() {
+        let e = event(json!({
+            "protocolData": { "http": {
+                "queryString": "?x-amz-customauthorizer-name=lux-sync-auth&x-lux-token=abc"
+            } }
+        }));
+        assert_eq!(extract_token(&e).as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn missing_token_is_none() {
+        let e = event(json!({ "protocolData": { "http": { "headers": {} } } }));
+        assert_eq!(extract_token(&e), None);
+        assert_eq!(extract_token(&event(json!({}))), None);
+    }
+}

--- a/services/sync-api/Cargo.toml
+++ b/services/sync-api/Cargo.toml
@@ -12,13 +12,15 @@ publish = false
 # produces from this binary.
 
 [dependencies]
+lux-auth = { path = "../../crates/lux-auth" }
+lux-wire = { path = "../../crates/lux-wire" }
 lambda_http.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde.workspace = true
 serde_json.workspace = true
 aws-config.workspace = true
 aws-sdk-dynamodb = "1"
-jsonwebtoken = "10"
+aws-sdk-iotdataplane = "1"
 reqwest.workspace = true
 # rustls with no baked-in crypto provider; main() installs ring as the process
 # default, sidestepping the aws-lc-rs C build that reqwest's `rustls` feature pulls.

--- a/services/sync-api/src/main.rs
+++ b/services/sync-api/src/main.rs
@@ -2,32 +2,43 @@
 //!
 //! The app calls this Function URL with `Authorization: Bearer <Cognito ID
 //! token>` to push and pull its setups. The handler verifies the JWT against the
-//! Cognito user pool (`auth`), derives the caller's `sub`, and reads/writes only
-//! that user's partition of the `lux-sync` DynamoDB table (`store`). No AWS
+//! Cognito user pool (`lux-auth`), derives the caller's `sub`, and reads/writes
+//! only that user's partition of the `lux-sync` DynamoDB table (`store`). No AWS
 //! credentials ever reach the client, and cross-tenant access is impossible: the
 //! partition key comes from the verified token, never from the request.
+//!
+//! Every body that crosses this wire is a `lux-wire` type — the same crate the
+//! desktop deserializes with — so the two sides cannot drift.
 //!
 //! Routes (all under the Function URL):
 //! - `GET    /setups`        — list the caller's setups (incl. tombstones)
 //! - `PUT    /setups/{id}`   — create/update one, optimistic-concurrency on `baseUpdatedAt`
 //! - `DELETE /setups/{id}?baseUpdatedAt=N` — soft-delete (tombstone)
+//!
+//! After each committed write the handler publishes a tiny opaque nudge frame
+//! to the caller's own IoT topic (`lux_wire::nudge`) so their other devices
+//! pull promptly. Publishing is best-effort and never fails the request; with
+//! `IOT_ENDPOINT` unset (tests, minimal dev stacks) it is skipped entirely.
 
-mod auth;
 mod store;
 
 use std::sync::Arc;
 
 use aws_config::BehaviorVersion;
 use lambda_http::{run, service_fn, Body, Error, Request, RequestExt, Response};
-use serde::Deserialize;
-use serde_json::{json, Value};
+use lux_wire::{
+    ErrorResponse, ListSetupsResponse, TombstoneResponse, UpsertSetupBody, WriteResponse,
+};
+use serde::{Deserialize, Serialize};
 
-use store::{StoreError, UpsertBody};
+use store::StoreError;
 
 struct Ctx {
     ddb: aws_sdk_dynamodb::Client,
     table: String,
-    verifier: auth::Verifier,
+    verifier: lux_auth::Verifier,
+    /// IoT data-plane client for change nudges; `None` when `IOT_ENDPOINT` is unset.
+    iot: Option<aws_sdk_iotdataplane::Client>,
 }
 
 #[tokio::main]
@@ -47,17 +58,38 @@ async fn main() -> Result<(), Error> {
     let region = env("COGNITO_REGION");
     let table = env("DYNAMODB_TABLE");
 
-    let verifier = auth::Verifier::new(&region, &pool_id, &client_id)
+    let verifier = lux_auth::Verifier::new(&region, &pool_id, &client_id)
         .await
         .expect("failed to fetch Cognito JWKS");
 
     let conf = aws_config::load_defaults(BehaviorVersion::latest()).await;
     let ddb = aws_sdk_dynamodb::Client::new(&conf);
 
+    // The nudge publisher needs the account's ATS data endpoint (the default
+    // SDK endpoint is the wrong hostname class for IoT data-plane calls).
+    let iot = std::env::var("IOT_ENDPOINT")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(|host| {
+            let url = if host.starts_with("http") {
+                host
+            } else {
+                format!("https://{host}")
+            };
+            let iot_conf = aws_sdk_iotdataplane::config::Builder::from(&conf)
+                .endpoint_url(url)
+                .build();
+            aws_sdk_iotdataplane::Client::from_conf(iot_conf)
+        });
+    if iot.is_none() {
+        tracing::info!("IOT_ENDPOINT unset; change nudges disabled");
+    }
+
     let ctx = Arc::new(Ctx {
         ddb,
         table,
         verifier,
+        iot,
     });
 
     run(service_fn(move |req: Request| {
@@ -75,7 +107,7 @@ async fn handle(ctx: Arc<Ctx>, req: Request) -> Result<Response<Body>, Error> {
     // Identity comes only from the verified token; the request never names a user.
     let sub = match bearer(&req).and_then(|t| ctx.verifier.verify(&t).ok()) {
         Some(claims) => claims.sub,
-        None => return reply(401, json!({ "error": "invalid or missing token" })),
+        None => return reply(401, error("invalid or missing token")),
     };
 
     let method = req.method().clone();
@@ -83,34 +115,47 @@ async fn handle(ctx: Arc<Ctx>, req: Request) -> Result<Response<Body>, Error> {
     let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
 
     match (method.as_str(), segments.as_slice()) {
-        ("GET", ["setups"]) => list(&ctx, &sub).await,
-        ("PUT", ["setups", id]) => upsert(&ctx, &sub, id, &req).await,
-        ("DELETE", ["setups", id]) => tombstone(&ctx, &sub, id, &req).await,
-        _ => reply(404, json!({ "error": "not found" })),
+        ("GET", [seg]) if *seg == lux_wire::SETUPS_SEGMENT => list(&ctx, &sub).await,
+        ("PUT", [seg, id]) if *seg == lux_wire::SETUPS_SEGMENT => {
+            upsert(&ctx, &sub, id, &req).await
+        }
+        ("DELETE", [seg, id]) if *seg == lux_wire::SETUPS_SEGMENT => {
+            tombstone(&ctx, &sub, id, &req).await
+        }
+        _ => reply(404, error("not found")),
     }
 }
 
 async fn list(ctx: &Ctx, sub: &str) -> Result<Response<Body>, Error> {
     match store::list(&ctx.ddb, &ctx.table, sub).await {
-        Ok(setups) => reply(200, json!({ "setups": setups })),
+        Ok(setups) => reply(200, ListSetupsResponse { setups }),
         Err(e) => {
             tracing::error!("list failed: {e}");
-            reply(500, json!({ "error": "internal" }))
+            reply(500, error("internal"))
         }
     }
 }
 
 async fn upsert(ctx: &Ctx, sub: &str, id: &str, req: &Request) -> Result<Response<Body>, Error> {
-    let body: UpsertBody = match parse_body(req) {
+    let body: UpsertSetupBody = match parse_body(req) {
         Ok(b) => b,
-        Err(e) => return reply(400, json!({ "error": e })),
+        Err(e) => return reply(400, error(&e)),
     };
     match store::upsert(&ctx.ddb, &ctx.table, sub, id, &body, now_millis()).await {
-        Ok(res) => reply(200, json!({ "updatedAt": res.updated_at, "rev": res.rev })),
-        Err(StoreError::Conflict) => reply(409, json!({ "error": "conflict" })),
+        Ok(res) => {
+            nudge(ctx, sub).await;
+            reply(
+                200,
+                WriteResponse {
+                    updated_at: res.updated_at,
+                    rev: res.rev,
+                },
+            )
+        }
+        Err(StoreError::Conflict) => reply(409, error("conflict")),
         Err(StoreError::Internal(e)) => {
             tracing::error!("upsert failed: {e}");
-            reply(500, json!({ "error": "internal" }))
+            reply(500, error("internal"))
         }
     }
 }
@@ -118,15 +163,46 @@ async fn upsert(ctx: &Ctx, sub: &str, id: &str, req: &Request) -> Result<Respons
 async fn tombstone(ctx: &Ctx, sub: &str, id: &str, req: &Request) -> Result<Response<Body>, Error> {
     let base = req
         .query_string_parameters()
-        .first("baseUpdatedAt")
+        .first(lux_wire::BASE_UPDATED_AT_QUERY)
         .and_then(|s| s.parse::<i64>().ok());
     match store::tombstone(&ctx.ddb, &ctx.table, sub, id, base, now_millis()).await {
-        Ok(updated_at) => reply(200, json!({ "updatedAt": updated_at, "deleted": true })),
-        Err(StoreError::Conflict) => reply(409, json!({ "error": "conflict" })),
+        Ok(updated_at) => {
+            nudge(ctx, sub).await;
+            reply(
+                200,
+                TombstoneResponse {
+                    updated_at,
+                    deleted: true,
+                },
+            )
+        }
+        Err(StoreError::Conflict) => reply(409, error("conflict")),
         Err(StoreError::Internal(e)) => {
             tracing::error!("tombstone failed: {e}");
-            reply(500, json!({ "error": "internal" }))
+            reply(500, error("internal"))
         }
+    }
+}
+
+/// Best-effort change nudge: publish the opaque `{"changed":"setups"}` frame to
+/// the caller's own topic so their other devices pull now. Never fails the
+/// request — a missed nudge is healed by the app's pull-on-focus/reconnect
+/// safety nets. (All of the user's connected devices get the frame, including
+/// the writer; its re-pull is coalesced client-side and harmless.)
+async fn nudge(ctx: &Ctx, sub: &str) {
+    let Some(iot) = &ctx.iot else { return };
+    let topic = lux_wire::nudge::user_topic(sub);
+    if let Err(e) = iot
+        .publish()
+        .topic(&topic)
+        .qos(0)
+        .payload(aws_sdk_iotdataplane::primitives::Blob::new(
+            lux_wire::nudge::setups_changed_frame().into_bytes(),
+        ))
+        .send()
+        .await
+    {
+        tracing::warn!("nudge publish to {topic} failed: {e}");
     }
 }
 
@@ -163,9 +239,15 @@ fn now_millis() -> i64 {
         .unwrap_or(0)
 }
 
-fn reply(status: u16, body: Value) -> Result<Response<Body>, Error> {
+fn error(message: &str) -> ErrorResponse {
+    ErrorResponse {
+        error: message.to_owned(),
+    }
+}
+
+fn reply<T: Serialize>(status: u16, body: T) -> Result<Response<Body>, Error> {
     Ok(Response::builder()
         .status(status)
         .header("content-type", "application/json")
-        .body(Body::from(body.to_string()))?)
+        .body(Body::from(serde_json::to_string(&body)?))?)
 }

--- a/services/sync-api/src/store.rs
+++ b/services/sync-api/src/store.rs
@@ -10,35 +10,9 @@
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::types::{AttributeValue, ReturnValue};
 use aws_sdk_dynamodb::Client;
-use serde::{Deserialize, Serialize};
+use lux_wire::{SetupRecord, UpsertSetupBody};
 use serde_json::Value;
 use std::collections::HashMap;
-
-/// Request body for an upsert. `baseUpdatedAt` is the client's last-known server
-/// timestamp for this setup — `None` means "create, fail if it already exists".
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UpsertBody {
-    pub name: String,
-    pub universe: u16,
-    /// Opaque to the server — the app's `Vec<Fixture>`, round-tripped as JSON.
-    pub fixtures: Value,
-    #[serde(default)]
-    pub base_updated_at: Option<i64>,
-}
-
-/// A setup as returned by [`list`].
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SetupItem {
-    pub id: String,
-    pub name: String,
-    pub universe: u16,
-    pub fixtures: Value,
-    pub rev: i64,
-    pub updated_at: i64,
-    pub deleted: bool,
-}
 
 /// The result of a successful write: the new server timestamp + revision.
 #[derive(Debug)]
@@ -72,7 +46,7 @@ fn sk(setup_id: &str) -> String {
 }
 
 /// All of a user's setups, including tombstones (the client filters them).
-pub async fn list(ddb: &Client, table: &str, sub: &str) -> Result<Vec<SetupItem>, StoreError> {
+pub async fn list(ddb: &Client, table: &str, sub: &str) -> Result<Vec<SetupRecord>, StoreError> {
     let out = ddb
         .query()
         .table_name(table)
@@ -85,11 +59,13 @@ pub async fn list(ddb: &Client, table: &str, sub: &str) -> Result<Vec<SetupItem>
     let mut setups = Vec::new();
     for item in out.items() {
         // Only setup items; skip any per-user META row that may share the pk.
-        let Some(sk_val) = s(item, "sk") else { continue };
+        let Some(sk_val) = s(item, "sk") else {
+            continue;
+        };
         let Some(id) = sk_val.strip_prefix("SETUP#") else {
             continue;
         };
-        setups.push(SetupItem {
+        setups.push(SetupRecord {
             id: id.to_owned(),
             name: s(item, "name").unwrap_or_default(),
             universe: n(item, "universe").unwrap_or(1) as u16,
@@ -98,7 +74,10 @@ pub async fn list(ddb: &Client, table: &str, sub: &str) -> Result<Vec<SetupItem>
                 .unwrap_or(Value::Array(vec![])),
             rev: n(item, "rev").unwrap_or(0),
             updated_at: n(item, "updatedAt").unwrap_or(0),
-            deleted: item.get("deleted").and_then(|v| v.as_bool().ok().copied()).unwrap_or(false),
+            deleted: item
+                .get("deleted")
+                .and_then(|v| v.as_bool().ok().copied())
+                .unwrap_or(false),
         });
     }
     Ok(setups)
@@ -112,7 +91,7 @@ pub async fn upsert(
     table: &str,
     sub: &str,
     setup_id: &str,
-    body: &UpsertBody,
+    body: &UpsertSetupBody,
     now: i64,
 ) -> Result<WriteResult, StoreError> {
     let mut req = ddb
@@ -147,7 +126,9 @@ pub async fn upsert(
     };
 
     let out = req.send().await.map_err(conflict_or_internal)?;
-    let attrs = out.attributes().ok_or_else(|| StoreError::Internal("no attributes returned".into()))?;
+    let attrs = out
+        .attributes()
+        .ok_or_else(|| StoreError::Internal("no attributes returned".into()))?;
     Ok(WriteResult {
         updated_at: n(attrs, "updatedAt").unwrap_or(now),
         rev: n(attrs, "rev").unwrap_or(0),
@@ -188,7 +169,9 @@ pub async fn tombstone(
     };
 
     let out = req.send().await.map_err(conflict_or_internal)?;
-    let attrs = out.attributes().ok_or_else(|| StoreError::Internal("no attributes returned".into()))?;
+    let attrs = out
+        .attributes()
+        .ok_or_else(|| StoreError::Internal("no attributes returned".into()))?;
     Ok(n(attrs, "updatedAt").unwrap_or(now))
 }
 
@@ -212,7 +195,10 @@ fn conflict_or_internal<E, R>(err: SdkError<E, R>) -> StoreError
 where
     E: ConditionalCheck + std::fmt::Display,
 {
-    if err.as_service_error().is_some_and(|e| e.is_conditional_check()) {
+    if err
+        .as_service_error()
+        .is_some_and(|e| e.is_conditional_check())
+    {
         StoreError::Conflict
     } else {
         StoreError::Internal(err.to_string())


### PR DESCRIPTION
## What

Closes the architectural review's P0 for lux — the desktop↔sync-api wire was the only unguarded wire among the flagship products (hand-written JSON on both sides) — and adopts the house sync model: server-authoritative writes, an open socket listening for tiny events, nudged pull.

- **`crates/lux-wire`** — the wire contract declared once and depended on by both sides, so the schema cannot drift. Golden tests pin the exact JSON; editing a shape is now a conscious, reviewable wire change. `cloud.rs` and the sync-api drop their hand-maintained mirrors.
- **`crates/lux-auth`** — the Cognito ID-token verifier, moved out of sync-api and shared with the new authorizer.
- **Nudge channel** (the vegify sync model, with IoT Core as the connection holder so everything stays serverless):
  - `services/sync-api` publishes an opaque `{"changed":"setups"}` frame to `lux/sync/user/<sub>` after each committed write (best-effort, never fails the request; disabled when `IOT_ENDPOINT` is unset).
  - `services/iot-authorizer` + `infra/nudge.tf` — IoT custom authorizer (`lux-sync-auth`) verifies the app's JWT and returns a policy scoped to the **verified** user's own topic + client-id prefix (same token-derived tenant isolation as the DynamoDB partition key).
  - Desktop `nudge.rs` — one open MQTT-over-WebSocket connection while signed in; the frame is never parsed (any frame = "pull now" through the existing coalesced `schedule_sync`); capped 1→30s reconnect backoff, token re-read (and refreshed after auth-shaped failures) on every attempt; webpki roots for iOS parity. Env-configured-else-no-op (`LUX_NUDGE_ENDPOINT` / `LUX_NUDGE_AUTHORIZER`).
- **`docs/ARCHITECTURE.md`** — the intent doc: runtime shape, type spines, sync model.

## Compatibility

Wire-compatible with shipped v0.10 clients: same routes, same JSON (the client now also reads `rev`, which the server has sent since v0.8.0). The nudge is additive — desktops without config behave exactly like v0.10, and all existing pulls (sign-in, startup, focus, offline retry) remain as safety nets. Ship order is free: Lambda first, desktop release after.

## Post-merge checklist

1. The release apply creates the authorizer + roles. If `CreateAuthorizer` fails with AccessDenied on the first run, re-run the job — the same apply expands its own role policy and IAM propagation can lag a few seconds.
2. Deploy the Lambdas (`cargo lambda build --release --x86-64` + `cargo lambda deploy` for `lux-sync-api` and `lux-iot-authorizer`).
3. Read `terraform -chdir=infra output nudge_endpoint` → set `LUX_NUDGE_ENDPOINT` in dev `.env`, and (follow-up) bake it into `DEFAULT_NUDGE_ENDPOINT` in `nudge.rs` so released builds get nudges without a `.env`.
4. Live verification: two signed-in app instances; edit a setup on one → the other's UI updates within a second or two without focusing the window. `cloud_round_trip_live` (ignored test) still passes against the deployed sync-api.