### PR TITLE
ci: freeze bun installs, add terraform workflow concurrency

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           bun-version-file: apps/desktop/package.json
 
-      - run: bun install
+      - run: bun install --frozen-lockfile
 
       - name: check @tauri-apps JS <-> crate version match
         run: bun run check:tauri-versions
@@ -99,7 +99,7 @@ jobs:
         with:
           bun-version-file: apps/desktop/package.json
 
-      - run: bun install
+      - run: bun install --frozen-lockfile
 
       # vite build emits the production bundle and the gitignored
       # routeTree.gen.ts that the typecheck depends on, so it runs first and
@@ -183,7 +183,7 @@ jobs:
       - name: Build frontend (for generate_context!)
         working-directory: apps/desktop
         run: |
-          bun install
+          bun install --frozen-lockfile
           bun run build
 
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
@@ -231,6 +231,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - run: bun install
+      - run: bun install --frozen-lockfile
       - run: bun run --cwd apps/site typecheck
       - run: bun run --cwd apps/site build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
         with:
           workspaces: "."
 
-      - run: bun install
+      - run: bun install --frozen-lockfile
         working-directory: apps/desktop
 
       # Pull the updater signing key from AWS Secrets Manager via OIDC — no

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - run: bun install
+      - run: bun install --frozen-lockfile
 
       - run: bun run --cwd apps/site build
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- `bun install --frozen-lockfile` at all six CI install sites (desktop x4, release, site) -- lockfile drift now fails loudly instead of resolving fresh
- `terraform.yml` gets per-ref `cancel-in-progress` concurrency, matching the other validation workflows

`ci:` prefix, non-releasable.