### PR TITLE
fix(sync-api): install a JWT crypto backend so verification works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1434,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,6 +1607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1640,6 +1659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1790,6 +1810,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,6 +1852,27 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "embed-resource"
@@ -1964,6 +2019,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2302,6 +2367,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2442,6 +2508,17 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3171,11 +3248,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64 0.22.1",
+ "ed25519-dalek",
  "getrandom 0.2.17",
+ "hmac 0.12.1",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
+ "rand 0.8.6",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -3287,6 +3371,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libappindicator"
@@ -3370,6 +3457,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -3670,6 +3763,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3722,6 +3831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4040,6 +4150,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4113,6 +4247,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -4228,6 +4371,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4337,6 +4491,15 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -4679,6 +4842,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4719,6 +4892,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5010,6 +5203,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secret-service"
@@ -5359,6 +5566,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 

--- a/crates/lux-auth/Cargo.toml
+++ b/crates/lux-auth/Cargo.toml
@@ -12,6 +12,11 @@ publish = false
 workspace = true
 
 [dependencies]
-jsonwebtoken = "10"
+# jsonwebtoken 10 ships no crypto backend in its default features, so a build
+# without one compiles but panics on the first signature verify ("Could not
+# automatically determine the process-level CryptoProvider"). rust_crypto is
+# the pure-Rust backend (rsa + sha2 cover our RS256) — no C, no musl-static
+# linking risk on the Lambda.
+jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/crates/lux-auth/src/lib.rs
+++ b/crates/lux-auth/src/lib.rs
@@ -94,3 +94,110 @@ impl Verifier {
         Ok(data.claims)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde::Serialize;
+
+    const KID: &str = "test-key";
+    const ISSUER: &str = "https://cognito-idp.us-west-1.amazonaws.com/us-west-1_test";
+    const CLIENT_ID: &str = "test-client";
+
+    // A throwaway 2048-bit RSA keypair, for this test only.
+    const PRIVATE_PEM: &[u8] = b"-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCuCAG4yH4kvTeh
+MkF84jX4Q1RgR28rEbwHG0nbnVCKNtRKsD1DijWjvoXxcLPpLmCBixF6GmyHQ8j1
+tSJH5T6HSke/9mgSBnfrkpykIks/LKGJ1/6ox8h9DntfHf6z5uLUvg5geYIyXeg0
+6uOxQaaDSQSpOxHzT7VoGLiZCfG/+FwdLQCMOi0bRRxfBo53rBvCJTP8ZgJX3YSK
+I8Xj0NLQGZTnb1amI9HIqpxMfWRhPRpAy6kgGEai1WiMdAnDHvDxWNm5vl0rGBzB
+eNHhEMEsyIBTsWMs3biNGdt2rb6qDNa3HouPApuuMPLpNm7W1fvxZ7Gghrl2ehK9
+SYw1PoLzAgMBAAECggEAJesxsNjif0/JGLLSCQti1gKZllbKNpipHuVHvPW0cEEN
+FW78EkTBdjmThq1XTfXgailqd+/c+MYAueSrIP4mlyTMqFtghpjpNSdfQPYF7jBj
+zByHbLAHE5R9thZbgkhK4S6+BDBFeYLzjuAlF2CmDtHwlYz81sZl0NYeFp5PkdOH
+6nPLbD9CRPfvEB1A/QpHU/DD1/3T8/tDBO392mJKsVxzpG62r4MTr4sP+zyKqnaj
+tCO7XxkQUkOwv41JXJKLnUz6SNlSW8vz76qNcRIzccHLWrLtiIW2ZiR6fhF8lFHe
+7//HZXANIbdAs+Imao/S7ekWui4wypktYaa/tvnMjQKBgQDd0HFAFPXLlNKI7l4s
+sFDVBJ7nqr0G6s1cC+eJbPOVOoy7e+BSCzOp5ivk6YJjJx1yK0tmV5oqxQX17OaO
+5aqZOvTLRa5ck5WCl3Q+7mSxs3FpexH6l+SHVtZGLKAoOKwGekF0sJOMgFJO7HXJ
+bqLJni1UJTjkbnCMJJ+Q0PFnvwKBgQDI2lB99kOudVBcNCMD5QEcX33bpaqrGFCH
+JgDhkpZDVhVMNsONpCqNU7j2nNVEvjgbat/VcdAYGIF4dp90QJHpQxYonPZ/DWps
+IeNHuH5syfdYBdcrNP4WgthD0xNbluJPbcji9soofQp5uqMvdMyGNH/Z0KjlnAOJ
+ymJoXKVRzQKBgQDE0pX7X93vBKKAgMst6lH/gzchqF5NCgKpf6K3Tecibq68GiKl
+im0QgD5IxG8/XlEBoqsoJ+mTs/ojC1BWUjK7/xWCXdVnLkoHdC7hPJY7HFgxWdRN
+QYS2FvbRk/2VUxxKLydvzNNQY/klMSsfTz3Bm8rrFJBUGi9iG4k/bjgXbwKBgB+S
+oeCLG6yK6Gz2DSMJlpkdMa2bZy6qDc6Q3MaYwmInYAWw/iB/0+iPZp3tnWDG/g7h
+R/pHf8yp3YBQNVSS6dzfHNaZhe4G79m7ofyeNdFoFieSE3bJR7/GJbTTs1FMcJrH
+yTJUVQb0UPc9rXVCSPw3uHlG4aXmVnAMjleVaK9pAoGBANxk8XLmvRZoVoNKuUGZ
+f2GOeMvrbEBLrzaSDN3mGx1dxBisaYl6P6XeKsq8cO+Y5sq+D5gzm26aIxxn/e8e
+DZ9X7qMu4asofS1OhFYEzHASk/xQxzHWfQ4GElRg/DxZJv2Md3RmVPKVx8N8+Vw7
+p6mW1b1y0a1+HBXK3Q29CgPg
+-----END PRIVATE KEY-----
+";
+    const PUBLIC_PEM: &[u8] = b"-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArggBuMh+JL03oTJBfOI1
++ENUYEdvKxG8BxtJ251QijbUSrA9Q4o1o76F8XCz6S5ggYsRehpsh0PI9bUiR+U+
+h0pHv/ZoEgZ365KcpCJLPyyhidf+qMfIfQ57Xx3+s+bi1L4OYHmCMl3oNOrjsUGm
+g0kEqTsR80+1aBi4mQnxv/hcHS0AjDotG0UcXwaOd6wbwiUz/GYCV92EiiPF49DS
+0BmU529WpiPRyKqcTH1kYT0aQMupIBhGotVojHQJwx7w8VjZub5dKxgcwXjR4RDB
+LMiAU7FjLN24jRnbdq2+qgzWtx6LjwKbrjDy6TZu1tX78WexoIa5dnoSvUmMNT6C
+8wIDAQAB
+-----END PUBLIC KEY-----
+";
+
+    #[derive(Serialize)]
+    struct TestClaims {
+        sub: String,
+        token_use: String,
+        iss: String,
+        aud: String,
+        exp: usize,
+    }
+
+    fn verifier() -> Verifier {
+        Verifier {
+            keys: HashMap::from([(
+                KID.to_string(),
+                DecodingKey::from_rsa_pem(PUBLIC_PEM).unwrap(),
+            )]),
+            issuer: ISSUER.to_string(),
+            client_id: CLIENT_ID.to_string(),
+        }
+    }
+
+    fn sign(token_use: &str) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(KID.to_string());
+        let claims = TestClaims {
+            sub: "user-123".to_string(),
+            token_use: token_use.to_string(),
+            iss: ISSUER.to_string(),
+            aud: CLIENT_ID.to_string(),
+            exp: 4_102_444_800, // 2100-01-01
+        };
+        encode(
+            &header,
+            &claims,
+            &EncodingKey::from_rsa_pem(PRIVATE_PEM).unwrap(),
+        )
+        .unwrap()
+    }
+
+    // Regression guard: jsonwebtoken 10 ships no crypto backend in its default
+    // features, so without `rust_crypto` this verify panics ("Could not
+    // determine the process-level CryptoProvider") — which is exactly how the
+    // sync API and IoT authorizer 500'd on every authenticated request.
+    #[test]
+    fn verifies_a_valid_id_token() {
+        let claims = verifier()
+            .verify(&sign("id"))
+            .expect("a well-formed ID token verifies");
+        assert_eq!(claims.sub, "user-123");
+    }
+
+    #[test]
+    fn rejects_a_non_id_token() {
+        assert!(verifier().verify(&sign("access")).is_err());
+    }
+}


### PR DESCRIPTION
## What

`jsonwebtoken` 10 ships **no crypto backend in its default features** (`default = ["use_pem"]`), so `lux-auth` — the Cognito verifier shared by the sync API and the IoT nudge authorizer — compiled but **panicked on the first RS256 verify at runtime**:

```
Could not automatically determine the process-level CryptoProvider ...
make sure exactly one of the 'rust_crypto' and 'aws_lc_rs' features is enabled.
```

Every **authenticated** request 500'd; **unauthenticated** ones still returned a clean typed 401. That asymmetry is why the release smoke test (a no-auth 401 check) never caught it — and why cloud sync showed offline on desktop and mobile and the nudge WebSocket kept dropping ("Connection closed by peer abruptly").

Confirmed from the `lux-sync-api` CloudWatch logs (`panicked at jsonwebtoken-10.4.0/src/crypto/mod.rs:125`).

## Fix

Enable jsonwebtoken's pure-Rust `rust_crypto` backend in `lux-auth` (`rsa` + `sha2` cover our RS256 — no C, no musl-static linking risk on the Lambda), and add a `lux-auth` test that signs and verifies a real RS256 token. That test **panics without a crypto backend and passes with one**, so it guards the exact regression at the verify seam.

## Note on the smoke gap

The deploy smoke checks the sync API returns a typed 401 unauthenticated; it can't practically exercise the authenticated crypto path without a real Cognito token, so the new unit test is the guard. Reaches prod on the next release (deploy-lambdas rebuilds all three functions from the tag).
