### PR TITLE
fix(desktop): register the data-protection keychain store on iOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,6 +3423,7 @@ dependencies = [
  "base64 0.22.1",
  "enttecopendmx",
  "keyring",
+ "keyring-core",
  "libftd2xx 0.33.1",
  "log",
  "lux-wire",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -91,6 +91,10 @@ tauri-plugin-updater = "2"
 # feature — Cargo unifies it onto the same instance keyring uses.
 [target.'cfg(target_os = "ios")'.dependencies]
 apple-native-keyring-store = { version = "1", features = ["protected"] }
+# Naming keyring's backing crate directly lets us register the data-protection
+# store as the default at startup (see account::init_keychain) — keyring's own
+# auto-registration skips iOS.
+keyring-core = "1"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -473,6 +473,31 @@ fn sdk_err<E: ProvideErrorMetadata, R>(e: SdkError<E, R>) -> String {
 
 // --- keychain (refresh token at rest) ---------------------------------------
 
+/// Register the credential store that [`keyring`] uses. Call once at startup,
+/// before any keychain access (session restore or sign-in).
+///
+/// `keyring`'s `v1` feature auto-registers a default store for macOS, Windows,
+/// and Linux, but its `set_credential_store` (keyring 4.1.2 `src/v1.rs`) has no
+/// branch for iOS — so on iOS no default store is ever set and every keychain
+/// read/write fails with `NoDefaultStore`, silently losing the signed-in
+/// session across launches. iOS only exposes the data-protection Keychain, so
+/// register the `protected` store as the default here.
+#[cfg(target_os = "ios")]
+pub fn init_keychain() {
+    match apple_native_keyring_store::protected::Store::new() {
+        Ok(store) => {
+            keyring_core::set_default_store(store);
+            log::info!("registered the iOS data-protection Keychain store");
+        }
+        Err(e) => log::error!("could not register the iOS Keychain store: {e}"),
+    }
+}
+
+/// No-op off iOS: `keyring`'s `v1` feature self-registers the platform store
+/// (macOS Keychain, Windows Credential Manager, Linux Secret Service).
+#[cfg(not(target_os = "ios"))]
+pub fn init_keychain() {}
+
 fn keyring_entry() -> Result<keyring::Entry, keyring::Error> {
     keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER)
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -47,6 +47,9 @@ pub async fn run() {
         app.manage(setup::load(app.handle()));
         // Cognito accounts (no-op unless the endpoints file configures them);
         // restore a signed-in session from the keychain in the background.
+        // Register the Keychain store first — on iOS nothing else does, and the
+        // restore below reads from it.
+        account::init_keychain();
         app.manage(account::LuxAccount::load());
         account::restore_on_startup(app.handle());
         remote::connect(app.handle());


### PR DESCRIPTION
keyring 4's `v1` auto-registration installs a default credential store on macOS, Windows, and Linux, but not iOS — so on iOS every keychain read/write failed with `NoDefaultStore` and a signed-in session was never persisted across launches.

Registers apple-native-keyring-store's `protected` (data-protection) store as the default at startup on iOS, before the session restore runs. No-op on the other platforms, where keyring self-registers.

Verified on device: the session now persists and restores across a force-quit.
