### PR TITLE
ci(infra): grant the apply role the provider's refresh-phase reads

### DIFF
--- a/infra/terraform-ci.tf
+++ b/infra/terraform-ci.tf
@@ -133,6 +133,10 @@ resource "aws_iam_role_policy" "terraform_apply" {
           "lambda:GetPolicy", "lambda:CreateFunctionUrlConfig", "lambda:GetFunctionUrlConfig",
           "lambda:UpdateFunctionUrlConfig", "lambda:DeleteFunctionUrlConfig",
           "lambda:TagResource", "lambda:UntagResource", "lambda:ListTags",
+          # Provider refresh reads code-signing config on every function refresh
+          # (discovered on the first CI apply — plan never catches these because
+          # the plan role runs on ReadOnlyAccess, which includes all reads).
+          "lambda:GetFunctionCodeSigningConfig",
         ]
         Resource = "arn:aws:lambda:*:${local.aws_account_id}:function:lux*"
       },
@@ -164,6 +168,9 @@ resource "aws_iam_role_policy" "terraform_apply" {
           "iot:DeleteCertificate", "iot:CreatePolicy", "iot:GetPolicy", "iot:DeletePolicy",
           "iot:ListPolicyVersions", "iot:ListTargetsForPolicy", "iot:AttachPolicy", "iot:DetachPolicy",
           "iot:ListAttachedPolicies", "iot:AttachThingPrincipal", "iot:DetachThingPrincipal",
+          # Provider refresh reads thing-principal attachments via the V2 API
+          # (first-CI-apply discovery, like GetFunctionCodeSigningConfig above).
+          "iot:ListThingPrincipalsV2",
           # The nudge channel's custom authorizer (nudge.tf).
           "iot:CreateAuthorizer", "iot:DescribeAuthorizer", "iot:UpdateAuthorizer", "iot:DeleteAuthorizer",
           "iot:TagResource", "iot:UntagResource", "iot:ListTagsForResource",
@@ -202,9 +209,14 @@ resource "aws_iam_role_policy" "terraform_apply" {
         Resource = "*"
       },
       {
-        Sid      = "ReadLuxSecrets"
-        Effect   = "Allow"
-        Action   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+        Sid    = "ReadLuxSecrets"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret",
+          # Provider refresh reads each secret's resource policy (first-CI-apply
+          # discovery, like GetFunctionCodeSigningConfig above).
+          "secretsmanager:GetResourcePolicy",
+        ]
         Resource = "arn:aws:secretsmanager:*:${local.aws_account_id}:secret:lux/*"
       },
       {


### PR DESCRIPTION
## What

The first-ever CI terraform apply (the v0.11.0 release run, 28676370127) failed in the refresh phase — the pipeline gates worked exactly as designed (deploy-lambdas and build-macos were skipped; nothing shipped, updaters still serve v0.10.0), and this unblocks it.

The AWS provider performs reads during refresh that the curated apply role never granted:

- `lambda:GetFunctionCodeSigningConfig` — read on every `aws_lambda_function` refresh
- `iot:ListThingPrincipalsV2` — the provider moved thing-principal reads to the V2 API
- `secretsmanager:GetResourcePolicy` — read on every `aws_secretsmanager_secret` refresh

## Why plans never caught it

The plan role runs on `ReadOnlyAccess`, which includes all of these — so PR plans are green while the apply's own refresh 403s. The apply role's write path was validated with policy simulation, but the provider's refresh reads weren't in the simulation set. (Worth remembering: this class recurs whenever a provider upgrade adds a refresh read; the fix pattern is add-the-read + re-run.)

## Bootstrap note

Chicken-and-egg: a refresh failure aborts the apply before it can expand its own policy, so CI can't self-heal this one. After this merges, the policy gets a one-shot targeted local apply (`-target=aws_iam_role_policy.terraform_apply` — the documented escape hatch, third use), then the failed release jobs re-run and v0.11.0 completes through CI without re-tagging.