### PR TITLE
fix(desktop): persist the live universe across restarts

### DIFF
--- a/apps/desktop/src-tauri/src/buffer.rs
+++ b/apps/desktop/src-tauri/src/buffer.rs
@@ -1,7 +1,10 @@
 use crate::{devices::DmxOutput, sync::SyncEvent};
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tauri::{Manager, Runtime};
 
 /// A full DMX512 universe is 512 one-byte slots. Lux drives the whole universe:
@@ -89,15 +92,79 @@ impl LuxBuffer {
     /// optimistically — *before* the render, which may hit the network (sACN) or
     /// have no device attached — then push it to the active DMX output. Leading
     /// the render keeps the sliders from snapping back to a lagging value
-    /// mid-drag when a network node is in the path.
+    /// mid-drag when a network node is in the path. Persistence is scheduled
+    /// before the render too: the state changed even if no output accepts it,
+    /// and the user expects the levels they set to survive a restart either way.
     fn commit<R: Runtime>(
         &self,
         snapshot: Buffer,
         app: tauri::AppHandle<R>,
     ) -> Result<LuxBuffer, String> {
         emit_buffer(snapshot.clone(), &app)?;
+        schedule_persist(&app);
         render(&snapshot, &app)?;
         Ok(self.clone())
+    }
+}
+
+// --- persistence (app_config_dir/buffer.json) --------------------------------
+
+/// Restore the last-rendered universe from disk, so a restart brings the light
+/// back to how the user left it instead of the seed default. `None` on first
+/// run or unreadable data (the caller keeps its default; a corrupt file is
+/// logged, not fatal — persistence never sits in the live DMX path).
+pub fn restore<R: Runtime>(app: &tauri::AppHandle<R>) -> Option<Buffer> {
+    restore_from(&app.path().app_config_dir().ok()?.join("buffer.json"))
+}
+
+fn restore_from(path: &Path) -> Option<Buffer> {
+    let json = std::fs::read_to_string(path).ok()?;
+    match parse_buffer(&json) {
+        Ok(buffer) => Some(buffer),
+        Err(e) => {
+            log::warn!("buffer.json unreadable ({e}); starting from the default buffer");
+            None
+        }
+    }
+}
+
+/// Parse a persisted buffer and normalize it to exactly [`UNIVERSE_SIZE`] slots,
+/// so a file from an older (shorter-buffer) version still restores cleanly.
+fn parse_buffer(json: &str) -> Result<Buffer, serde_json::Error> {
+    serde_json::from_str::<Vec<u8>>(json).map(|values| normalize(&values))
+}
+
+/// Debounced write of the live buffer. A slider drag calls `set` dozens of
+/// times a second, so writes coalesce: the first change queues one writer,
+/// which sleeps briefly and then snapshots whatever the buffer holds by the
+/// time it wakes — later changes inside the window ride along for free.
+/// Best-effort, like the setups store.
+fn schedule_persist<R: Runtime>(app: &tauri::AppHandle<R>) {
+    static PENDING: AtomicBool = AtomicBool::new(false);
+    if PENDING.swap(true, Ordering::SeqCst) {
+        return; // a writer is already queued and will pick this change up
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        PENDING.store(false, Ordering::SeqCst);
+        let snapshot: Buffer = app.state::<LuxBuffer>().buffer.lock().unwrap().clone();
+        save(&app, &snapshot);
+    });
+}
+
+fn save<R: Runtime>(app: &tauri::AppHandle<R>, buffer: &Buffer) {
+    let Ok(dir) = app.path().app_config_dir() else {
+        return;
+    };
+    let _ = std::fs::create_dir_all(&dir);
+    match serde_json::to_string(buffer) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(dir.join("buffer.json"), json) {
+                log::warn!("could not persist the buffer: {e}");
+            }
+        }
+        Err(e) => log::warn!("could not serialize the buffer: {e}"),
     }
 }
 
@@ -112,4 +179,36 @@ fn emit_buffer<R: Runtime>(buffer: Buffer, app: &tauri::AppHandle<R>) -> Result<
     SyncEvent::BufferSet { buffer }
         .emit(app)
         .map_err(|e| format!("Failed to emit buffer_set event: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_buffer_normalizes_short_and_long_inputs() {
+        // A pre-universe 6-slot file still restores, padded to the full universe.
+        let short = parse_buffer("[121,255,255,0,0,42]").unwrap();
+        assert_eq!(short.len(), UNIVERSE_SIZE);
+        assert_eq!(&short[..6], &[121, 255, 255, 0, 0, 42]);
+        assert!(short[6..].iter().all(|&v| v == 0));
+
+        // An oversized file truncates rather than panicking downstream.
+        let long = parse_buffer(&serde_json::to_string(&vec![7u8; 600]).unwrap()).unwrap();
+        assert_eq!(long.len(), UNIVERSE_SIZE);
+        assert!(long.iter().all(|&v| v == 7));
+    }
+
+    #[test]
+    fn parse_buffer_rejects_garbage() {
+        assert!(parse_buffer("not json").is_err());
+        assert!(parse_buffer(r#"{"buffer":[1]}"#).is_err());
+        // Out-of-range slot values are a type error (u8), not a silent clamp.
+        assert!(parse_buffer("[300]").is_err());
+    }
+
+    #[test]
+    fn restore_from_missing_file_is_none() {
+        assert!(restore_from(Path::new("/nonexistent/buffer.json")).is_none());
+    }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -33,6 +33,13 @@ pub async fn run() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     let builder = setup(tauri::Builder::default(), |app| {
+        // Restore the last-rendered universe so a restart brings the light back
+        // to how the user left it (the seed default below only covers first
+        // run). Done before autodetect spawns: selecting a device pushes the
+        // current buffer to the output, which renders the restored state.
+        if let Some(restored) = buffer::restore(app.handle()) {
+            *app.state::<LuxBuffer>().buffer.lock().unwrap() = restored;
+        }
         // Load the user's setups (migrating a legacy patch.json, or seeding the
         // default "Home" setup on first run) into state.
         app.manage(setup::load(app.handle()));


### PR DESCRIPTION
## What

The live buffer wasn't being persisted: every launch reconstructed the seed default (`vec![121, 255, 255, 0, 0, 42]`, lib.rs), so the light and the UI always came back to the same color regardless of what was set before quitting. Persistence of the live state was always the intent — setups, channel metadata, and device selection already persist — this puts it back.

- Every committed buffer change schedules a **debounced best-effort write** to `app_config_dir()/buffer.json` (a slider drag coalesces into one write ~400ms later; the writer snapshots whatever the buffer holds when it wakes). Scheduled before the render, so state persists even with no output attached.
- On startup the buffer is **restored before device autodetect runs** — selecting the output pushes the current buffer to the hardware, so the light returns to its pre-restart state, and the UI's initial `sync_buffer` read reflects it.
- Old 6-slot files normalize to the full universe; oversized/corrupt files log and fall back to the default (persistence never sits in the live DMX path). Unit tests cover the parse/normalize/missing-file cases.
- The deliberate blackout on setup switching is unchanged and persists faithfully. The startup/sign-in sync paths (`broadcast_synced_state`) never zero the buffer, so a cloud pull at launch cannot clobber the restore.

## Verification

Workspace suite green (45 desktop tests including the new parse/normalize cases). Needs a manual pass on real hardware: set a color, quit, relaunch — the light and the picker should both come back to the set color.