### PR TITLE
fix(desktop): reflect DMX, sync, and channel state on iOS

### DIFF
--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { RgbaColorPicker, type RgbaColor } from "react-colorful";
-import { createTauRPCProxy, type Fixture, type LuxLabelColor } from "@/bindings";
+import { type Fixture, type LuxLabelColor } from "@/bindings";
 import { Popover, PopoverContent } from "@/components/ui/popover";
 import ColorTrigger from "@/components/color-picker/color-trigger";
 import useThrottle from "@/hooks/useThrottle";
+import { setChannelValue } from "@/lib/actions";
 import { emittersToRgb, mixToEmitters } from "@/lib/color-mix";
 
 /** First DMX address (1-based) within the fixture carrying `role`, or null. */
@@ -49,7 +50,6 @@ export default function FixtureColor({
   }, [buffer, r, g, b, amber, white, dimmer]);
 
   const send = useThrottle((next: RgbaColor) => {
-    const taurpc = createTauRPCProxy();
     const mix = mixToEmitters(next.r, next.g, next.b, {
       amber: amber !== null,
       white: white !== null,
@@ -63,7 +63,7 @@ export default function FixtureColor({
       [dimmer, Math.round(next.a * 255)],
     ];
     for (const [addr, value] of writes) {
-      if (addr) taurpc.cmd.update_channel_value(addr, value).catch(() => {});
+      if (addr) setChannelValue({ channelNumber: addr, value }).catch(() => {});
     }
   }, 40);
 

--- a/apps/desktop/src/components/setup-switcher.tsx
+++ b/apps/desktop/src/components/setup-switcher.tsx
@@ -8,9 +8,10 @@ import {
   Settings2,
   Trash2,
 } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
 import { createTauRPCProxy, type SetupSummary } from "@/bindings";
 import useSetups from "@/hooks/useSetups";
-import useDmxDevices from "@/hooks/useDmxDevices";
+import useDmxDevices, { DMX_DEVICES_QUERY_KEY } from "@/hooks/useDmxDevices";
 import useLuxRefresh from "@/hooks/useLuxRefresh";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -40,6 +41,9 @@ export default function SetupSwitcher() {
   const active = setups?.find((s) => s.active) ?? null;
   const dmxDevices = useDmxDevices();
   const refresh = useLuxRefresh();
+  const queryClient = useQueryClient();
+  const refreshDevices = () =>
+    queryClient.invalidateQueries({ queryKey: DMX_DEVICES_QUERY_KEY });
 
   const [manageOpen, setManageOpen] = useState(false);
   const [editName, setEditName] = useState("");
@@ -118,11 +122,13 @@ export default function SetupSwitcher() {
   const selectDevice = (key: string) => {
     cmd()
       .set_dmx_device(key)
+      .then(refreshDevices)
       .catch((e) => toast.error(String(e)));
   };
 
   // Detection runs ~3s on the backend and reports back via `dmxDevicesChanged`;
-  // show the spinner across that window rather than block on the call's return.
+  // show the spinner across that window rather than block on the call's return,
+  // and refetch the list when it closes (the event doesn't reach iOS).
   const rescanDevices = async () => {
     setRescanning(true);
     try {
@@ -130,7 +136,10 @@ export default function SetupSwitcher() {
     } catch (e) {
       toast.error(String(e));
     }
-    setTimeout(() => setRescanning(false), 3500);
+    setTimeout(() => {
+      setRescanning(false);
+      void refreshDevices();
+    }, 3500);
   };
 
   return (

--- a/apps/desktop/src/hooks/useBuffer.ts
+++ b/apps/desktop/src/hooks/useBuffer.ts
@@ -1,37 +1,42 @@
-import { attachConsole } from "@tauri-apps/plugin-log";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createTauRPCProxy } from "@/bindings";
 
-function useBuffer() {
-  const [buffer, setBuffer] = useState<number[] | null>(null);
+/** Query key for the live DMX buffer (the current value of every channel). */
+export const BUFFER_QUERY_KEY = ["buffer"] as const;
+
+/**
+ * The live DMX buffer — the current value of every channel. `null` until the
+ * first read resolves.
+ *
+ * Faders keep their own optimistic state so dragging is always smooth; this
+ * query reflects changes made elsewhere. The channel-value setter pushes the
+ * buffer it gets back straight into the cache (see lib/actions), which is what
+ * keeps it current on iOS. On desktop the `bufferSet` event is also honored as
+ * a fast path so out-of-band changes — a remote command over IoT — still show
+ * live; that event just never reaches the webview on iOS.
+ */
+export default function useBuffer(): number[] | null {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    queryKey: BUFFER_QUERY_KEY,
+    queryFn: () =>
+      createTauRPCProxy()
+        .sync.sync_buffer()
+        .then((b) => b.buffer),
+  });
 
   useEffect(() => {
-    const taurpc = createTauRPCProxy();
-    let active = true;
-    const consoleAttached = attachConsole();
-
-    // Fetch the current buffer directly so the UI reflects state on load even if
-    // the startup sync event fires before this listener is attached.
-    taurpc.sync
-      .sync_buffer()
-      .then((b) => {
-        if (active) setBuffer(b.buffer);
-      })
-      .catch(() => {});
-
-    const unlisten = taurpc.sync.event.on((event) => {
-      if (event.type !== "bufferSet") return;
-      setBuffer(event.buffer);
+    const unlisten = createTauRPCProxy().sync.event.on((event) => {
+      if (event.type === "bufferSet") {
+        queryClient.setQueryData(BUFFER_QUERY_KEY, event.buffer);
+      }
     });
-
     return () => {
-      active = false;
       unlisten.then((f) => f());
-      consoleAttached.then((detach) => detach());
     };
-  }, []);
+  }, [queryClient]);
 
-  return buffer;
+  return data ?? null;
 }
-
-export default useBuffer;

--- a/apps/desktop/src/hooks/useChannelsMetaData.ts
+++ b/apps/desktop/src/hooks/useChannelsMetaData.ts
@@ -1,37 +1,27 @@
 import type { LuxChannel } from "@/global";
-import { trace } from "@tauri-apps/plugin-log";
-import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { createTauRPCProxy } from "@/bindings";
 
-function useChannelData() {
-  const [channelData, setChannelData] = useState<LuxChannel[] | null>(null);
+/** Query key for the channel metadata (label + color per channel). */
+export const CHANNELS_QUERY_KEY = ["channels"] as const;
 
-  useEffect(() => {
-    const taurpc = createTauRPCProxy();
-    let active = true;
-
-    // Fetch the current channels directly so the grid populates even if the
-    // startup sync event fires before this listener is attached. The listener
-    // then keeps it live for later updates.
-    taurpc.sync
-      .sync_channels()
-      .then((c) => {
-        if (active) setChannelData(c.channels);
-      })
-      .catch((e) => trace(`sync_channels failed: ${e}`));
-
-    const unlisten = taurpc.cmd.event.on((event) => {
-      if (event.type !== "channelDataSet") return;
-      setChannelData(event.channels);
-    });
-
-    return () => {
-      active = false;
-      unlisten.then((f) => f());
-    };
-  }, []);
-
-  return channelData;
+/**
+ * The 512 channels' metadata (label + color). `null` until the first read.
+ *
+ * This changes only when fixtures are patched — which the backend echoes on the
+ * `channelDataSet` event, undelivered to the webview on iOS. So it refreshes
+ * with the fixture views (see useLuxRefresh), plus refetch-on-focus for
+ * cloud-synced changes, rather than relying on the event.
+ */
+function useChannelData(): LuxChannel[] | null {
+  const { data } = useQuery({
+    queryKey: CHANNELS_QUERY_KEY,
+    queryFn: () =>
+      createTauRPCProxy()
+        .sync.sync_channels()
+        .then((c) => c.channels),
+  });
+  return data ?? null;
 }
 
 export default useChannelData;

--- a/apps/desktop/src/hooks/useDmxDevices.tsx
+++ b/apps/desktop/src/hooks/useDmxDevices.tsx
@@ -1,39 +1,24 @@
-import { useEffect, useState } from "react";
-import { trace } from "@tauri-apps/plugin-log";
+import { useQuery } from "@tanstack/react-query";
 import { createTauRPCProxy, type DmxDeviceInfo } from "@/bindings";
 
+/** Query key for the detected DMX outputs. */
+export const DMX_DEVICES_QUERY_KEY = ["dmxDevices"] as const;
+
 /**
- * The detected DMX outputs and which one is active. Fetches on mount and stays
- * live via the `dmxDevicesChanged` event the backend emits on auto-detect,
- * rescan, or a manual pick. `null` while the first fetch is in flight.
+ * The detected DMX outputs and which one is active. `null` while the first read
+ * is in flight. Backs the in-app output picker — the only output selector on
+ * mobile, where there's no system tray.
  *
- * This backs the in-app output picker — the only output selector on mobile,
- * where there's no system tray.
+ * The backend emits `dmxDevicesChanged` on auto-detect / rescan / pick, but it
+ * doesn't reach the webview on iOS. So poll a few times just after mount to
+ * catch the ~3s startup auto-detect, then stop; the setup switcher invalidates
+ * this key after a pick or a rescan.
  */
-export default function useDmxDevices() {
-  const [devices, setDevices] = useState<DmxDeviceInfo[] | null>(null);
-
-  useEffect(() => {
-    const taurpc = createTauRPCProxy();
-    let active = true;
-
-    taurpc.cmd
-      .list_dmx_devices()
-      .then((d) => {
-        if (active) setDevices(d);
-      })
-      .catch((e) => trace(`list_dmx_devices failed: ${e}`));
-
-    const unlisten = taurpc.cmd.event.on((event) => {
-      if (event.type !== "dmxDevicesChanged") return;
-      setDevices(event.devices);
-    });
-
-    return () => {
-      active = false;
-      unlisten.then((f) => f());
-    };
-  }, []);
-
-  return devices;
+export default function useDmxDevices(): DmxDeviceInfo[] | null {
+  const { data } = useQuery({
+    queryKey: DMX_DEVICES_QUERY_KEY,
+    queryFn: () => createTauRPCProxy().cmd.list_dmx_devices(),
+    refetchInterval: (query) => (query.state.dataUpdateCount < 3 ? 2500 : false),
+  });
+  return data ?? null;
 }

--- a/apps/desktop/src/hooks/useLuxRefresh.ts
+++ b/apps/desktop/src/hooks/useLuxRefresh.ts
@@ -1,19 +1,27 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { FIXTURES_QUERY_KEY } from "./useFixtures";
 import { SETUPS_QUERY_KEY } from "./useSetups";
+import { CHANNELS_QUERY_KEY } from "./useChannelsMetaData";
+import { BUFFER_QUERY_KEY } from "./useBuffer";
 
 /**
- * Refetch the fixture + setup views after a mutation. The backend's `patchSet`
- * and `setupsChanged` events aren't reliably delivered to the webview on iOS,
- * so a mutation refreshes authoritatively instead of relying on them. Both keys
- * refresh together because they're coupled — switching a setup swaps the
- * active patch, and adding a fixture changes the active setup's fixture count.
+ * Refetch the reactive views a fixture/setup mutation can affect. The backend's
+ * `patchSet` / `setupsChanged` / `channelDataSet` / `bufferSet` events aren't
+ * reliably delivered to the webview on iOS, so a mutation refreshes
+ * authoritatively instead of relying on them. All four keys refresh together
+ * because they're coupled — switching a setup swaps the active patch, its
+ * channel labels, and the live buffer; patching a fixture changes the fixture
+ * count and the channel metadata.
  */
 export default function useLuxRefresh() {
   const queryClient = useQueryClient();
   return () =>
-    Promise.all([
-      queryClient.invalidateQueries({ queryKey: FIXTURES_QUERY_KEY }),
-      queryClient.invalidateQueries({ queryKey: SETUPS_QUERY_KEY }),
-    ]);
+    Promise.all(
+      [
+        FIXTURES_QUERY_KEY,
+        SETUPS_QUERY_KEY,
+        CHANNELS_QUERY_KEY,
+        BUFFER_QUERY_KEY,
+      ].map((queryKey) => queryClient.invalidateQueries({ queryKey }))
+    );
 }

--- a/apps/desktop/src/hooks/useSyncStatus.ts
+++ b/apps/desktop/src/hooks/useSyncStatus.ts
@@ -1,36 +1,24 @@
-import { useEffect, useState } from "react";
-import { trace } from "@tauri-apps/plugin-log";
+import { useQuery } from "@tanstack/react-query";
 import { createTauRPCProxy, type SyncState } from "@/bindings";
 
+/** Query key for the cloud-sync state. */
+export const SYNC_STATUS_QUERY_KEY = ["syncStatus"] as const;
+
 /**
- * The current cloud-sync state (idle / syncing / synced / offline). Fetches on
- * mount and stays live via the `syncStatusChanged` event the backend emits as a
- * push/pull cycle progresses. `null` until the first fetch resolves.
+ * The current cloud-sync state (idle / syncing / synced / offline). `null` until
+ * the first read.
+ *
+ * The backend pushes this as a push/pull cycle progresses via the
+ * `syncStatusChanged` event, which doesn't reach the webview on iOS. It's driven
+ * by the backend rather than a UI mutation, so poll it — `sync_status` is a
+ * cheap in-memory read, the poll pauses while the app is backgrounded, and the
+ * indicator is only mounted while signed in.
  */
-export default function useSyncStatus() {
-  const [state, setState] = useState<SyncState | null>(null);
-
-  useEffect(() => {
-    const taurpc = createTauRPCProxy();
-    let active = true;
-
-    taurpc.cmd
-      .sync_status()
-      .then((s) => {
-        if (active) setState(s);
-      })
-      .catch((e) => trace(`sync_status failed: ${e}`));
-
-    const unlisten = taurpc.cmd.event.on((event) => {
-      if (event.type !== "syncStatusChanged") return;
-      setState(event.state);
-    });
-
-    return () => {
-      active = false;
-      unlisten.then((f) => f());
-    };
-  }, []);
-
-  return state;
+export default function useSyncStatus(): SyncState | null {
+  const { data } = useQuery({
+    queryKey: SYNC_STATUS_QUERY_KEY,
+    queryFn: () => createTauRPCProxy().cmd.sync_status(),
+    refetchInterval: 2000,
+  });
+  return data ?? null;
 }

--- a/apps/desktop/src/lib/actions.ts
+++ b/apps/desktop/src/lib/actions.ts
@@ -1,5 +1,12 @@
 import { createTauRPCProxy } from "@/bindings";
+import { queryClient } from "@/lib/query-client";
+import { BUFFER_QUERY_KEY } from "@/hooks/useBuffer";
 
+/**
+ * Set one channel's value. Pushes the buffer the backend returns straight into
+ * the query cache, so every buffer view reflects the change without waiting on
+ * the `bufferSet` event (undelivered to the webview on iOS).
+ */
 async function setChannelValue({
   channelNumber,
   value,
@@ -8,7 +15,9 @@ async function setChannelValue({
   value: number;
 }) {
   const taurpc = createTauRPCProxy();
-  return await taurpc.cmd.update_channel_value(channelNumber, value);
+  const buffer = await taurpc.cmd.update_channel_value(channelNumber, value);
+  queryClient.setQueryData(BUFFER_QUERY_KEY, buffer.buffer);
+  return buffer;
 }
 
 export { setChannelValue };

--- a/apps/desktop/src/lib/query-client.ts
+++ b/apps/desktop/src/lib/query-client.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/**
+ * The app's single QueryClient, exported as a module singleton rather than
+ * created inside a component so non-React code can reach the cache too — the
+ * channel-value setter in `lib/actions` pushes the buffer the backend returns
+ * straight into `["buffer"]`, since the `bufferSet` event that would normally
+ * carry it doesn't reach the webview on iOS.
+ */
+export const queryClient = new QueryClient();

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,10 +1,15 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { attachConsole } from "@tauri-apps/plugin-log";
+import { queryClient } from "@/lib/query-client";
 import { routeTree } from "./routeTree.gen";
 import "@fontsource-variable/inter";
 import "./globals.css";
+
+// Pipe the Rust logger into the webview console (once, app-wide).
+attachConsole();
 
 const router = createRouter({ routeTree });
 
@@ -13,11 +18,6 @@ declare module "@tanstack/react-router" {
     router: typeof router;
   }
 }
-
-// Backend->frontend events aren't reliably delivered to the webview on iOS, so
-// reactive state is read through TanStack Query (refetch on focus + invalidate
-// after mutations) rather than relying on those events alone.
-const queryClient = new QueryClient();
 
 const rootElement = document.getElementById("root")!;
 createRoot(rootElement).render(


### PR DESCRIPTION
Follow-up to #114 (the account/patch hooks): migrates the four remaining event-driven hooks off the backend events that don't reach the webview on iOS.

- `useBuffer`, `useChannelsMetaData`, `useSyncStatus`, and `useDmxDevices` read through TanStack Query.
- The channel-value setter pushes the buffer the backend returns straight into the cache (`lib/actions` + a shared `query-client` singleton), so color-picker and fader changes reflect across views without the `bufferSet` event.
- `useLuxRefresh` also invalidates the channel + buffer keys, since a setup switch swaps all of them.
- `useSyncStatus` polls (it's backend-driven); `useDmxDevices` polls briefly after mount for the ~3s startup auto-detect, and the setup switcher invalidates it after a pick or rescan.

`useBuffer` keeps the `bufferSet` listener as a **desktop** fast path so live remote (IoT) changes still show instantly there — that event just never fires on iOS.

One deliberate tradeoff: the sync **spinner** on desktop now polls (every 2s) rather than reacting to the event, so the transient "syncing…" animation is best-effort; the synced/offline state stays correct.

Verified on device: add/rename/delete fixture and setup switching reflect live, universe faders and channel labels render, and a color-swatch change moves the individual channel faders to match.
