### PR TITLE
ci(release): gate releases on tests and deploy Lambdas in order

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - 'apps/desktop/**'
       - 'services/**'
+      - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/desktop.yml'
@@ -23,17 +24,24 @@ on:
     paths:
       - 'apps/desktop/**'
       - 'services/**'
+      - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/desktop.yml'
+  # Reusable form: release.yml calls this as its gate, so nothing ships from a
+  # release run unless the exact release commit passes the same checks as a PR.
+  workflow_call:
 
 permissions:
   contents: read
 
 # Newer pushes to the same ref supersede in-flight runs (a PR and a main push use
-# different refs, so they never cancel each other).
+# different refs, so they never cancel each other). github.workflow is the
+# CALLER's name when this runs via workflow_call, so a release-gate invocation
+# groups separately from the push-triggered run of the same commit instead of
+# the two cancelling each other.
 concurrency:
-  group: desktop-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,12 +106,28 @@ jobs:
           git push origin "HEAD:$PR_BRANCH"
           echo "Synced Cargo.lock to $version on $PR_BRANCH"
 
-  # Builds the macOS app and attaches it to the release — after a release-please
-  # release, or on a manual dispatch for an existing tag. Unsigned for now
-  # (Gatekeeper will warn until Developer ID signing + notarization are wired in).
-  build-macos:
+  # The release gate: the same checks as the PR/main `desktop` workflow
+  # (tauri-versions, frontend build/typecheck/lint, cargo test --workspace),
+  # re-run against the exact release commit. Everything that ships — infra,
+  # Lambda code, the desktop bundle — is downstream of this job, so a red main
+  # cannot release.
+  ci:
     needs: release-please
-    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/desktop.yml
+
+  # Builds, signs, and notarizes the macOS app and attaches it (plus the
+  # updater's latest.json) to the release — after a release-please release, or
+  # on a manual dispatch for an existing tag. On the release path this runs
+  # LAST, only after the Lambdas deployed and passed their smokes: the updater
+  # manifest publishing is what makes a release visible to users, so a release
+  # whose backend didn't ship never reaches them. Manual dispatch rebuilds an
+  # existing tag whose backend already shipped, so it skips those gates.
+  build-macos:
+    needs: [release-please, deploy-lambdas]
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (needs.release-please.outputs.release_created == 'true' && needs.deploy-lambdas.result == 'success')) }}
     runs-on: macos-latest
     permissions:
       contents: write
@@ -207,8 +223,8 @@ jobs:
   # don't cut a release. An infra PR therefore merges first and applies here with
   # the next release — its diff was reviewed as the terraform.yml PR plan.
   terraform-apply:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    needs: [release-please, ci]
+    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.ci.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -229,5 +245,94 @@ jobs:
       - name: init
         run: terraform init -input=false
 
+      # One automatic retry: when an apply expands the apply role's own inline
+      # policy and creates resources needing the new grants in the same run,
+      # IAM propagation can lose the race. terraform apply is idempotent, so
+      # the second pass just finishes whatever the first couldn't.
       - name: apply
-        run: terraform apply -auto-approve -no-color -input=false
+        run: |
+          terraform apply -auto-approve -no-color -input=false || {
+            echo "::warning::apply failed once; retrying after IAM propagation delay"
+            sleep 20
+            terraform apply -auto-approve -no-color -input=false
+          }
+
+  # Ship the Lambda code — every release, from the release tag, after the infra
+  # is in place. Deploying all three every time (even when only one changed)
+  # keeps deployed code == main with no path-filter guesswork: workspace crates
+  # like lux-wire feed all of them, and a redeploy of unchanged code is a no-op.
+  # Each function then gets a smoke test that proves the new code actually cold
+  # starts and answers before the desktop artifacts are allowed to publish.
+  deploy-lambdas:
+    needs: [release-please, terraform-apply]
+    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.terraform-apply.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC: assume the lambda-deploy role
+    env:
+      TAG: ${{ needs.release-please.outputs.tag_name }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.TAG }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
+      # cargo-lambda cross-links against an AL2023-compatible glibc via zig; a
+      # plain host build on ubuntu-latest links a newer glibc than the Lambda
+      # runtime ships and fails at cold start with missing symbol versions.
+      - name: Install cargo-lambda (+ zig for the AL2023-safe link)
+        run: pip3 install cargo-lambda ziglang
+
+      # The role is created by the terraform-apply job that just ran, so on the
+      # very first release after it lands, STS may not see it instantly —
+      # retry the assume instead of failing the release.
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::735853783919:role/lux-lambda-deploy
+          aws-region: us-west-1
+          retry-max-attempts: 6
+
+      - name: Build
+        run: cargo lambda build --release --x86-64 -p lux-sync-api -p lux-iot-authorizer -p lux-discord-bot
+
+      - name: Deploy
+        run: |
+          cargo lambda deploy lux-sync-api
+          cargo lambda deploy lux-iot-authorizer
+          cargo lambda deploy lux-discord-bot
+
+      # Unauthenticated 401s are this API's health check: a correct 401 with the
+      # typed error body proves the new binary cold-started (its init fetches
+      # the Cognito JWKS before serving) and is routing requests.
+      - name: Smoke sync-api
+        run: |
+          url=$(aws lambda get-function-url-config --function-name lux-sync-api --query FunctionUrl --output text)
+          code=$(curl -s -o /tmp/body -w '%{http_code}' "${url}setups")
+          cat /tmp/body; echo
+          test "$code" = "401" && grep -q '"error"' /tmp/body
+
+      # Invoke the authorizer directly with a garbage token: a well-formed
+      # deny proves it cold-started (JWKS fetch) and rejects bad tokens.
+      - name: Smoke iot-authorizer
+        run: |
+          aws lambda invoke --function-name lux-iot-authorizer \
+            --cli-binary-format raw-in-base64-out \
+            --payload '{"token":"smoke-test-garbage","protocolData":{"http":{"headers":{}}}}' \
+            /tmp/authorizer.json >/dev/null
+          cat /tmp/authorizer.json; echo
+          grep -q '"isAuthenticated":false' /tmp/authorizer.json
+
+      # The bot verifies Discord's ed25519 signature before anything else, so an
+      # unsigned request answering 401 proves the new code is up and checking.
+      - name: Smoke bot
+        run: |
+          url=$(aws lambda get-function-url-config --function-name lux-discord-bot --query FunctionUrl --output text)
+          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'content-type: application/json' -d '{}' "$url")
+          echo "bot answered $code"
+          test "$code" = "401"

--- a/infra/terraform-ci.tf
+++ b/infra/terraform-ci.tf
@@ -217,6 +217,67 @@ resource "aws_iam_role_policy" "terraform_apply" {
   })
 }
 
+# --- lambda-deploy role: ship Lambda code on release, main branch only -------
+#
+# Assumed by release.yml's deploy-lambdas job (after terraform-apply, before the
+# desktop build), so deployed Lambda code always matches the release tag instead
+# of drifting behind manual `cargo lambda deploy` runs. Deliberately narrow:
+# update code + read config on the three lux functions, plus what the post-deploy
+# smoke tests need (the Function URLs, and a direct test invoke of the
+# authorizer's deny path). It cannot touch IAM, config, or any other resource.
+
+locals {
+  lux_lambda_functions = [
+    "arn:aws:lambda:*:${local.aws_account_id}:function:lux-sync-api",
+    "arn:aws:lambda:*:${local.aws_account_id}:function:lux-iot-authorizer",
+    "arn:aws:lambda:*:${local.aws_account_id}:function:lux-discord-bot",
+  ]
+}
+
+resource "aws_iam_role" "lambda_deploy" {
+  name = "lux-lambda-deploy"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = data.aws_iam_openid_connect_provider.github.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          # Only a workflow running on main (the release deploy) may assume this.
+          "token.actions.githubusercontent.com:sub" = "${local.github_repo_sub}:ref:refs/heads/main"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_deploy" {
+  name = "lux-lambda-deploy"
+  role = aws_iam_role.lambda_deploy.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DeployLuxLambdaCode"
+        Effect = "Allow"
+        Action = [
+          "lambda:GetFunction", "lambda:GetFunctionConfiguration",
+          "lambda:UpdateFunctionCode", "lambda:GetFunctionUrlConfig",
+        ]
+        Resource = local.lux_lambda_functions
+      },
+      {
+        Sid      = "SmokeInvokeAuthorizer"
+        Effect   = "Allow"
+        Action   = "lambda:InvokeFunction"
+        Resource = "arn:aws:lambda:*:${local.aws_account_id}:function:lux-iot-authorizer"
+      },
+    ]
+  })
+}
+
 output "terraform_plan_role_arn" {
   description = "role-to-assume for the terraform PR plan job (read-only)."
   value       = aws_iam_role.terraform_plan.arn
@@ -225,4 +286,9 @@ output "terraform_plan_role_arn" {
 output "terraform_apply_role_arn" {
   description = "role-to-assume for the terraform apply job (main only)."
   value       = aws_iam_role.terraform_apply.arn
+}
+
+output "lambda_deploy_role_arn" {
+  description = "role-to-assume for the release lambda-deploy job (main only)."
+  value       = aws_iam_role.lambda_deploy.arn
 }


### PR DESCRIPTION
## What

Systematizes the release deployment order (follow-up to #89): one merge of the release PR ships everything, in order, fail-loud — no manual deploy sequence, and no path for broken code to reach users.

```
release-please
  └─ ci                the full desktop.yml gate, re-run at the exact release commit
      └─ terraform-apply   (+ one auto-retry for same-run IAM propagation races)
          └─ deploy-lambdas   cargo-lambda build from the release tag → deploy
              │                lux-sync-api · lux-iot-authorizer · lux-discord-bot
              │                then smoke each (see below)
              └─ build-macos   sign/notarize + attach artifacts and the updater
                               latest.json — publishes LAST
```

Every arrow is a hard gate. Red tests block everything; an infra failure blocks code deploys; a failed smoke blocks the desktop artifacts. Because the updater manifest only publishes with the artifacts, a release whose backend didn't ship is never visible to updaters — worst case users simply stay on the previous version until the pipeline greens.

## Smoke tests (proof of cold start, not just deploy success)

- **sync-api**: unauthenticated `GET /setups` on the Function URL must answer `401` with the typed error body — its init fetches the Cognito JWKS before serving, so a correct 401 proves the new binary booted end-to-end.
- **iot-authorizer**: direct invoke with a garbage token must return a well-formed `"isAuthenticated":false`.
- **bot**: an unsigned POST must answer `401` (ed25519 check alive).

## Also in here

- `lux-lambda-deploy` OIDC role: main-only trust (same posture as the apply role), permissions limited to code-update + the smoke calls on the three lux functions. Created by the same release run's apply, so the deploy job retries its role assumption.
- `desktop.yml` gains `workflow_call` (this is CI-study punch item 14 — release gates on green) and `crates/**` in its path filters — previously a PR touching only `crates/lux-wire` would have skipped the test gate entirely.
- Deploying all three Lambdas every release keeps deployed code identical to main and retires the manual `cargo lambda deploy` step (and its drift) completely; unchanged code redeploys as a no-op.

## Effect on the pending v0.11.0

Merging this before release PR #90 means v0.11.0 ships through the new pipeline: apply creates the authorizer, the Lambdas deploy and smoke automatically, and steps 1–2 of #89's post-merge checklist disappear. What remains manual: the two-device nudge verification and the one-line `DEFAULT_NUDGE_ENDPOINT` bake for the release after.