### PR TITLE
ci: fix the release-gate concurrency deadlock; make release re-runs resume

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -47,8 +47,12 @@ permissions:
 # whose push CI was cancelled after 4s by the release merge landing behind
 # it). github.workflow is the CALLER's name under workflow_call, so a
 # release-gate invocation groups separately from the push-triggered run.
+# The "-gate" suffix is load-bearing: without it, a release-run invocation
+# computes the group "release-<ref>" — the SAME group the calling release
+# run itself holds — and the called workflow deadlocks queueing behind its
+# own parent (GitHub kills the job at startup; broke the v0.12.2 run).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-gate-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
       pull-requests: write
       id-token: write # AWS OIDC, to read the release-bot App key from Secrets Manager
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.effective.outputs.release_created }}
+      tag_name: ${{ steps.effective.outputs.tag_name }}
     steps:
       # Authenticate as a GitHub App (when configured) instead of the default
       # GITHUB_TOKEN. GitHub deliberately won't let GITHUB_TOKEN-authored events
@@ -82,6 +82,35 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token || github.token }}
+
+      # Re-run resilience: release-please publishes the GitHub release first,
+      # so if anything later in the run fails and the run is re-run, the second
+      # attempt sees the release as already existing, reports
+      # release_created=false, and the whole pipeline skips — leaving a
+      # published release with no deployed backend and no artifacts (the
+      # v0.12.2 failure). On a re-run attempt, resume shipping the manifest
+      # version iff its release exists with zero assets; a release with assets
+      # is done and must not be rebuilt (re-signing an already-served tag is
+      # the known updater-breaker).
+      - name: Resolve the release to ship (re-run resume)
+        id: effective
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RP_CREATED: ${{ steps.release.outputs.release_created }}
+          RP_TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          if [ "$RP_CREATED" = "true" ]; then
+            { echo "release_created=true"; echo "tag_name=$RP_TAG"; } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          tag="v$(jq -r '."."' .release-please-manifest.json)"
+          if [ "${{ github.run_attempt }}" != "1" ] \
+            && [ "$(gh release view "$tag" --json assets --jq '.assets | length' 2>/dev/null)" = "0" ]; then
+            echo "::notice::resuming assetless release $tag (run attempt ${{ github.run_attempt }})"
+            { echo "release_created=true"; echo "tag_name=$tag"; } >> "$GITHUB_OUTPUT"
+          else
+            { echo "release_created=false"; echo "tag_name="; } >> "$GITHUB_OUTPUT"
+          fi
 
       # release-please uses release-type "simple", which bumps the version in
       # apps/desktop/src-tauri/Cargo.toml but leaves the `lux` entry in the root


### PR DESCRIPTION
## What broke (v0.12.2's release run)

Attempt 1: release-please published v0.12.2, then the `ci` job died at startup — inside a called workflow `github.workflow` evaluates to the **caller's** name, so the reusable gate computed concurrency group `release-refs/heads/main`, the exact group its parent release run was holding. Queued behind its own parent → GitHub deadlock-kill → run failure. The re-run (attempt 2) then found the release already existing, reported `release_created=false`, and skipped the entire pipeline — leaving a published release with no artifacts. (The artifacts were shipped via the documented `workflow_dispatch` path; this release contained no backend changes, so no drift.)

## Fixes

1. **Gate group suffix**: the desktop gate's concurrency group becomes `${{ github.workflow }}-gate-${{ github.ref }}` — push-queueing and PR-supersede semantics unchanged, but a release-run invocation now groups as `release-gate-…`, never colliding with the caller's `release-…` group. Comment marks the suffix as load-bearing.
2. **Re-run resume**: the release-please job resolves an *effective* release — normally the action's own outputs; on a re-run attempt (`github.run_attempt > 1`) it resumes the manifest version **iff its release exists with zero assets**. A release with assets is finished and is never rebuilt — re-signing an already-served tag is the known updater-breaker. Any post-publication failure in a release run is now recoverable with a plain re-run instead of stranding an assetless release.

## Verification

actionlint clean (the two pre-existing App-token schema findings only). The deadlock fix is first exercised by the next release run; the resume path by any future re-run — both are guarded by the pipeline's existing fail-closed ordering.