### PR TITLE
ci: queue main CI and serialize release runs; gate releases at the tag

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -31,18 +31,25 @@ on:
   # Reusable form: release.yml calls this as its gate, so nothing ships from a
   # release run unless the exact release commit passes the same checks as a PR.
   workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to check out (empty = the triggering sha)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
 
-# Newer pushes to the same ref supersede in-flight runs (a PR and a main push use
-# different refs, so they never cancel each other). github.workflow is the
-# CALLER's name when this runs via workflow_call, so a release-gate invocation
-# groups separately from the push-triggered run of the same commit instead of
-# the two cancelling each other.
+# PRs supersede (a force-push cancels the stale run); pushes to main QUEUE
+# instead — every main commit must end with a completed CI record, so
+# back-to-back merges can't cancel each other's runs (that burned 69642ae,
+# whose push CI was cancelled after 4s by the release merge landing behind
+# it). github.workflow is the CALLER's name under workflow_call, so a
+# release-gate invocation groups separately from the push-triggered run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   tauri-versions:
@@ -52,6 +59,8 @@ jobs:
         working-directory: apps/desktop
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: oven-sh/setup-bun@v2
 
@@ -67,6 +76,8 @@ jobs:
         working-directory: apps/desktop
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: oven-sh/setup-bun@v2
 
@@ -93,6 +104,8 @@ jobs:
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -123,6 +136,8 @@ jobs:
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       # Tauri's Rust crates link the system webkitgtk/gtk stack on Linux, so the
       # -dev packages must be present for the *-sys crates to compile.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,15 @@ on:
 
 permissions: {}
 
+# Strictly one release run at a time, never cancelled: back-to-back merges to
+# main once raced two runs, and the EARLIER commit's run cut the release
+# (release-please acts on latest main, not its checkout) — so its gates ran one
+# commit behind the tag. Queueing serializes them; the tag-pinned checkouts
+# below make whichever run cuts the release gate/build the tag itself.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     if: ${{ github.event_name == 'push' }}
@@ -117,6 +126,10 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/desktop.yml
+    with:
+      # Gate the tag itself, not this run's triggering sha — the two can differ
+      # when a race let an earlier push's run cut the release.
+      ref: ${{ needs.release-please.outputs.tag_name }}
 
   # Builds, signs, and notarizes the macOS app and attaches it (plus the
   # updater's latest.json) to the release — after a release-please release, or
@@ -233,7 +246,11 @@ jobs:
       run:
         working-directory: infra
     steps:
+      # The tag, not github.sha — the infra applied must be exactly the infra
+      # the release's endpoints file and binaries were built against.
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
Closes both holes exposed by merging #97 and #96 back-to-back (69642ae's push CI shows "Cancelled after 4s" on the commit status):

1. **Every main commit gets a completed CI record.** `desktop.yml`'s `cancel-in-progress` now applies only to `pull_request` events (force-pushes still supersede); pushes to main queue sequentially instead of cancelling each other.
2. **Release runs are serialized and tag-pinned.** The double-push raced two release runs, and the *earlier* commit's run cut v0.12.1 — release-please acts on latest main state, not its checkout — so that run's `ci` gate and apply executed one commit behind the tag. `release.yml` now has a queue-never-cancel concurrency group, and both the `ci` reusable call (new `ref` input on `desktop.yml`, threaded to every checkout) and the `terraform-apply` checkout are pinned to `tag_name` — whichever run cuts a release, everything it gates, applies, deploys, and builds is exactly the tag commit. (`deploy-lambdas` and `build-macos` were already tag-pinned.)

Process note, now enforced structurally rather than by restraint: merges to main should let the prior push's CI land, and with this change even back-to-back merges are safe.

**Not merged until the in-flight v0.12.1 run (28679052429) completed** — pushing main under a live release run is the failure mode this PR closes.
