### PR TITLE
ci(release): deploy Lambdas as static musl zips; rehearse the build in the PR gate

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -81,6 +81,40 @@ jobs:
 
       - run: bun run lint
 
+  # Build the three Lambda services exactly as the release deploy job will
+  # (static musl, release profile, same package names) — so a broken link, a
+  # renamed crate, or a musl-hostile dependency is a red PR check instead of a
+  # failed release run.
+  lambda-build:
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install musl-gcc
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+          cache-targets: "false"
+
+      - name: Build (static musl, release profile)
+        run: cargo build --release --target x86_64-unknown-linux-musl -p lux-sync-api -p lux-iot-authorizer -p lux-discord-bot
+
+      - name: sccache stats
+        if: ${{ always() }}
+        run: sccache --show-stats
+
   rust:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,22 +285,36 @@ jobs:
       id-token: write # OIDC: assume the lambda-deploy role
     env:
       TAG: ${{ needs.release-please.outputs.tag_name }}
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ env.TAG }}
 
+      # Static musl binaries: fully self-contained, so there is no glibc-version
+      # question on provided.al2023 at all — no cargo-lambda, no zig, just the
+      # same cargo the test gate uses, plus the musl target and musl-gcc for
+      # ring's C bits. Everything is pure Rust + ring, musl's happy path; if a
+      # C-heavy dependency ever lands, revisit (that's the honest trigger for a
+      # container-image build).
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install musl-gcc
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      # Same caching pair as the desktop test gate: sccache owns per-crate
+      # compilation (content-addressed, survives lockfile bumps), rust-cache
+      # keeps the registry/index warm without caching target/.
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "."
-
-      # cargo-lambda cross-links against an AL2023-compatible glibc via zig; a
-      # plain host build on ubuntu-latest links a newer glibc than the Lambda
-      # runtime ships and fails at cold start with missing symbol versions.
-      - name: Install cargo-lambda (+ zig for the AL2023-safe link)
-        run: pip3 install cargo-lambda ziglang
+          cache-targets: "false"
 
       # The role is created by the terraform-apply job that just ran, so on the
       # very first release after it lands, STS may not see it instantly —
@@ -311,14 +325,26 @@ jobs:
           aws-region: us-west-1
           retry-max-attempts: 6
 
-      - name: Build
-        run: cargo lambda build --release --x86-64 -p lux-sync-api -p lux-iot-authorizer -p lux-discord-bot
+      - name: Build (static musl)
+        run: cargo build --release --target x86_64-unknown-linux-musl -p lux-sync-api -p lux-iot-authorizer -p lux-discord-bot
 
+      # provided.al2023 runs the zip's `bootstrap`; package each binary under
+      # that name and wait until Lambda finishes swapping code before smoking.
       - name: Deploy
         run: |
-          cargo lambda deploy lux-sync-api
-          cargo lambda deploy lux-iot-authorizer
-          cargo lambda deploy lux-discord-bot
+          for fn in lux-sync-api lux-iot-authorizer lux-discord-bot; do
+            staging=$(mktemp -d)
+            cp "target/x86_64-unknown-linux-musl/release/$fn" "$staging/bootstrap"
+            (cd "$staging" && zip -q9 function.zip bootstrap)
+            aws lambda update-function-code --function-name "$fn" \
+              --zip-file "fileb://$staging/function.zip" --query 'CodeSha256' --output text
+            aws lambda wait function-updated --function-name "$fn"
+            echo "deployed $fn"
+          done
+
+      - name: sccache stats
+        if: ${{ always() }}
+        run: sccache --show-stats
 
       # Unauthenticated 401s are this API's health check: a correct 401 with the
       # typed error body proves the new binary cold-started (its init fetches


### PR DESCRIPTION
## What

Swaps the Lambda deploy mechanism — zip artifacts stay, cargo-lambda and zig go:

- **deploy-lambdas** builds each service with plain `cargo build --release --target x86_64-unknown-linux-musl` (fully static — the glibc-version question on `provided.al2023` disappears rather than being answered by a cross-linker), zips each binary as `bootstrap`, deploys with `aws lambda update-function-code`, and waits for the code swap to settle before the smokes run. No pip-resolved tools, no wrapper name conventions — the same cargo the test gate uses.
- **New `lambda-build` job in the PR gate**: the exact release build (musl, release profile, same `-p` names) runs on every PR touching the workspace. The v0.12.0 failure (`-p lux-discord-bot` matching nothing) would have been a red check on the PR that introduced it; so will any future musl-hostile dependency or broken LTO link. **This PR is the first rehearsal — its own gate runs the build.**
- Deploy job gains the same sccache + rust-cache pair as the test gate (it had rust-cache only).

## Caching status across the repo (asked)

| job | sccache | rust-cache |
|---|---|---|
| desktop.yml `rust` (PR/main gate) | ✓ | ✓ (registry-only, `cache-targets: false` — sccache owns compilation) |
| desktop.yml `lambda-build` (new) | ✓ | ✓ (registry-only) |
| release.yml `build-macos` | ✓ | ✓ (full `target/`, universal-build dep artifacts) |
| release.yml `deploy-lambdas` | ✓ (this PR) | ✓ (registry-only, this PR) |

The known ceiling stands: fat-LTO final links are never cacheable (accepted; it's the smallest-binary profile, kept deliberately).

## Sequencing

Merge before the 0.12.1 release PR so its release run deploys the musl way on first pass.
