### PR TITLE
build(ios): pin the development team for device signing

### DIFF
--- a/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
@@ -235,6 +235,10 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					392BACEAAF50AF6DADBDCF14 = {
+						DevelopmentTeam = T3UN6N5K6Z;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 37A3037E896E43D54854B48E /* Build configuration list for PBXProject "lux" */;
@@ -379,6 +383,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = lux_iOS/lux_iOS.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = T3UN6N5K6Z;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -393,7 +399,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncarmack.lux;
-				PRODUCT_NAME = "lux";
+				PRODUCT_NAME = lux;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;
@@ -466,6 +472,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = lux_iOS/lux_iOS.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = T3UN6N5K6Z;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -480,7 +488,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncarmack.lux;
-				PRODUCT_NAME = "lux";
+				PRODUCT_NAME = lux;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -73,6 +73,11 @@ targets:
         RUST_LOG: info
     settings:
       base:
+        # Device signing: Xcode's automatic management, pinned to the team so
+        # an `xcodegen generate` can never strip what Xcode configured. The
+        # dev cert/profile live in the developer account, not the repo.
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: T3UN6N5K6Z
         ENABLE_BITCODE: false
         ARCHS: [arm64]
         VALID_ARCHS: arm64 


### PR DESCRIPTION
Persists device-signing configuration where it survives regeneration: `CODE_SIGN_STYLE: Automatic` + `DEVELOPMENT_TEAM` in `project.yml`, with the regenerated `project.pbxproj`. Xcode's automatic signing manages the certificate and provisioning profile in the developer account; the repo carries only the team pin. Without this, any `xcodegen generate` run strips the signing settings Xcode wrote into the generated project.