### PR TITLE
build(ios): stamp the Xcode 26 upgrade check; pin script sandboxing off

### DIFF
--- a/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
@@ -233,7 +233,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 2660;
 				TargetAttributes = {
 					392BACEAAF50AF6DADBDCF14 = {
 						DevelopmentTeam = T3UN6N5K6Z;
@@ -386,6 +386,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = T3UN6N5K6Z;
 				ENABLE_BITCODE = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -475,6 +476,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = T3UN6N5K6Z;
 				ENABLE_BITCODE = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
@@ -41,7 +41,6 @@
 		4AF4BAEB9E80F20D9EF0EC9F /* remote.rs */ = {isa = PBXFileReference; path = remote.rs; sourceTree = "<group>"; };
 		543D41562DCA3689CFF2DA17 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		623B61A7992B3DBDF95053BC /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; path = assets; sourceTree = SOURCE_ROOT; };
-		6463DB4B6F1A260E25A692FC /* lux_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = lux_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6494611D9DAF8D55704BE2D4 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		65519633ACBE62859637CE34 /* error.rs */ = {isa = PBXFileReference; path = error.rs; sourceTree = "<group>"; };
 		6DF90FDE7A6A99B512BF4C9A /* account.rs */ = {isa = PBXFileReference; path = account.rs; sourceTree = "<group>"; };
@@ -58,6 +57,7 @@
 		A9B6FEEEB4E81F8CA6417A1B /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		ACC92720A312E5EC94D6BD32 /* cmd.rs */ = {isa = PBXFileReference; path = cmd.rs; sourceTree = "<group>"; };
 		ADC061DF4CBF154936DD8BE9 /* colors.rs */ = {isa = PBXFileReference; path = colors.rs; sourceTree = "<group>"; };
+		D19521C0023ADBB8F8E9AA7B /* lux.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = lux.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCBE693964070B3DB25263B2 /* bindings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bindings.h; sourceTree = "<group>"; };
 		E6628D23D43C715526F8BEDC /* lux_iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = lux_iOS.entitlements; sourceTree = "<group>"; };
 		FD3A418F87082A7A1D1FBA17 /* logger.rs */ = {isa = PBXFileReference; path = logger.rs; sourceTree = "<group>"; };
@@ -188,7 +188,7 @@
 		CBBE790730D4C83654C616B0 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				6463DB4B6F1A260E25A692FC /* lux_iOS.app */,
+				D19521C0023ADBB8F8E9AA7B /* lux.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -223,7 +223,7 @@
 			packageProductDependencies = (
 			);
 			productName = lux_iOS;
-			productReference = 6463DB4B6F1A260E25A692FC /* lux_iOS.app */;
+			productReference = D19521C0023ADBB8F8E9AA7B /* lux.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/xcshareddata/xcschemes/lux_iOS.xcscheme
+++ b/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/xcshareddata/xcschemes/lux_iOS.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2660"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -26,7 +27,8 @@
       buildConfiguration = "debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -36,6 +38,10 @@
             ReferencedContainer = "container:lux.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <Testables>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"
@@ -48,8 +54,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "debug"
@@ -71,6 +75,8 @@
             ReferencedContainer = "container:lux.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"
@@ -100,6 +106,8 @@
             ReferencedContainer = "container:lux.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"

--- a/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/xcshareddata/xcschemes/lux_iOS.xcscheme
+++ b/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/xcshareddata/xcschemes/lux_iOS.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
-   version = "1.7">
+   LastUpgradeVersion = "2660"
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -16,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "392BACEAAF50AF6DADBDCF14"
-               BuildableName = "lux_iOS.app"
+               BuildableName = "lux.app"
                BlueprintName = "lux_iOS"
                ReferencedContainer = "container:lux.xcodeproj">
             </BuildableReference>
@@ -27,21 +26,16 @@
       buildConfiguration = "debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "392BACEAAF50AF6DADBDCF14"
-            BuildableName = "lux_iOS.app"
+            BuildableName = "lux.app"
             BlueprintName = "lux_iOS"
             ReferencedContainer = "container:lux.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-      </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"
@@ -54,6 +48,8 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "debug"
@@ -70,13 +66,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "392BACEAAF50AF6DADBDCF14"
-            BuildableName = "lux_iOS.app"
+            BuildableName = "lux.app"
             BlueprintName = "lux_iOS"
             ReferencedContainer = "container:lux.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"
@@ -101,13 +95,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "392BACEAAF50AF6DADBDCF14"
-            BuildableName = "lux_iOS.app"
+            BuildableName = "lux.app"
             BlueprintName = "lux_iOS"
             ReferencedContainer = "container:lux.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -33,6 +33,10 @@ targets:
   lux_iOS:
     type: application
     platform: iOS
+    # Keeps the generated product reference named lux.app (matching
+    # PRODUCT_NAME and the scheme's runnable) — without it xcodegen names the
+    # product after the target, and Xcode's Run action asserts on the mismatch.
+    productName: lux
     sources:
       - path: Sources
       - path: Assets.xcassets

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -3,6 +3,12 @@ options:
   bundleIdPrefix: com.johncarmack.lux
   deploymentTarget:
     iOS: 14.0
+  # Stamps LastUpgradeCheck/LastUpgradeVersion as already reviewed by Xcode 26,
+  # so it stops offering "Update to recommended settings" — those
+  # recommendations are wrong for this generated project (script sandboxing
+  # breaks the Rust build phase, auto-architectures fights the per-arch
+  # libapp.a layout).
+  xcodeVersion: "26.6"
 fileGroups: [../../src]
 configs:
   debug: debug
@@ -78,6 +84,10 @@ targets:
         # dev cert/profile live in the developer account, not the repo.
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: T3UN6N5K6Z
+        # Explicitly off: the "Build Rust Code" phase writes cargo's target/
+        # and Externals/, far outside any sandbox a script phase may declare.
+        # An accepted Xcode "recommended settings" pass once flipped this on.
+        ENABLE_USER_SCRIPT_SANDBOXING: false
         ENABLE_BITCODE: false
         ARCHS: [arm64]
         VALID_ARCHS: arm64 


### PR DESCRIPTION
Silences Xcode 26's persistent "Update to recommended settings" prompt for the generated iOS project: `options.xcodeVersion: 26.6` in `project.yml` stamps `LastUpgradeCheck` (project) and `LastUpgradeVersion` (scheme) as already reviewed, and `ENABLE_USER_SCRIPT_SANDBOXING: false` is pinned explicitly.

The recommended changes are wrong for this project: user-script sandboxing denies the tauri "Build Rust Code" phase its writes (cargo `target/`, `Externals/`), and automatic architecture selection conflicts with the per-arch `libapp.a` search paths. With the values in `project.yml`, an accepted upgrade pass is reverted by the next `xcodegen generate`.