### PR TITLE
feat: in-app account deletion

### DIFF
--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -16,13 +16,13 @@
 use crate::lock::LockPolicy;
 use std::sync::{Arc, Mutex, OnceLock};
 
+use aws_cognito_srp::{SrpClient, User};
 use aws_config::BehaviorVersion;
-use aws_smithy_http_client::tls::{self, rustls_provider::CryptoMode};
 use aws_sdk_cognitoidentityprovider::config::Region;
 use aws_sdk_cognitoidentityprovider::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_cognitoidentityprovider::types::{AttributeType, AuthFlowType, ChallengeNameType};
 use aws_sdk_cognitoidentityprovider::Client;
-use aws_cognito_srp::{SrpClient, User};
+use aws_smithy_http_client::tls::{self, rustls_provider::CryptoMode};
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use tauri::{AppHandle, Manager};
@@ -111,7 +111,9 @@ impl LuxAccount {
         let config = load_config();
         match &config {
             Some(c) => log::info!("accounts enabled (Cognito pool {})", c.pool_id),
-            None => log::info!("accounts not configured (endpoints file has no Cognito values); sign-in disabled"),
+            None => log::info!(
+                "accounts not configured (endpoints file has no Cognito values); sign-in disabled"
+            ),
         }
         let sync_url = Some(crate::endpoints::effective().sync_url.clone())
             .filter(|url| !url.is_empty())
@@ -201,6 +203,45 @@ impl LuxAccount {
         clear_session();
         self.session.lock_or_recover().clear();
         self.status()
+    }
+
+    /// Permanently delete the signed-in Cognito user (self-service `DeleteUser`,
+    /// authorized by the access token), then clear the session + keychain. The
+    /// caller wipes the account's server-side data *first*, while the tokens
+    /// still authenticate; both steps are idempotent, so a failure here leaves
+    /// the account intact and the whole flow retryable.
+    pub fn delete_account(&self) -> Result<AuthStatus, String> {
+        let cfg = self.config()?;
+        let access = self
+            .session
+            .lock_or_recover()
+            .access_token
+            .clone()
+            .filter(|t| !t.is_empty())
+            .ok_or("not signed in")?;
+        if let Err(first) = block_on(do_delete_user(cfg.clone(), access)) {
+            // The access token may simply have expired — refresh once and retry,
+            // surfacing the original error if the refresh path can't help.
+            let refresh = self
+                .session
+                .lock_or_recover()
+                .refresh_token
+                .clone()
+                .ok_or_else(|| first.clone())?;
+            let tokens = block_on(do_refresh(cfg.clone(), refresh)).map_err(|_| first.clone())?;
+            self.apply(tokens, None);
+            let access = self
+                .session
+                .lock_or_recover()
+                .access_token
+                .clone()
+                .filter(|t| !t.is_empty())
+                .ok_or(first)?;
+            block_on(do_delete_user(cfg, access))?;
+        }
+        clear_session();
+        self.session.lock_or_recover().clear();
+        Ok(self.status())
     }
 
     /// Store freshly-issued tokens. `email` is set on sign-in; left untouched on
@@ -332,7 +373,11 @@ async fn do_sign_in(cfg: Config, email: String, password: String) -> Result<Toke
     let client = cognito_client(&cfg.region).await;
 
     // SRP step 1: send SRP_A, get the PASSWORD_VERIFIER challenge.
-    let srp = SrpClient::new(User::new(&cfg.pool_id, &email, &password), &cfg.client_id, None);
+    let srp = SrpClient::new(
+        User::new(&cfg.pool_id, &email, &password),
+        &cfg.client_id,
+        None,
+    );
     let auth = srp.get_auth_parameters();
     let init = client
         .initiate_auth()
@@ -369,7 +414,10 @@ async fn do_sign_in(cfg: Config, email: String, password: String) -> Result<Toke
         .challenge_name(ChallengeNameType::PasswordVerifier)
         .client_id(&cfg.client_id)
         .challenge_responses("USERNAME", user_id)
-        .challenge_responses("PASSWORD_CLAIM_SECRET_BLOCK", proof.password_claim_secret_block)
+        .challenge_responses(
+            "PASSWORD_CLAIM_SECRET_BLOCK",
+            proof.password_claim_secret_block,
+        )
         .challenge_responses("PASSWORD_CLAIM_SIGNATURE", proof.password_claim_signature)
         .challenge_responses("TIMESTAMP", proof.timestamp)
         .send()
@@ -377,6 +425,17 @@ async fn do_sign_in(cfg: Config, email: String, password: String) -> Result<Toke
         .map_err(sdk_err)?;
 
     tokens_from(resp.authentication_result())
+}
+
+async fn do_delete_user(cfg: Config, access_token: String) -> Result<(), String> {
+    let client = cognito_client(&cfg.region).await;
+    client
+        .delete_user()
+        .access_token(access_token)
+        .send()
+        .await
+        .map_err(sdk_err)?;
+    Ok(())
 }
 
 async fn do_refresh(cfg: Config, refresh_token: String) -> Result<Tokens, String> {
@@ -447,7 +506,8 @@ fn clear_session() {
 /// A dedicated thread with its own current-thread runtime keeps this safe to
 /// call whether or not we're already inside the Tauri runtime; auth is
 /// infrequent (sign-in / sign-up / refresh), so the per-call runtime is fine.
-fn block_on<F>(fut: F) -> F::Output
+/// `crate::cloud` borrows it for its own rare synchronous call (account wipe).
+pub(crate) fn block_on<F>(fut: F) -> F::Output
 where
     F: std::future::Future + Send + 'static,
     F::Output: Send + 'static,
@@ -513,6 +573,9 @@ mod tests {
         let password = std::env::var("LUX_TEST_PASSWORD").unwrap();
         let tokens = block_on(do_sign_in(cfg, email, password)).expect("SRP sign-in failed");
         assert!(!tokens.id.is_empty(), "expected an id token");
-        assert!(tokens.refresh.is_some(), "expected a refresh token on sign-in");
+        assert!(
+            tokens.refresh.is_some(),
+            "expected a refresh token on sign-in"
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -20,7 +20,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
-use lux_wire::{ListSetupsResponse, SetupRecord, TombstoneResponse, UpsertSetupBody, WriteResponse};
+use lux_wire::{
+    DeleteUserDataResponse, ListSetupsResponse, SetupRecord, TombstoneResponse, UpsertSetupBody,
+    WriteResponse,
+};
 use reqwest::{Client, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -145,7 +148,9 @@ fn reconcile(local: Vec<Setup>, remote: &[SetupRecord]) -> Vec<Setup> {
     }
 
     for c in remote {
-        let fresh = Uuid::parse_str(&c.id).map(|id| !local_ids.contains(&id)).unwrap_or(false);
+        let fresh = Uuid::parse_str(&c.id)
+            .map(|id| !local_ids.contains(&id))
+            .unwrap_or(false);
         if fresh && !c.deleted {
             if let Some(s) = cloud_to_setup(c) {
                 merged.push(s);
@@ -199,7 +204,10 @@ async fn tombstone(
 ) -> Result<(), SyncError> {
     let mut url = format!("{base}/{}/{}", lux_wire::SETUPS_SEGMENT, delete.setup_id);
     if let Some(base_updated_at) = delete.base_updated_at {
-        url.push_str(&format!("?{}={base_updated_at}", lux_wire::BASE_UPDATED_AT_QUERY));
+        url.push_str(&format!(
+            "?{}={base_updated_at}",
+            lux_wire::BASE_UPDATED_AT_QUERY
+        ));
     }
     let resp = client
         .delete(url)
@@ -211,13 +219,28 @@ async fn tombstone(
     Ok(())
 }
 
+async fn delete_user_data(
+    client: &Client,
+    base: &str,
+    token: String,
+) -> Result<DeleteUserDataResponse, SyncError> {
+    let resp = client
+        .delete(format!("{base}/{}", lux_wire::USER_SEGMENT))
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|e| SyncError::Other(e.to_string()))?;
+    read_json(resp).await
+}
+
 async fn read_json<T: DeserializeOwned>(resp: reqwest::Response) -> Result<T, SyncError> {
     match resp.status() {
         StatusCode::UNAUTHORIZED => Err(SyncError::Unauthorized),
         StatusCode::CONFLICT => Err(SyncError::Conflict),
-        status if status.is_success() => {
-            resp.json::<T>().await.map_err(|e| SyncError::Other(e.to_string()))
-        }
+        status if status.is_success() => resp
+            .json::<T>()
+            .await
+            .map_err(|e| SyncError::Other(e.to_string())),
         status => {
             let body = resp.text().await.unwrap_or_default();
             Err(SyncError::Other(format!("{status}: {body}")))
@@ -249,7 +272,10 @@ async fn push_all(app: &AppHandle, client: &Client, base: &str, token: &mut Stri
         match result {
             Ok(w) => app.state::<LuxSetups>().mark_pushed(setup.id, w.updated_at),
             Err(SyncError::Conflict) => {
-                log::info!("push conflict for setup {}; reconciling on next pull", setup.id)
+                log::info!(
+                    "push conflict for setup {}; reconciling on next pull",
+                    setup.id
+                )
             }
             Err(e) => log::warn!("push failed for setup {}: {e}", setup.id),
         }
@@ -266,9 +292,9 @@ async fn push_all(app: &AppHandle, client: &Client, base: &str, token: &mut Stri
         match result {
             // A conflict means the setup changed remotely; drop the delete and let
             // the next pull surface the remote state.
-            Ok(()) | Err(SyncError::Conflict) => {
-                app.state::<LuxSetups>().clear_pending_delete(delete.setup_id)
-            }
+            Ok(()) | Err(SyncError::Conflict) => app
+                .state::<LuxSetups>()
+                .clear_pending_delete(delete.setup_id),
             Err(e) => log::warn!("delete push failed for {}: {e}", delete.setup_id),
         }
     }
@@ -285,9 +311,11 @@ async fn pull_and_push(app: &AppHandle) {
     if !account.signed_in() {
         return;
     }
-    let (Some(base), Some(email), Some(mut token)) =
-        (account.sync_url(), account.email(), account.current_id_token())
-    else {
+    let (Some(base), Some(email), Some(mut token)) = (
+        account.sync_url(),
+        account.email(),
+        account.current_id_token(),
+    ) else {
         return;
     };
     drop(account);
@@ -328,6 +356,34 @@ async fn pull_and_push(app: &AppHandle) {
     crate::cmd::broadcast_synced_state(app);
 
     push_all(app, &client, &base, &mut token).await;
+}
+
+/// Hard-delete all of the signed-in user's server-side data (`DELETE /user`) —
+/// step 1 of account deletion, run while the id token still authenticates (the
+/// Cognito user is removed right after). `Ok(())` when cloud sync was never
+/// configured: there is nothing to wipe. Synchronous on purpose: it runs on
+/// [`crate::account::block_on`] so the ttipc command can sequence the two steps.
+pub fn wipe_account_data(app: &AppHandle) -> Result<(), String> {
+    let (base, token) = {
+        let account = app.state::<LuxAccount>();
+        let Some(base) = account.sync_url() else {
+            return Ok(());
+        };
+        let token = account.current_id_token().ok_or("not signed in")?;
+        (base, token)
+    };
+    let app = app.clone();
+    crate::account::block_on(async move {
+        let client = Client::new();
+        let mut result = delete_user_data(&client, &base, token).await;
+        if matches!(result, Err(SyncError::Unauthorized)) {
+            let fresh = refresh(&app).await.map_err(|e| e.to_string())?;
+            result = delete_user_data(&client, &base, fresh).await;
+        }
+        result
+            .map(|_| ())
+            .map_err(|e| format!("could not delete cloud data: {e}"))
+    })
 }
 
 fn syncable(app: &AppHandle) -> bool {
@@ -382,7 +438,11 @@ pub fn schedule_sync(app: &AppHandle) {
     if !syncable(app) {
         return;
     }
-    if app.state::<LuxSync>().in_flight.swap(true, Ordering::SeqCst) {
+    if app
+        .state::<LuxSync>()
+        .in_flight
+        .swap(true, Ordering::SeqCst)
+    {
         return;
     }
     let app = app.clone();
@@ -390,7 +450,9 @@ pub fn schedule_sync(app: &AppHandle) {
         app.state::<LuxSync>().set(&app, SyncState::Syncing);
         pull_and_push(&app).await;
         finish_cycle(&app);
-        app.state::<LuxSync>().in_flight.store(false, Ordering::SeqCst);
+        app.state::<LuxSync>()
+            .in_flight
+            .store(false, Ordering::SeqCst);
     });
 }
 
@@ -429,7 +491,9 @@ fn schedule_retry(app: &AppHandle) {
             }
             attempt += 1;
         }
-        app.state::<LuxSync>().retrying.store(false, Ordering::SeqCst);
+        app.state::<LuxSync>()
+            .retrying
+            .store(false, Ordering::SeqCst);
     });
 }
 

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -71,12 +71,12 @@ pub trait CmdMethods {
         id: String,
         universe: u16,
     ) -> Result<Vec<SetupSummary>, String>;
-    fn delete_setup(&self, app_handle: AppHandle, id: String)
-        -> Result<Vec<SetupSummary>, String>;
+    fn delete_setup(&self, app_handle: AppHandle, id: String) -> Result<Vec<SetupSummary>, String>;
     fn set_active_setup(&self, app_handle: AppHandle, id: String) -> Result<SetupSummary, String>;
     // Accounts — Cognito identity (gates cloud sync; no-op when COGNITO_* unset).
     fn auth_status(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
-    fn sign_up(&self, app_handle: AppHandle, email: String, password: String) -> Result<(), String>;
+    fn sign_up(&self, app_handle: AppHandle, email: String, password: String)
+        -> Result<(), String>;
     fn confirm_sign_up(
         &self,
         app_handle: AppHandle,
@@ -90,6 +90,7 @@ pub trait CmdMethods {
         password: String,
     ) -> Result<AuthStatus, String>;
     fn sign_out(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
+    fn delete_account(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
     // Cloud sync — current status for the indicator, and a manual pull (fired on
     // window focus so remote edits land without waiting for a restart).
     fn sync_status(&self, app_handle: AppHandle) -> Result<crate::cloud::SyncState, String>;
@@ -261,11 +262,7 @@ impl CmdMethods for CmdEndpoint {
         commit_setups(&app_handle, setups.inner())
     }
 
-    fn delete_setup(
-        &self,
-        app_handle: AppHandle,
-        id: String,
-    ) -> Result<Vec<SetupSummary>, String> {
+    fn delete_setup(&self, app_handle: AppHandle, id: String) -> Result<Vec<SetupSummary>, String> {
         let id = parse_setup_id(&id)?;
         let setups = app_handle.state::<LuxSetups>();
         let was_active = setups.active_id() == id;
@@ -278,11 +275,7 @@ impl CmdMethods for CmdEndpoint {
         commit_setups(&app_handle, setups.inner())
     }
 
-    fn set_active_setup(
-        &self,
-        app_handle: AppHandle,
-        id: String,
-    ) -> Result<SetupSummary, String> {
+    fn set_active_setup(&self, app_handle: AppHandle, id: String) -> Result<SetupSummary, String> {
         let id = parse_setup_id(&id)?;
         let setups = app_handle.state::<LuxSetups>();
         setups.set_active(id)?;
@@ -295,7 +288,12 @@ impl CmdMethods for CmdEndpoint {
         Ok(app_handle.state::<LuxAccount>().status())
     }
 
-    fn sign_up(&self, app_handle: AppHandle, email: String, password: String) -> Result<(), String> {
+    fn sign_up(
+        &self,
+        app_handle: AppHandle,
+        email: String,
+        password: String,
+    ) -> Result<(), String> {
         app_handle.state::<LuxAccount>().sign_up(email, password)
     }
 
@@ -327,6 +325,21 @@ impl CmdMethods for CmdEndpoint {
 
     fn sign_out(&self, app_handle: AppHandle) -> Result<AuthStatus, String> {
         let status = app_handle.state::<LuxAccount>().sign_out();
+        crate::nudge::stop(&app_handle);
+        emit_auth_changed(&app_handle, status.clone())?;
+        Ok(status)
+    }
+
+    fn delete_account(&self, app_handle: AppHandle) -> Result<AuthStatus, String> {
+        // Wipe the cloud data while the tokens still authenticate, then remove
+        // the Cognito user; a failure at either step leaves the account intact
+        // and the whole flow retryable.
+        crate::cloud::wipe_account_data(&app_handle)?;
+        let status = app_handle.state::<LuxAccount>().delete_account()?;
+        // The local setups stay usable on this device as never-synced data.
+        let setups = app_handle.state::<LuxSetups>();
+        setups.reset_for_new_account();
+        setup::save(&app_handle, &setups);
         crate::nudge::stop(&app_handle);
         emit_auth_changed(&app_handle, status.clone())?;
         Ok(status)

--- a/apps/desktop/src-tauri/src/setup.rs
+++ b/apps/desktop/src-tauri/src/setup.rs
@@ -170,11 +170,7 @@ impl SetupStore {
 
     fn active_mut(&mut self) -> &mut Setup {
         let id = self.active_setup_id;
-        let idx = self
-            .setups
-            .iter()
-            .position(|s| s.id == id)
-            .unwrap_or(0);
+        let idx = self.setups.iter().position(|s| s.id == id).unwrap_or(0);
         &mut self.setups[idx]
     }
 }
@@ -341,7 +337,12 @@ impl LuxSetups {
     /// Setups with changes the cloud doesn't have yet (clones, for pushing).
     pub fn dirty_for_push(&self) -> Vec<Setup> {
         let store = self.store.lock_or_recover();
-        store.setups.iter().filter(|s| s.needs_push()).cloned().collect()
+        store
+            .setups
+            .iter()
+            .filter(|s| s.needs_push())
+            .cloned()
+            .collect()
     }
 
     /// Pending delete tombstones to push.
@@ -396,6 +397,9 @@ impl LuxSetups {
 
     /// Forget cloud binding and sync metadata so a *different* account signing in
     /// on this device can't push the previous user's setups into their cloud.
+    /// Also runs after account deletion: the setups stay usable on this device
+    /// as plain never-synced local data (with no stale server timestamps that
+    /// would wedge a future claim in permanent conflict).
     pub fn reset_for_new_account(&self) {
         let mut store = self.store.lock_or_recover();
         store.bound_email = None;
@@ -718,7 +722,10 @@ mod tests {
 
         let store = load_from_dir(&dir);
         assert_eq!(store.setups.len(), 2);
-        assert!(store.setups.iter().any(|s| s.name == "Church" && s.universe == 5));
+        assert!(store
+            .setups
+            .iter()
+            .any(|s| s.name == "Church" && s.universe == 5));
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -729,7 +736,7 @@ mod tests {
 
         let store = load_from_dir(&dir);
         assert_eq!(store.setups[0].name, "Home"); // fell back to default
-        // The bad file is moved aside, never clobbered, and not re-read.
+                                                  // The bad file is moved aside, never clobbered, and not re-read.
         assert!(dir.join("setups.json.corrupt-0").exists());
         assert!(!dir.join("setups.json").exists());
         std::fs::remove_dir_all(&dir).ok();

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -110,6 +110,11 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  delete_account(): Promise<AuthStatus> {
+    return invoke("cmd.delete_account");
+  },
+
+  /** @throws {string} */
   sync_status(): Promise<SyncState> {
     return invoke("cmd.sync_status");
   },

--- a/apps/desktop/src/components/account-menu.tsx
+++ b/apps/desktop/src/components/account-menu.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { toast } from "sonner";
-import { LogOut, User as UserIcon } from "lucide-react";
+import { LogOut, Trash2, User as UserIcon } from "lucide-react";
 import { createTauRPCProxy } from "@/bindings";
 import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
@@ -30,9 +30,11 @@ type Mode = "signIn" | "signUp" | "confirm";
 /**
  * Account control in the nav. Hidden entirely when accounts aren't configured
  * (no `COGNITO_*`), so the local-only app is unchanged. Signed in: a dropdown
- * with the email + sign out. Signed out: a dialog with sign-in / sign-up /
- * email-confirmation. State updates reactively from the `authChanged` event, so
- * a successful sign-in just closes the dialog.
+ * with the email, sign out, and account deletion (behind a confirm dialog —
+ * removes the account and its cloud data; local setups stay on the device).
+ * Signed out: a dialog with sign-in / sign-up / email-confirmation. State
+ * updates reactively from the `authChanged` event, so a successful sign-in or
+ * deletion just closes its dialog.
  */
 export default function AccountMenu() {
   const status = useAuth();
@@ -42,6 +44,8 @@ export default function AccountMenu() {
   const [password, setPassword] = useState("");
   const [code, setCode] = useState("");
   const [pending, setPending] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   // Accounts disabled (or status still loading) — render nothing.
   if (!status?.configured) return null;
@@ -51,24 +55,74 @@ export default function AccountMenu() {
       cmd()
         .sign_out()
         .catch((e) => toast.error(String(e)));
+    const deleteAccount = async () => {
+      setDeleting(true);
+      try {
+        await cmd().delete_account();
+        setConfirmDelete(false); // `authChanged` flips the menu to signed-out
+        toast.success("Account deleted. Your setups are still on this device.");
+      } catch (err) {
+        toast.error(String(err));
+      } finally {
+        setDeleting(false);
+      }
+    };
     return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm" className="gap-1.5">
-            <UserIcon className="size-3.5" />
-            <span className="max-w-32 truncate">{status.email ?? "Account"}</span>
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuLabel className="truncate font-normal text-muted-foreground">
-            {status.email}
-          </DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={signOut} className="gap-2">
-            <LogOut className="size-4" /> Sign out
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-1.5">
+              <UserIcon className="size-3.5" />
+              <span className="max-w-32 truncate">{status.email ?? "Account"}</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuLabel className="truncate font-normal text-muted-foreground">
+              {status.email}
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={signOut} className="gap-2">
+              <LogOut className="size-4" /> Sign out
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() => setConfirmDelete(true)}
+              className="gap-2 text-destructive focus:text-destructive"
+            >
+              <Trash2 className="size-4" /> Delete account…
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <Dialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+          <DialogContent className="sm:max-w-sm">
+            <DialogHeader>
+              <DialogTitle>Delete account?</DialogTitle>
+              <DialogDescription>
+                This permanently deletes your account and its cloud-synced
+                setups. Setups on this device stay on this device. This can't
+                be undone.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setConfirmDelete(false)}
+                disabled={deleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={deleteAccount}
+                disabled={deleting}
+              >
+                {deleting ? "…" : "Delete account"}
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </>
     );
   }
 

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -23,6 +23,10 @@ pub const SETUPS_SEGMENT: &str = "setups";
 /// Query parameter carrying the optimistic-concurrency base on `DELETE`.
 pub const BASE_UPDATED_AT_QUERY: &str = "baseUpdatedAt";
 
+/// The path segment for the caller's whole account: `DELETE /user` wipes every
+/// item in their partition ahead of Cognito account deletion.
+pub const USER_SEGMENT: &str = "user";
+
 /// One setup as it crosses the wire (an element of [`ListSetupsResponse`]).
 ///
 /// `fixtures` is deliberately opaque here: the server round-trips it as JSON
@@ -79,6 +83,15 @@ pub struct WriteResponse {
 pub struct TombstoneResponse {
     pub updated_at: i64,
     pub deleted: bool,
+}
+
+/// Response to a successful `DELETE /user` — the server-side data wipe that
+/// precedes deleting the Cognito user (in-app account deletion).
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteUserDataResponse {
+    /// Items hard-deleted from the caller's partition.
+    pub deleted_items: i64,
 }
 
 /// Error body for every non-2xx reply.
@@ -223,6 +236,15 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&body).unwrap(),
             r#"{"updatedAt":42,"deleted":true}"#
+        );
+    }
+
+    #[test]
+    fn delete_user_data_response_shape() {
+        let body = DeleteUserDataResponse { deleted_items: 3 };
+        assert_eq!(
+            serde_json::to_string(&body).unwrap(),
+            r#"{"deletedItems":3}"#
         );
     }
 

--- a/infra/accounts.tf
+++ b/infra/accounts.tf
@@ -116,6 +116,8 @@ resource "aws_iam_role_policy" "lux_sync_api_ddb" {
         "dynamodb:GetItem",
         "dynamodb:PutItem",
         "dynamodb:UpdateItem",
+        # Account deletion (`DELETE /user`) hard-deletes the user's partition.
+        "dynamodb:DeleteItem",
       ]
       Resource = aws_dynamodb_table.lux_sync.arn
     }]

--- a/services/sync-api/src/main.rs
+++ b/services/sync-api/src/main.rs
@@ -14,6 +14,7 @@
 //! - `GET    /setups`        — list the caller's setups (incl. tombstones)
 //! - `PUT    /setups/{id}`   — create/update one, optimistic-concurrency on `baseUpdatedAt`
 //! - `DELETE /setups/{id}?baseUpdatedAt=N` — soft-delete (tombstone)
+//! - `DELETE /user`          — hard-delete the caller's whole partition (account deletion)
 //!
 //! After each committed write the handler publishes a tiny opaque nudge frame
 //! to the caller's own IoT topic (`lux_wire::nudge`) so their other devices
@@ -27,7 +28,8 @@ use std::sync::Arc;
 use aws_config::BehaviorVersion;
 use lambda_http::{run, service_fn, Body, Error, Request, RequestExt, Response};
 use lux_wire::{
-    ErrorResponse, ListSetupsResponse, TombstoneResponse, UpsertSetupBody, WriteResponse,
+    DeleteUserDataResponse, ErrorResponse, ListSetupsResponse, TombstoneResponse, UpsertSetupBody,
+    WriteResponse,
 };
 use serde::{Deserialize, Serialize};
 
@@ -122,6 +124,7 @@ async fn handle(ctx: Arc<Ctx>, req: Request) -> Result<Response<Body>, Error> {
         ("DELETE", [seg, id]) if *seg == lux_wire::SETUPS_SEGMENT => {
             tombstone(&ctx, &sub, id, &req).await
         }
+        ("DELETE", [seg]) if *seg == lux_wire::USER_SEGMENT => delete_user_data(&ctx, &sub).await,
         _ => reply(404, error("not found")),
     }
 }
@@ -179,6 +182,20 @@ async fn tombstone(ctx: &Ctx, sub: &str, id: &str, req: &Request) -> Result<Resp
         Err(StoreError::Conflict) => reply(409, error("conflict")),
         Err(StoreError::Internal(e)) => {
             tracing::error!("tombstone failed: {e}");
+            reply(500, error("internal"))
+        }
+    }
+}
+
+/// Account deletion, step 1 of 2: hard-delete everything the caller owns. The
+/// app calls this while the tokens still authenticate, then removes the Cognito
+/// user itself (self-service `DeleteUser`). No nudge: the other devices' next
+/// refresh fails and they simply sign out.
+async fn delete_user_data(ctx: &Ctx, sub: &str) -> Result<Response<Body>, Error> {
+    match store::delete_all(&ctx.ddb, &ctx.table, sub).await {
+        Ok(deleted_items) => reply(200, DeleteUserDataResponse { deleted_items }),
+        Err(e) => {
+            tracing::error!("account data wipe failed: {e}");
             reply(500, error("internal"))
         }
     }

--- a/services/sync-api/src/store.rs
+++ b/services/sync-api/src/store.rs
@@ -175,6 +175,45 @@ pub async fn tombstone(
     Ok(n(attrs, "updatedAt").unwrap_or(now))
 }
 
+/// Hard-delete every item in a user's partition (account deletion — the data
+/// must actually leave the table, so no tombstones). Pages through the
+/// partition and deletes item-by-item; a user's partition is small (their
+/// setups), and per-item deletes keep the required IAM surface minimal.
+/// Idempotent: a retry after a partial failure deletes whatever remains.
+pub async fn delete_all(ddb: &Client, table: &str, sub: &str) -> Result<i64, StoreError> {
+    let mut deleted = 0i64;
+    let mut start_key: Option<HashMap<String, AttributeValue>> = None;
+    loop {
+        let out = ddb
+            .query()
+            .table_name(table)
+            .key_condition_expression("pk = :pk")
+            .expression_attribute_values(":pk", AttributeValue::S(pk(sub)))
+            .projection_expression("pk, sk")
+            .set_exclusive_start_key(start_key.take())
+            .send()
+            .await
+            .map_err(internal)?;
+        for item in out.items() {
+            let (Some(pk_val), Some(sk_val)) = (item.get("pk"), item.get("sk")) else {
+                continue;
+            };
+            ddb.delete_item()
+                .table_name(table)
+                .key("pk", pk_val.clone())
+                .key("sk", sk_val.clone())
+                .send()
+                .await
+                .map_err(internal)?;
+            deleted += 1;
+        }
+        start_key = out.last_evaluated_key().cloned();
+        if start_key.is_none() {
+            return Ok(deleted);
+        }
+    }
+}
+
 // --- helpers ----------------------------------------------------------------
 
 fn s(item: &HashMap<String, AttributeValue>, key: &str) -> Option<String> {


### PR DESCRIPTION
## What

In-app account deletion, end to end — required by App Store Guideline 5.1.1(v) for any app with account creation, and groundwork for the iOS App Store submission.

- **lux-wire**: new `USER_SEGMENT` (`DELETE /user`) and `DeleteUserDataResponse`, golden-tested like every other wire shape.
- **sync-api**: `DELETE /user` hard-deletes every item in the caller's partition (paginated query, per-item deletes, idempotent). No tombstones — account erasure must actually remove the data. No nudge — the user's other devices fail their next token refresh and sign out on their own.
- **infra**: the sync-api role gains `dynamodb:DeleteItem` on the `lux-sync` table. The release pipeline applies Terraform before deploying Lambdas, so the permission lands first.
- **desktop**: the `delete_account` command wipes cloud data while the tokens still authenticate (one 401 refresh-retry), then removes the Cognito user via self-service `DeleteUser` (one expired-access-token refresh-retry), then clears the session + keychain. Local setups stay usable on the device as never-synced data via `reset_for_new_account`, so stale server timestamps can't wedge a future claim in permanent conflict.
- **UI**: a destructive "Delete account…" item in the account menu, behind a confirm dialog that spells out what is and isn't deleted.

## Ordering / failure model

Wipe server data → delete Cognito user → clear local session. Both server steps are idempotent, so a failure at any step leaves the account intact and the whole flow retryable from the same button.

## Verification

- `cargo test --workspace --locked` — 60 tests green, including the new wire golden and the bindings drift guard (bindings regenerated, not hand-edited)
- `vite build` + `tsc --noEmit` + `eslint src` clean
- The Terraform plan job shows the IAM delta on this PR