### PR TITLE
ci: fail clippy on warnings, and fix the ones that slipped through

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -212,10 +212,10 @@ jobs:
       # Lint gate: deny-level workspace lints fail this step (notably
       # clippy::unwrap_used — production code must not unwrap; see
       # [workspace.lints] in the root Cargo.toml). Default targets only, so
-      # test code keeps idiomatic unwraps; warn-level lints stay visible
-      # without blocking.
+      # test code keeps idiomatic unwraps. `-D warnings` fails the build on any
+      # warning, so clippy's default-warn lints can't slip through unnoticed.
       - name: cargo clippy
-        run: cargo clippy --workspace --locked
+        run: cargo clippy --workspace --locked -- -D warnings
 
       - name: sccache stats
         if: ${{ always() }}

--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -318,7 +318,6 @@ async fn pull_and_push(app: &AppHandle) {
     ) else {
         return;
     };
-    drop(account);
 
     let different_account = app
         .state::<LuxSetups>()

--- a/apps/desktop/src-tauri/src/devices/enttec_open_dmx_usb.rs
+++ b/apps/desktop/src-tauri/src/devices/enttec_open_dmx_usb.rs
@@ -129,15 +129,6 @@ impl EnttecOpenDMX {
         }
     }
 
-    /// Allows to set the value of a specific DMX channel. For the channel only values lower than 513 are allowed or the code will `panic!`
-    pub fn _set_channel(&mut self, channel: usize, value: u8) {
-        if channel < 513 {
-            self.buffer.0[channel] = value;
-        } else {
-            panic!("invalid channel: {}", channel);
-        }
-    }
-
     /// Allows too set the whole state of the universe at once.
     #[allow(dead_code)]
     pub fn set_buffer(&mut self, buf: [u8; BUF_SIZE]) {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -92,7 +92,10 @@ where
     R: tauri::Runtime,
     F: FnOnce(&tauri::App<R>) + Send + 'static,
 {
-    builder.setup(move |app| Ok(setup(app)))
+    builder.setup(move |app| {
+        setup(app);
+        Ok(())
+    })
 }
 
 pub fn ttipc_bindings() -> ttipc::Bindings {

--- a/apps/desktop/src-tauri/src/nudge.rs
+++ b/apps/desktop/src-tauri/src/nudge.rs
@@ -96,7 +96,6 @@ pub fn start(app: &AppHandle) {
             } else {
                 account.current_id_token()
             };
-            drop(account);
             let Some(token) = token else { return };
             let Some(sub) = jwt_sub(&token) else {
                 log::warn!(

--- a/apps/desktop/src-tauri/src/sync.rs
+++ b/apps/desktop/src-tauri/src/sync.rs
@@ -36,7 +36,7 @@ impl SyncMethods for SyncEndpoint {
         log::trace!("sync_state");
         SyncEndpoint.sync_buffer(app_handle.clone())?;
         SyncEndpoint.sync_channels(app_handle)?;
-        let msg = format!("State synced!");
+        let msg = "State synced!".to_string();
         log::trace!("{:?}", msg);
         Ok(msg)
     }

--- a/services/iot-authorizer/src/main.rs
+++ b/services/iot-authorizer/src/main.rs
@@ -60,9 +60,9 @@ async fn main() -> Result<(), Error> {
     // default before the JWKS fetch below performs any TLS.
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let pool_id = env("COGNITO_USER_POOL_ID");
-    let client_id = env("COGNITO_APP_CLIENT_ID");
-    let region = env("COGNITO_REGION");
+    let pool_id = env("COGNITO_USER_POOL_ID")?;
+    let client_id = env("COGNITO_APP_CLIENT_ID")?;
+    let region = env("COGNITO_REGION")?;
 
     let verifier = lux_auth::Verifier::new(&region, &pool_id, &client_id)
         .await
@@ -75,8 +75,8 @@ async fn main() -> Result<(), Error> {
     .await
 }
 
-fn env(key: &str) -> String {
-    std::env::var(key).unwrap_or_else(|_| panic!("{key} must be set"))
+fn env(key: &str) -> Result<String, Error> {
+    std::env::var(key).map_err(|_| format!("missing required env var {key}").into())
 }
 
 fn authorize(verifier: &lux_auth::Verifier, event: LambdaEvent<Value>) -> Value {

--- a/services/sync-api/src/main.rs
+++ b/services/sync-api/src/main.rs
@@ -55,10 +55,10 @@ async fn main() -> Result<(), Error> {
     // default before the JWKS fetch below performs any TLS.
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let pool_id = env("COGNITO_USER_POOL_ID");
-    let client_id = env("COGNITO_APP_CLIENT_ID");
-    let region = env("COGNITO_REGION");
-    let table = env("DYNAMODB_TABLE");
+    let pool_id = env("COGNITO_USER_POOL_ID")?;
+    let client_id = env("COGNITO_APP_CLIENT_ID")?;
+    let region = env("COGNITO_REGION")?;
+    let table = env("DYNAMODB_TABLE")?;
 
     let verifier = lux_auth::Verifier::new(&region, &pool_id, &client_id)
         .await
@@ -101,8 +101,8 @@ async fn main() -> Result<(), Error> {
     .await
 }
 
-fn env(key: &str) -> String {
-    std::env::var(key).unwrap_or_else(|_| panic!("{key} must be set"))
+fn env(key: &str) -> Result<String, Error> {
+    std::env::var(key).map_err(|_| format!("missing required env var {key}").into())
 }
 
 async fn handle(ctx: Arc<Ctx>, req: Request) -> Result<Response<Body>, Error> {


### PR DESCRIPTION
The `cargo clippy` step ran without `-D warnings`, so only the workspace's deny-level lints (`unwrap_used`) failed the build — clippy's default warn-level lints (`useless_format`, `unit_arg`, `drop_non_drop`, `panic`) just printed to the log and passed.

Adds `-D warnings` to the step, and fixes the seven warnings that had accumulated — no suppressions:

- **Lambda `env()` helpers** read required config via `panic!` — now return an error and `?`-propagate (`main` already returns `Result`), so a missing var fails cold-start init cleanly instead of crashing.
- **`drop(account)`** calls removed — `State` isn't `Drop`, and the borrows end at scope regardless; confirmed the following awaits don't need the early release.
- **dead `_set_channel`** (unused, `_`-prefixed, panicking) deleted.
- `format!("literal")` → `.to_string()`; unit-arg in the `setup` wrapper.

`cargo clippy --workspace --locked -- -D warnings` is clean and `cargo test --workspace` passes.
