### PR TITLE
build(ios): App Store privacy manifest + export-compliance key

### DIFF
--- a/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04E599390D3B632B4A0BFABA /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 0D6E56C15B49B8005BDD43E0 /* PrivacyInfo.xcprivacy */; };
 		1D70FE76DA06E4A954CF3CAC /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 623B61A7992B3DBDF95053BC /* assets */; };
 		2EEEB60236695CD1D82EE028 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F4B202D8D58B522F646FA10 /* QuartzCore.framework */; };
 		322834C88F9656BA124CDDC1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4A7C66DAE6212F7FF4BA6D0A /* Assets.xcassets */; };
@@ -22,10 +23,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		00E956AA67F8F4C53E9C8D30 /* nudge.rs */ = {isa = PBXFileReference; path = nudge.rs; sourceTree = "<group>"; };
 		0652621D61E48CFB715F2BF0 /* enttec_open_dmx_usb.rs */ = {isa = PBXFileReference; path = enttec_open_dmx_usb.rs; sourceTree = "<group>"; };
+		0D6E56C15B49B8005BDD43E0 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		0F78E63BDF56E0958B450096 /* lock.rs */ = {isa = PBXFileReference; path = lock.rs; sourceTree = "<group>"; };
 		13C0AD25CBBEA51729057C41 /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
 		13C72DEA1AE27665518F020F /* discovery.rs */ = {isa = PBXFileReference; path = discovery.rs; sourceTree = "<group>"; };
 		15CC3DB1433D23D972C8DE99 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
+		1FB84EA1206FA010A2803370 /* endpoints.rs */ = {isa = PBXFileReference; path = endpoints.rs; sourceTree = "<group>"; };
 		22790B3A18EE98177B6FC9E2 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		2D119CC234411C2677391DD9 /* lib.rs */ = {isa = PBXFileReference; path = lib.rs; sourceTree = "<group>"; };
 		3577B415FEFCC7650ED0D82F /* fixture.rs */ = {isa = PBXFileReference; path = fixture.rs; sourceTree = "<group>"; };
@@ -89,11 +94,14 @@
 				3A3E2BD6CA45BC1721CFE6C8 /* cloud.rs */,
 				ACC92720A312E5EC94D6BD32 /* cmd.rs */,
 				ADC061DF4CBF154936DD8BE9 /* colors.rs */,
+				1FB84EA1206FA010A2803370 /* endpoints.rs */,
 				65519633ACBE62859637CE34 /* error.rs */,
 				3577B415FEFCC7650ED0D82F /* fixture.rs */,
 				2D119CC234411C2677391DD9 /* lib.rs */,
+				0F78E63BDF56E0958B450096 /* lock.rs */,
 				FD3A418F87082A7A1D1FBA17 /* logger.rs */,
 				91D705F0C0650E85740F6C5D /* main.rs */,
+				00E956AA67F8F4C53E9C8D30 /* nudge.rs */,
 				4AF4BAEB9E80F20D9EF0EC9F /* remote.rs */,
 				FE41F2EEAC3FFC3CCA4FC84F /* setup.rs */,
 				92111F847FCD365ABA6BC31A /* sync.rs */,
@@ -190,6 +198,7 @@
 			children = (
 				543D41562DCA3689CFF2DA17 /* Info.plist */,
 				E6628D23D43C715526F8BEDC /* lux_iOS.entitlements */,
+				0D6E56C15B49B8005BDD43E0 /* PrivacyInfo.xcprivacy */,
 			);
 			path = lux_iOS;
 			sourceTree = "<group>";
@@ -254,6 +263,7 @@
 			files = (
 				322834C88F9656BA124CDDC1 /* Assets.xcassets in Resources */,
 				345ADEA90A44D9418E7F8327 /* LaunchScreen.storyboard in Resources */,
+				04E599390D3B632B4A0BFABA /* PrivacyInfo.xcprivacy in Resources */,
 				1D70FE76DA06E4A954CF3CAC /* assets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/xcshareddata/xcschemes/lux_iOS.xcscheme
+++ b/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/xcshareddata/xcschemes/lux_iOS.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1430"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -15,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "392BACEAAF50AF6DADBDCF14"
-               BuildableName = "lux.app"
+               BuildableName = "lux_iOS.app"
                BlueprintName = "lux_iOS"
                ReferencedContainer = "container:lux.xcodeproj">
             </BuildableReference>
@@ -26,16 +27,21 @@
       buildConfiguration = "debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "392BACEAAF50AF6DADBDCF14"
-            BuildableName = "lux.app"
+            BuildableName = "lux_iOS.app"
             BlueprintName = "lux_iOS"
             ReferencedContainer = "container:lux.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <Testables>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"
@@ -48,8 +54,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "debug"
@@ -66,11 +70,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "392BACEAAF50AF6DADBDCF14"
-            BuildableName = "lux.app"
+            BuildableName = "lux_iOS.app"
             BlueprintName = "lux_iOS"
             ReferencedContainer = "container:lux.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"
@@ -95,11 +101,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "392BACEAAF50AF6DADBDCF14"
-            BuildableName = "lux.app"
+            BuildableName = "lux_iOS.app"
             BlueprintName = "lux_iOS"
             ReferencedContainer = "container:lux.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"

--- a/apps/desktop/src-tauri/gen/apple/lux_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/lux_iOS/Info.plist
@@ -15,11 +15,15 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.0</string>
+	<string>0.12.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.9.0</string>
+	<string>0.12.2</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>lux discovers and controls DMX lighting nodes (Art-Net / sACN) on your local network.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -40,7 +44,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>lux discovers and controls DMX lighting nodes (Art-Net / sACN) on your local network.</string>
 </dict>
 </plist>

--- a/apps/desktop/src-tauri/gen/apple/lux_iOS/PrivacyInfo.xcprivacy
+++ b/apps/desktop/src-tauri/gen/apple/lux_iOS/PrivacyInfo.xcprivacy
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<!-- The email address is the account identity (Cognito sign-in); it is
+		     linked to the user by definition and never used for tracking. -->
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeEmailAddress</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<!-- App-scoped preferences (Tauri / WKWebView persistence). -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<!-- File metadata inside the app container (setups.json et al). -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<!-- Monotonic uptime clocks (Rust Instant / tokio timers). -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -30,7 +30,11 @@ targets:
     sources:
       - path: Sources
       - path: Assets.xcassets
+      # Externals holds gitignored build products (libapp.a); exclude them all
+      # so regeneration never sweeps a stale artifact into the bundle as a
+      # resource and the pbxproj stays independent of local build state.
       - path: Externals
+        excludes: ["**"]
       - path: lux_iOS
       - path: assets
         buildPhase: resources
@@ -40,6 +44,11 @@ targets:
       path: lux_iOS/Info.plist
       properties:
         LSRequiresIPhoneOS: true
+        # xcodegen regenerates Info.plist from these properties — every custom
+        # key must live here, or a `xcodegen generate` run silently drops it.
+        NSLocalNetworkUsageDescription: lux discovers and controls DMX lighting nodes (Art-Net / sACN) on your local network.
+        # Only standard-exempt TLS (rustls); skips the per-build export question.
+        ITSAppUsesNonExemptEncryption: false
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:
@@ -51,8 +60,11 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.9.0
-        CFBundleVersion: "0.9.0"
+        # Cosmetic: `tauri ios build` restamps both values (source Info.plist
+        # included) from tauri.conf.json's version on every build, so these only
+        # need to be valid, not current.
+        CFBundleShortVersionString: 0.12.2
+        CFBundleVersion: "0.12.2"
     entitlements:
       path: lux_iOS/lux_iOS.entitlements
     scheme:


### PR DESCRIPTION
## What

The remaining in-repo App Store paperwork for the iOS submission:

- **`PrivacyInfo.xcprivacy`** — the privacy manifest App Store Connect checks (missing ones draw ITMS-91053 flags). Declares email collection (account identity: linked to the user, not used for tracking, app-functionality purpose) and the required-reason API categories the app actually touches: UserDefaults (CA92.1, app-scoped prefs via Tauri/WKWebView), file timestamps (C617.1, app-container files like setups.json), and system-uptime clocks (35F9.1, Rust `Instant`/tokio timers). Wired into the bundle through the existing `lux_iOS` source path's Resources phase.
- **`ITSAppUsesNonExemptEncryption = false`** — the app uses only standard-exempt TLS (rustls); this skips the per-build export-compliance questionnaire.

## Fixes surfaced along the way

- `project.yml` is what xcodegen regenerates `Info.plist` from, but `NSLocalNetworkUsageDescription` had been added to the plist directly — any `xcodegen generate` run silently dropped the local-network permission string. Every custom key now lives in `project.yml`.
- `Externals/` (gitignored build products) is excluded from target sources: regeneration on a machine with build output present swept a stale `libapp.a` into the bundle as a resource.
- The committed `gen/apple` version strings are cosmetic — `tauri ios build` restamps `CFBundleShortVersionString`/`CFBundleVersion` from `tauri.conf.json` on every build (tauri-cli #10944), so release-please stays out of `gen/apple`. Documented in `project.yml`.

## Verification

Simulator build (`tauri ios build --debug --target aarch64-sim --no-sign --ci`) from the regenerated project completes clean; the built `lux.app` contains `PrivacyInfo.xcprivacy`, both new Info.plist keys, and the version restamped to the current `tauri.conf.json` value. Both plists pass `plutil -lint`.

Note for iOS builds generally: the build regenerates `gen/schemas/acl-manifests.json` with the mobile plugin set; that churn is not committed here (the tracked file stays desktop-flavored).