### PR TITLE
refactor: deny unwrap in production code, workspace-wide

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -187,6 +187,14 @@ jobs:
       - name: cargo test
         run: cargo test --workspace --locked
 
+      # Lint gate: deny-level workspace lints fail this step (notably
+      # clippy::unwrap_used — production code must not unwrap; see
+      # [workspace.lints] in the root Cargo.toml). Default targets only, so
+      # test code keeps idiomatic unwraps; warn-level lints stay visible
+      # without blocking.
+      - name: cargo clippy
+        run: cargo clippy --workspace --locked
+
       - name: sccache stats
         if: ${{ always() }}
         run: sccache --show-stats

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,21 @@ members = [
     "services/sync-api",
 ]
 
+# Shared lint policy; members opt in with `[lints] workspace = true`. Production
+# code must never unwrap — a lighting app degrades and logs, it doesn't crash
+# (locks recover from poisoning via lock::LockPolicy instead). The CI gate runs
+# `cargo clippy --workspace` on default targets, so deny-level lints fail PRs
+# while test code keeps idiomatic unwraps. `expect` stays legal: it documents an
+# invariant; a naked `unwrap` doesn't.
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
+[workspace.lints.clippy]
+unwrap_used = "deny"
+panic = "warn"
+todo = "warn"
+unimplemented = "warn"
+
 # Dependencies shared across the desktop app and/or the Lambda services. Declared
 # once here; members opt in with `<dep>.workspace = true` (adding features as
 # needed). Bump a shared version in one place.

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,6 +18,9 @@ tauri-build = { version = "2.5.2", features = ["isolation", "codegen"] }
 [dev-dependencies]
 tauri = { version = "^2.9.3", features = ["devtools", "test", "tracing"] }
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.100"
 # Cognito accounts (sign-up / SRP sign-in / refresh) + secure refresh-token

--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -13,6 +13,7 @@
 //! SDK client runs with `.no_credentials()` — end users never hold AWS keys. SRP
 //! keeps the password on-device: only a zero-knowledge proof crosses the wire.
 
+use crate::lock::LockPolicy;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use aws_config::BehaviorVersion;
@@ -128,17 +129,17 @@ impl LuxAccount {
     }
 
     pub fn signed_in(&self) -> bool {
-        self.session.lock().unwrap().signed_in()
+        self.session.lock_or_recover().signed_in()
     }
 
     /// The signed-in account email, used as the local store's cloud-binding key.
     pub fn email(&self) -> Option<String> {
-        self.session.lock().unwrap().email.clone()
+        self.session.lock_or_recover().email.clone()
     }
 
     /// The current (possibly soon-to-expire) id token, for a sync request.
     pub fn current_id_token(&self) -> Option<String> {
-        self.session.lock().unwrap().id_token.clone()
+        self.session.lock_or_recover().id_token.clone()
     }
 
     /// Exchange the stored refresh token for fresh id/access tokens (called by
@@ -147,20 +148,19 @@ impl LuxAccount {
         let cfg = self.config()?;
         let refresh = self
             .session
-            .lock()
-            .unwrap()
+            .lock_or_recover()
             .refresh_token
             .clone()
             .ok_or("not signed in")?;
         let tokens = do_refresh(cfg, refresh).await?;
-        let mut session = self.session.lock().unwrap();
+        let mut session = self.session.lock_or_recover();
         session.id_token = Some(tokens.id.clone());
         session.access_token = Some(tokens.access);
         Ok(tokens.id)
     }
 
     pub fn status(&self) -> AuthStatus {
-        let session = self.session.lock().unwrap();
+        let session = self.session.lock_or_recover();
         AuthStatus {
             configured: self.config.is_some(),
             signed_in: session.signed_in(),
@@ -199,14 +199,14 @@ impl LuxAccount {
 
     pub fn sign_out(&self) -> AuthStatus {
         clear_session();
-        self.session.lock().unwrap().clear();
+        self.session.lock_or_recover().clear();
         self.status()
     }
 
     /// Store freshly-issued tokens. `email` is set on sign-in; left untouched on
     /// a silent refresh (it carries over from the restored session).
     fn apply(&self, tokens: Tokens, email: Option<String>) {
-        let mut session = self.session.lock().unwrap();
+        let mut session = self.session.lock_or_recover();
         session.id_token = Some(tokens.id);
         session.access_token = Some(tokens.access);
         if let Some(refresh) = tokens.refresh {
@@ -231,7 +231,7 @@ pub fn restore_on_startup(app: &AppHandle) {
         match do_refresh(cfg, stored.refresh_token).await {
             Ok(tokens) => {
                 {
-                    let mut s = session.lock().unwrap();
+                    let mut s = session.lock_or_recover();
                     s.id_token = Some(tokens.id);
                     s.access_token = Some(tokens.access);
                     s.refresh_token = load_session().map(|s| s.refresh_token);

--- a/apps/desktop/src-tauri/src/buffer.rs
+++ b/apps/desktop/src-tauri/src/buffer.rs
@@ -1,3 +1,4 @@
+use crate::lock::LockPolicy;
 use crate::{devices::DmxOutput, sync::SyncEvent};
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -32,13 +33,13 @@ fn normalize(value: &[u8]) -> Buffer {
 
 impl From<LuxBuffer> for Buffer {
     fn from(value: LuxBuffer) -> Self {
-        value.buffer.lock().unwrap().clone()
+        value.buffer.lock_or_recover().clone()
     }
 }
 
 impl From<&LuxBuffer> for Buffer {
     fn from(value: &LuxBuffer) -> Self {
-        value.buffer.lock().unwrap().clone()
+        value.buffer.lock_or_recover().clone()
     }
 }
 
@@ -61,7 +62,7 @@ impl LuxBuffer {
         app: tauri::AppHandle<R>,
     ) -> Result<LuxBuffer, String> {
         let snapshot = {
-            let mut guard = self.buffer.lock().unwrap();
+            let mut guard = self.buffer.lock_or_recover();
             let n = incoming.len().min(guard.len());
             guard[..n].copy_from_slice(&incoming[..n]);
             guard.clone()
@@ -81,7 +82,7 @@ impl LuxBuffer {
             ));
         }
         let snapshot = {
-            let mut guard = self.buffer.lock().unwrap();
+            let mut guard = self.buffer.lock_or_recover();
             guard[channel_number - 1] = value;
             guard.clone()
         };
@@ -148,7 +149,7 @@ fn schedule_persist<R: Runtime>(app: &tauri::AppHandle<R>) {
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(Duration::from_millis(400)).await;
         PENDING.store(false, Ordering::SeqCst);
-        let snapshot: Buffer = app.state::<LuxBuffer>().buffer.lock().unwrap().clone();
+        let snapshot: Buffer = app.state::<LuxBuffer>().buffer.lock_or_recover().clone();
         save(&app, &snapshot);
     });
 }

--- a/apps/desktop/src-tauri/src/channel.rs
+++ b/apps/desktop/src-tauri/src/channel.rs
@@ -1,3 +1,4 @@
+use crate::lock::LockPolicy;
 use std::sync::{Arc, Mutex};
 
 use crate::colors::LuxLabelColor;
@@ -29,16 +30,16 @@ impl LuxChannel {
     }
 
     pub fn get_channel_number(&self) -> u32 {
-        self.0.lock().unwrap().channel_number
+        self.0.lock_or_recover().channel_number
     }
 
     // pub fn _set(&self, data: LuxChannelData) {
-    //     let mut locked_data = self.lock().unwrap();
+    //     let mut locked_data = self.lock_or_recover();
     //     *locked_data = data;
     // }
 
     pub fn toogle_disabled(&mut self, disabled: bool) {
-        let mut locked_data = self.0.lock().unwrap();
+        let mut locked_data = self.0.lock_or_recover();
         locked_data.disabled = disabled;
     }
 }

--- a/apps/desktop/src-tauri/src/channels.rs
+++ b/apps/desktop/src-tauri/src/channels.rs
@@ -1,3 +1,4 @@
+use crate::lock::LockPolicy;
 use crate::buffer::UNIVERSE_SIZE;
 use crate::channel::{Channel, LuxChannel};
 use crate::cmd::CmdEvent;
@@ -17,13 +18,13 @@ pub struct LuxChannels {
 
 impl From<LuxChannels> for Channels {
     fn from(value: LuxChannels) -> Self {
-        value.channels.lock().unwrap().clone()
+        value.channels.lock_or_recover().clone()
     }
 }
 
 impl From<&LuxChannels> for Channels {
     fn from(value: &LuxChannels) -> Self {
-        value.channels.lock().unwrap().clone()
+        value.channels.lock_or_recover().clone()
     }
 }
 
@@ -46,7 +47,7 @@ impl From<Vec<Channel>> for LuxChannels {
 
 impl From<&LuxChannels> for LuxChannels {
     fn from(value: &LuxChannels) -> Self {
-        let channels = value.channels.lock().unwrap().clone();
+        let channels = value.channels.lock_or_recover().clone();
         LuxChannels {
             channels: Arc::new(Mutex::new(channels)),
         }
@@ -86,13 +87,13 @@ impl Default for LuxChannels {
 
 impl Display for LuxChannels {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.channels.lock().unwrap())
+        write!(f, "{:?}", self.channels.lock_or_recover())
     }
 }
 
 impl LuxChannels {
     pub fn get_all(&self) -> LuxChannels {
-        let channels = self.channels.lock().unwrap().clone();
+        let channels = self.channels.lock_or_recover().clone();
         LuxChannels::from(channels)
     }
 
@@ -104,7 +105,7 @@ impl LuxChannels {
         channel_number: usize,
         new_metadata: LuxChannel,
     ) -> Result<LuxChannel, String> {
-        let mut channels = self.channels.lock().unwrap();
+        let mut channels = self.channels.lock_or_recover();
         let len = channels.len();
         let index = channel_number
             .checked_sub(1)
@@ -122,7 +123,7 @@ impl LuxChannels {
     ) -> Result<LuxChannel, String> {
         let channel = self.put(channel_number, new_metadata)?;
         CmdEvent::ChannelDataSet {
-            channels: self.channels.lock().unwrap().clone(),
+            channels: self.channels.lock_or_recover().clone(),
         }
         .emit(&app)
         .map_err(|e| format!("Failed to emit channel_data_set event: {}", e))?;
@@ -131,7 +132,7 @@ impl LuxChannels {
 
     pub fn set_all(&mut self, channels: Channels) -> Result<LuxChannels, String> {
         log::trace!("set_all");
-        *self.channels.lock().unwrap() = channels.clone();
+        *self.channels.lock_or_recover() = channels.clone();
         Ok(LuxChannels::from(channels))
     }
 
@@ -143,7 +144,7 @@ impl LuxChannels {
         self.set_all(channels.into())?;
 
         CmdEvent::ChannelDataSet {
-            channels: self.channels.lock().unwrap().clone(),
+            channels: self.channels.lock_or_recover().clone(),
         }
         .emit(&app)
         .map_err(|e| format!("Failed to emit channel_data_set event: {}", e))?;
@@ -170,7 +171,7 @@ mod tests {
     #[test]
     fn default_spans_the_full_universe() {
         let channels = LuxChannels::default();
-        let locked = channels.channels.lock().unwrap();
+        let locked = channels.channels.lock_or_recover();
         assert_eq!(locked.len(), UNIVERSE_SIZE);
         // Slot 1 is the labelled Red channel, slot 7 is a generic raw channel.
         assert_eq!(locked[0].get_channel_number(), 1);
@@ -185,11 +186,11 @@ mod tests {
         assert_eq!(returned.get_channel_number(), 42);
 
         // 1-based channel 3 lives at array index 2, and must actually be written.
-        let stored = channels.channels.lock().unwrap()[2].clone();
+        let stored = channels.channels.lock_or_recover()[2].clone();
         assert_eq!(stored.get_channel_number(), 42);
 
         // neighbouring channels are untouched (default channel 4 keeps number 4).
-        let neighbour = channels.channels.lock().unwrap()[3].clone();
+        let neighbour = channels.channels.lock_or_recover()[3].clone();
         assert_eq!(neighbour.get_channel_number(), 4);
     }
 

--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -14,6 +14,7 @@
 //!   server `updatedAt`, then flush anything still dirty. First sign-in claims
 //!   the local setups into the account.
 
+use crate::lock::LockPolicy;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -62,12 +63,12 @@ pub struct LuxSync {
 impl LuxSync {
     /// The current state, for the `sync_status` command and event payloads.
     pub fn snapshot(&self) -> SyncState {
-        *self.state.lock().unwrap()
+        *self.state.lock_or_recover()
     }
 
     /// Move to `state` and emit the change to the UI.
     fn set(&self, app: &AppHandle, state: SyncState) {
-        *self.state.lock().unwrap() = state;
+        *self.state.lock_or_recover() = state;
         let _ = CmdEvent::SyncStatusChanged { state }.emit(app);
     }
 }

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -1,3 +1,4 @@
+use crate::lock::LockPolicy;
 use crate::{
     account::{AuthStatus, LuxAccount},
     buffer::{Buffer, LuxBuffer, UNIVERSE_SIZE},
@@ -457,7 +458,7 @@ fn activate(app: &AppHandle, setups: &LuxSetups) -> Result<(), String> {
 /// used after the live universe number changes so the new universe lights up
 /// with the levels already on screen.
 fn rerender_current(app: &AppHandle) {
-    let buffer = app.state::<LuxBuffer>().buffer.lock().unwrap().clone();
+    let buffer = app.state::<LuxBuffer>().buffer.lock_or_recover().clone();
     if let Err(e) = app.state::<DmxOutput>().render(&buffer) {
         log::trace!("post-universe-change render failed: {e}");
     }

--- a/apps/desktop/src-tauri/src/devices/enttec_open_dmx_usb.rs
+++ b/apps/desktop/src-tauri/src/devices/enttec_open_dmx_usb.rs
@@ -1,3 +1,4 @@
+use crate::lock::LockPolicy;
 use libftd2xx::DeviceInfo;
 use libftd2xx::DeviceType;
 use libftd2xx::FtStatus;
@@ -76,7 +77,7 @@ impl EnttecOpenDMX {
         };
 
         if let Some(ref ft) = ft {
-            let mut ftdi = ft.lock().unwrap();
+            let mut ftdi = ft.lock_or_recover();
             let device_info = ftdi.device_info().map_err(|e| format!("{:?}", e))?;
             let ftdi_status = ftdi.status().map_err(|e| format!("{:?}", e))?;
 
@@ -113,7 +114,7 @@ impl EnttecOpenDMX {
     /// Opens the connection with the Interface.
     pub fn open(&mut self) -> Result<(), FtStatus> {
         if let Some(ft) = self.ftdi.as_ref() {
-            let mut ftdi = ft.lock().unwrap();
+            let mut ftdi = ft.lock_or_recover();
             ftdi.reset()?;
             ftdi.set_baud_rate(BAUDRATE)?;
             ftdi.set_data_characteristics(BITS_8, STOP_BITS_2, PARITY_NONE)?;
@@ -151,10 +152,16 @@ impl EnttecOpenDMX {
     /// Renders the current buffer
     pub fn render(&mut self) -> Result<(), FtStatus> {
         if let Some(ft) = self.ftdi.as_ref() {
-            let mut ftdi = ft.lock().unwrap();
+            let mut ftdi = ft.lock_or_recover();
             ftdi.set_break_on()?;
             ftdi.set_break_off()?;
-            ftdi.write_all(&self.buffer.0).unwrap();
+            // A failed frame write (USB glitch, device yanked mid-render) is a
+            // render error like any other, not a reason to crash the app —
+            // the caller surfaces it and the next frame retries.
+            ftdi.write_all(&self.buffer.0).map_err(|e| {
+                log::warn!("enttec frame write failed: {e}");
+                FtStatus::IO_ERROR
+            })?;
             Ok(())
         } else {
             Err(FtStatus::DEVICE_NOT_FOUND) // Or any other appropriate error
@@ -165,18 +172,12 @@ impl EnttecOpenDMX {
     #[allow(dead_code)]
     pub fn close(&mut self) -> Result<(), FtStatus> {
         if let Some(ft) = self.ftdi.as_ref() {
-            let mut ftdi = ft.lock().unwrap();
+            let mut ftdi = ft.lock_or_recover();
             ftdi.close()?;
             Ok(())
         } else {
             Err(FtStatus::DEVICE_NOT_FOUND) // Or any other appropriate error
         }
-    }
-}
-
-impl Default for EnttecOpenDMX {
-    fn default() -> Self {
-        EnttecOpenDMX::new().unwrap()
     }
 }
 

--- a/apps/desktop/src-tauri/src/devices/mod.rs
+++ b/apps/desktop/src-tauri/src/devices/mod.rs
@@ -13,6 +13,7 @@ pub mod discovery;
 pub mod enttec_open_dmx_usb;
 pub mod sacn;
 
+use crate::lock::LockPolicy;
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -175,31 +176,31 @@ impl DmxOutput {
     pub fn render(&self, channels: &[u8]) -> Result<(), String> {
         // Clone the Arc out of the lock so a (possibly slow) render doesn't hold
         // it — a tray switch can then proceed concurrently.
-        let sink = self.inner.lock().unwrap().sink.clone();
+        let sink = self.inner.lock_or_recover().sink.clone();
         sink.render(channels)
     }
 
     pub fn needs_keepalive(&self) -> bool {
-        self.inner.lock().unwrap().transport.needs_keepalive()
+        self.inner.lock_or_recover().transport.needs_keepalive()
     }
 
     // The active key + detected list, read by the desktop tray's device menu and
     // the in-app output picker (the only selector on mobile, where there's no tray).
     pub fn active_key(&self) -> String {
-        self.inner.lock().unwrap().key.clone()
+        self.inner.lock_or_recover().key.clone()
     }
 
     pub fn devices(&self) -> Vec<Device> {
-        self.devices.lock().unwrap().clone()
+        self.devices.lock_or_recover().clone()
     }
 
     fn set_devices(&self, devices: Vec<Device>) {
-        *self.devices.lock().unwrap() = devices;
+        *self.devices.lock_or_recover() = devices;
     }
 
     fn set_device(&self, device: &Device) {
         let sink = build_sink(device);
-        let mut active = self.inner.lock().unwrap();
+        let mut active = self.inner.lock_or_recover();
         active.transport = device.transport;
         active.sink = sink;
         active.key = device.key();
@@ -210,7 +211,7 @@ impl DmxOutput {
     /// detected node, so the tray highlight and device memory stay put — only the
     /// wire universe follows the active setup.
     fn retarget_universe(&self, universe: u16) {
-        let mut active = self.inner.lock().unwrap();
+        let mut active = self.inner.lock_or_recover();
         if active.transport == Transport::Sacn {
             active.sink = build_sink(&Device {
                 transport: Transport::Sacn,
@@ -276,7 +277,7 @@ pub fn switch_to_device<R: Runtime>(app: &AppHandle<R>, device: &Device) {
         app.state::<DmxOutput>().retarget_universe(universe);
     }
     persist_key(app, &device.key());
-    let buffer = app.state::<crate::buffer::LuxBuffer>().buffer.lock().unwrap().clone();
+    let buffer = app.state::<crate::buffer::LuxBuffer>().buffer.lock_or_recover().clone();
     if let Err(e) = app.state::<DmxOutput>().render(&buffer) {
         log::trace!("post-switch render failed: {e}");
     }
@@ -411,7 +412,7 @@ pub fn start_keepalive<R: Runtime>(app: &AppHandle<R>) {
                 continue;
             }
             // Copy out of the lock before the render so no guard is held across it.
-            let buffer = app.state::<crate::buffer::LuxBuffer>().buffer.lock().unwrap().clone();
+            let buffer = app.state::<crate::buffer::LuxBuffer>().buffer.lock_or_recover().clone();
             if let Err(e) = app.state::<DmxOutput>().render(&buffer) {
                 log::trace!("sACN keepalive render failed: {e}");
             }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod devices;
 mod endpoints;
 mod error;
 mod fixture;
+mod lock;
 mod logger;
 mod nudge;
 mod remote;
@@ -19,6 +20,7 @@ mod sync;
 #[cfg(desktop)]
 mod tray;
 
+use crate::lock::LockPolicy;
 use buffer::LuxBuffer;
 use channels::LuxChannels;
 use cmd::*;
@@ -38,7 +40,7 @@ pub async fn run() {
         // run). Done before autodetect spawns: selecting a device pushes the
         // current buffer to the output, which renders the restored state.
         if let Some(restored) = buffer::restore(app.handle()) {
-            *app.state::<LuxBuffer>().buffer.lock().unwrap() = restored;
+            *app.state::<LuxBuffer>().buffer.lock_or_recover() = restored;
         }
         // Load the user's setups (migrating a legacy patch.json, or seeding the
         // default "Home" setup on first run) into state.

--- a/apps/desktop/src-tauri/src/lock.rs
+++ b/apps/desktop/src-tauri/src/lock.rs
@@ -1,0 +1,48 @@
+//! Mutex access policy: recover from poisoning instead of panicking.
+//!
+//! A poisoned lock means some other thread panicked while holding the guard.
+//! The default `.lock().unwrap()` response turns that one dead thread into a
+//! cascade — every later touch of the same state panics too — which in a
+//! lighting app means the output dies mid-show over an already-handled fault.
+//! Lux's shared state (the render buffer, setup store, session tokens, channel
+//! metadata) is plain data that is never left half-valid across an unwind
+//! boundary in a way worse than "slightly stale", so recovering the inner
+//! value and logging is strictly better than crashing.
+//!
+//! This trait is the only sanctioned way to take a `std::sync::Mutex` in this
+//! crate — `clippy::unwrap_used` is denied workspace-wide, so a bare
+//! `.lock().unwrap()` fails CI.
+
+use std::sync::{Mutex, MutexGuard};
+
+pub trait LockPolicy<T> {
+    /// Lock, recovering the data if a panicked thread poisoned it.
+    fn lock_or_recover(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T> LockPolicy<T> for Mutex<T> {
+    fn lock_or_recover(&self) -> MutexGuard<'_, T> {
+        self.lock().unwrap_or_else(|poisoned| {
+            log::warn!("a lock was poisoned by a panicked thread; recovering its state");
+            poisoned.into_inner()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovers_a_poisoned_lock() {
+        let lock = std::sync::Arc::new(Mutex::new(7u8));
+        let poisoner = lock.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.lock_or_recover();
+            panic!("poison the lock");
+        })
+        .join();
+        assert!(lock.is_poisoned());
+        assert_eq!(*lock.lock_or_recover(), 7);
+    }
+}

--- a/apps/desktop/src-tauri/src/setup.rs
+++ b/apps/desktop/src-tauri/src/setup.rs
@@ -12,6 +12,7 @@
 //! a legacy `patch.json`, [`load`] migrates it into a single "Home" setup and
 //! leaves the old file behind as `patch.json.migrated`.
 
+use crate::lock::LockPolicy;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -197,23 +198,23 @@ impl From<SetupStore> for LuxSetups {
 
 impl LuxSetups {
     pub fn summaries(&self) -> Vec<SetupSummary> {
-        self.store.lock().unwrap().summaries()
+        self.store.lock_or_recover().summaries()
     }
 
     pub fn active_id(&self) -> uuid::Uuid {
-        self.store.lock().unwrap().active_setup_id
+        self.store.lock_or_recover().active_setup_id
     }
 
     pub fn active_universe(&self) -> u16 {
-        self.store.lock().unwrap().active().universe
+        self.store.lock_or_recover().active().universe
     }
 
     pub fn active_fixtures(&self) -> Vec<Fixture> {
-        self.store.lock().unwrap().active().fixtures.clone()
+        self.store.lock_or_recover().active().fixtures.clone()
     }
 
     pub fn active_summary(&self) -> SetupSummary {
-        let store = self.store.lock().unwrap();
+        let store = self.store.lock_or_recover();
         let active = store.active();
         SetupSummary {
             id: active.id,
@@ -226,7 +227,7 @@ impl LuxSetups {
 
     /// Snapshot of the whole store, for persistence.
     pub fn snapshot(&self) -> SetupStore {
-        self.store.lock().unwrap().clone()
+        self.store.lock_or_recover().clone()
     }
 
     // -- fixture ops on the active setup --
@@ -237,7 +238,7 @@ impl LuxSetups {
         address: u16,
         channels: Vec<ChannelDef>,
     ) -> Result<(), String> {
-        let mut store = self.store.lock().unwrap();
+        let mut store = self.store.lock_or_recover();
         let active = store.active_mut();
         fixture::add(&mut active.fixtures, name, address, channels)?;
         active.dirty = true;
@@ -251,7 +252,7 @@ impl LuxSetups {
         address: u16,
         channels: Vec<ChannelDef>,
     ) -> Result<(), String> {
-        let mut store = self.store.lock().unwrap();
+        let mut store = self.store.lock_or_recover();
         let active = store.active_mut();
         fixture::update(&mut active.fixtures, id, name, address, channels)?;
         active.dirty = true;
@@ -259,7 +260,7 @@ impl LuxSetups {
     }
 
     pub fn remove_fixture(&self, id: uuid::Uuid) -> Result<(), String> {
-        let mut store = self.store.lock().unwrap();
+        let mut store = self.store.lock_or_recover();
         let active = store.active_mut();
         fixture::remove(&mut active.fixtures, id)?;
         active.dirty = true;
@@ -273,13 +274,13 @@ impl LuxSetups {
         let name = clean_name(name)?;
         let setup = new_setup(name, universe, Vec::new());
         let id = setup.id;
-        self.store.lock().unwrap().setups.push(setup);
+        self.store.lock_or_recover().setups.push(setup);
         Ok(id)
     }
 
     pub fn rename(&self, id: uuid::Uuid, name: String) -> Result<(), String> {
         let name = clean_name(name)?;
-        let mut store = self.store.lock().unwrap();
+        let mut store = self.store.lock_or_recover();
         let setup = store
             .setups
             .iter_mut()
@@ -291,7 +292,7 @@ impl LuxSetups {
     }
 
     pub fn set_universe(&self, id: uuid::Uuid, universe: u16) -> Result<(), String> {
-        let mut store = self.store.lock().unwrap();
+        let mut store = self.store.lock_or_recover();
         let setup = store
             .setups
             .iter_mut()
@@ -306,7 +307,7 @@ impl LuxSetups {
     /// removed, the first remaining one becomes active. A setup the cloud has
     /// seen leaves a pending tombstone so the delete propagates to other devices.
     pub fn delete(&self, id: uuid::Uuid) -> Result<(), String> {
-        let mut store = self.store.lock().unwrap();
+        let mut store = self.store.lock_or_recover();
         if store.setups.len() <= 1 {
             return Err("can't delete the only setup".into());
         }
@@ -327,7 +328,7 @@ impl LuxSetups {
     }
 
     pub fn set_active(&self, id: uuid::Uuid) -> Result<(), String> {
-        let mut store = self.store.lock().unwrap();
+        let mut store = self.store.lock_or_recover();
         if !store.setups.iter().any(|s| s.id == id) {
             return Err(format!("setup {id} not found"));
         }
@@ -339,18 +340,18 @@ impl LuxSetups {
 
     /// Setups with changes the cloud doesn't have yet (clones, for pushing).
     pub fn dirty_for_push(&self) -> Vec<Setup> {
-        let store = self.store.lock().unwrap();
+        let store = self.store.lock_or_recover();
         store.setups.iter().filter(|s| s.needs_push()).cloned().collect()
     }
 
     /// Pending delete tombstones to push.
     pub fn pending_deletes(&self) -> Vec<PendingDelete> {
-        self.store.lock().unwrap().pending_deletes.clone()
+        self.store.lock_or_recover().pending_deletes.clone()
     }
 
     /// Record a successful push: store the server timestamp and clear dirty.
     pub fn mark_pushed(&self, id: uuid::Uuid, updated_at: i64) {
-        let mut store = self.store.lock().unwrap();
+        let mut store = self.store.lock_or_recover();
         if let Some(s) = store.setups.iter_mut().find(|s| s.id == id) {
             s.updated_at = Some(updated_at);
             s.dirty = false;
@@ -360,26 +361,25 @@ impl LuxSetups {
     /// Drop a delivered delete tombstone.
     pub fn clear_pending_delete(&self, setup_id: uuid::Uuid) {
         self.store
-            .lock()
-            .unwrap()
+            .lock_or_recover()
             .pending_deletes
             .retain(|d| d.setup_id != setup_id);
     }
 
     /// Snapshot of all setups (clones), to feed reconcile.
     pub fn all(&self) -> Vec<Setup> {
-        self.store.lock().unwrap().setups.clone()
+        self.store.lock_or_recover().setups.clone()
     }
 
     /// The account email this store is currently synced with, if any.
     pub fn bound_email(&self) -> Option<String> {
-        self.store.lock().unwrap().bound_email.clone()
+        self.store.lock_or_recover().bound_email.clone()
     }
 
     /// Replace the working set with reconciled setups and bind it to `email`.
     /// Keeps the store non-empty and `active_setup_id` valid.
     pub fn replace_with_merged(&self, merged: Vec<Setup>, email: String) {
-        let mut store = self.store.lock().unwrap();
+        let mut store = self.store.lock_or_recover();
         store.bound_email = Some(email);
         if merged.is_empty() {
             let seed = new_setup("Home", DEFAULT_UNIVERSE, fixture::default_fixtures());
@@ -397,7 +397,7 @@ impl LuxSetups {
     /// Forget cloud binding and sync metadata so a *different* account signing in
     /// on this device can't push the previous user's setups into their cloud.
     pub fn reset_for_new_account(&self) {
-        let mut store = self.store.lock().unwrap();
+        let mut store = self.store.lock_or_recover();
         store.bound_email = None;
         store.pending_deletes.clear();
         for s in &mut store.setups {

--- a/apps/desktop/src-tauri/src/sync.rs
+++ b/apps/desktop/src-tauri/src/sync.rs
@@ -1,3 +1,4 @@
+use crate::lock::LockPolicy;
 use crate::{
     buffer::{Buffer, LuxBuffer},
     channels::LuxChannels,
@@ -23,7 +24,7 @@ impl SyncMethods for SyncEndpoint {
     fn sync_buffer(&self, app_handle: AppHandle) -> Result<LuxBuffer, String> {
         log::trace!("sync_buffer");
         let mut state = app_handle.state::<LuxBuffer>().inner().clone();
-        let buffer = state.buffer.lock().as_deref().unwrap().clone();
+        let buffer = state.buffer.lock_or_recover().clone();
         state.set(buffer, app_handle.clone())
     }
     fn sync_channels(&self, app_handle: AppHandle) -> Result<LuxChannels, String> {

--- a/crates/lux-auth/Cargo.toml
+++ b/crates/lux-auth/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 # a user's identity (services/sync-api, services/iot-authorizer). The desktop
 # never depends on this crate — it holds tokens, it doesn't verify them.
 
+[lints]
+workspace = true
+
 [dependencies]
 jsonwebtoken = "10"
 reqwest = { workspace = true }

--- a/crates/lux-wire/Cargo.toml
+++ b/crates/lux-wire/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 # sides (apps/desktop/src-tauri and services/sync-api), so the schema cannot
 # drift between them. Pure types + tiny helpers: serde only, no AWS, no HTTP.
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/services/bot/Cargo.toml
+++ b/services/bot/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 # deployed with cargo-lambda; the runtime expects a `bootstrap` executable,
 # which cargo-lambda produces from this binary.
 
+[lints]
+workspace = true
+
 [dependencies]
 lambda_http.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/services/iot-authorizer/Cargo.toml
+++ b/services/iot-authorizer/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 # policy scoped to that user's own nudge topic and client-id prefix (lux-wire).
 # Built and deployed with cargo-lambda, like the sibling services.
 
+[lints]
+workspace = true
+
 [dependencies]
 lux-auth = { path = "../../crates/lux-auth" }
 lux-wire = { path = "../../crates/lux-wire" }

--- a/services/sync-api/Cargo.toml
+++ b/services/sync-api/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 # cargo-lambda; the runtime expects a `bootstrap` executable, which cargo-lambda
 # produces from this binary.
 
+[lints]
+workspace = true
+
 [dependencies]
 lux-auth = { path = "../../crates/lux-auth" }
 lux-wire = { path = "../../crates/lux-wire" }


### PR DESCRIPTION
## What

`[workspace.lints]` at the root, all six members opted in: `clippy::unwrap_used = deny`, `unsafe_code = forbid` (the tree has none), `panic`/`todo`/`unimplemented` = warn. The desktop gate gains a `cargo clippy --workspace --locked` step — deny-level lints fail it, warn-level stays visible without blocking, and default targets keep test code idiomatically unwrappy. `expect` remains legal: it documents an invariant; a naked `unwrap` doesn't.

## The sweep (67 production sites, now zero)

- **66 were `.lock().unwrap()`** — converted to a `lock_or_recover()` extension trait (`lock.rs`) that recovers from mutex poisoning instead of panicking. Rationale in the module docs: a panicked background thread previously turned every subsequent lock of the same state into another panic, taking the lighting output down over an already-handled fault; recovered, slightly-stale state is strictly better than a dead app. `unwrap_or_else` isn't `unwrap`, so the codebase carries **zero `allow(clippy::unwrap_used)` escapes** — the deny is absolute.
- **Real bugs surfaced and fixed properly:**
  - the Enttec render path panicked on a failed USB frame write (device yanked mid-render) — now returns the render error; the next frame retries
  - an uncalled `Default` impl that unwrapped device discovery is removed
- The remaining sites (chained lock in `sync_buffer`, multi-line lock chains in account/setup) folded into the same helper.

## Verification

`cargo clippy --workspace --locked` exits clean; full workspace suite green (12 suites, including a poison-recovery unit test on the new trait). This is the ttipc workspace-lints kit from the dev-tooling standard, tightened from warn to deny for `unwrap_used`.