### PR TITLE
ci: cargo-deny gate with the FTDI license clarified

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -64,6 +64,20 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  deny:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # The deny action is a musl docker container; keep the workspace's
+      # sccache wrapper out of it.
+      RUSTC_WRAPPER: ""
+      SCCACHE_GHA_ENABLED: "false"
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check advisories bans licenses sources
+
   tauri-versions:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,7 +1695,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1974,7 +1974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3279,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1daef93704e6f6506d5b273175189bf8a5e00371930387fb77fd871e15c0d94"
+checksum = "f6ee8d4dae108d4177d0a0ce241f98acc1ef28e20837bdef43cff4d160cf70fe"
 dependencies = [
  "apple-native-keyring-store",
  "keyring-core",
@@ -3705,7 +3705,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3851,7 +3851,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -4126,7 +4126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4974,7 +4974,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5053,7 +5053,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5633,7 +5633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6312,10 +6312,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6751,7 +6751,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6799,7 +6799,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7217,7 +7217,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,8 @@ description = "A DMX lighting control system for Enttec Open DMX USB and sACN/E1
 authors = ["John Carmack"]
 edition = "2021"
 repository = "https://github.com/johncarmack1984/lux"
-license = "GNU GPLv3"
+license = "GPL-3.0-only"
+publish = false
 readme = "../../../README.md"
 
 [lib]

--- a/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
@@ -400,7 +400,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncarmack.lux;
-				PRODUCT_NAME = lux;
+				PRODUCT_NAME = "lux";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;
@@ -490,7 +490,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncarmack.lux;
-				PRODUCT_NAME = lux;
+				PRODUCT_NAME = "lux";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,96 @@
+# seeds/tooling canonical copy-source — refresh here first, then propagate.
+# cargo-deny config. Schema version 2.
+# Run: cargo deny check advisories bans licenses sources
+
+[graph]
+# Check the full target matrix the crates actually support.
+all-features = true
+
+[advisories]
+# version 2: vulnerabilities are always denied. Tune via `ignore` only.
+db-urls = ["https://github.com/RustSec/advisory-db"]
+# Flag unmaintained crates in our own tree; ignore deep transitive noise
+# we cannot act on.
+unmaintained = "workspace"
+yanked = "deny"
+ignore = [
+    # rsa's Marvin timing sidechannel, via jsonwebtoken -> lux-auth. The
+    # Lambdas only VERIFY Cognito JWTs (public-key ops); no private-key RSA
+    # runs here. No fixed rsa release exists.
+    { id = "RUSTSEC-2023-0071", reason = "verification-only rsa usage; no fixed release" },
+    # The legacy rustls-0.21/webpki-0.101 branch that aws-smithy-http-client
+    # (latest) still carries via hyper-rustls's acceptor feature. Never
+    # executed: the SDK's runtime client is the rustls-0.23/webpki-0.103 line,
+    # which is patched in this lockfile. No fixed 0.101 releases exist.
+    { id = "RUSTSEC-2026-0049", reason = "legacy aws-smithy rustls edge, unused at runtime" },
+    { id = "RUSTSEC-2026-0098", reason = "legacy aws-smithy rustls edge, unused at runtime" },
+    { id = "RUSTSEC-2026-0099", reason = "legacy aws-smithy rustls edge, unused at runtime" },
+    { id = "RUSTSEC-2026-0104", reason = "legacy aws-smithy rustls edge, unused at runtime" },
+]
+
+[licenses]
+# Permissive set verified satisfiable across the estate's current Rust trees
+# (via cargo-deny). Extend deliberately, with the license named here, when a
+# new dep needs it — never silence the check.
+allow = [
+    "LicenseRef-FTDI-D2XX", # FTDI proprietary driver terms; see clarify above
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Unicode-3.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "0BSD",
+    "MPL-2.0",
+    "Unlicense",
+    "CC0-1.0",
+    # webpki-roots / webpki-root-certs ship Mozilla's CA store under this
+    # permissive data license; any tree with rustls-platform-verifier (reqwest)
+    # carries it.
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.8
+# Private, unpublished workspace crates carry no license field by design; skip
+# them instead of licensing what never ships. Pair with `publish = false` in
+# each private crate's Cargo.toml — cargo-deny only treats marked crates as
+# private.
+private = { ignore = true }
+exceptions = [
+    # Per-crate license carve-outs go here if a crate needs a license not in
+    # the global allow list, e.g.:
+    # { allow = ["..."], crate = "some-crate" },
+]
+
+# libftd2xx-ffi ships FTDI's proprietary D2XX driver terms as a LICENSE file
+# with no SPDX expression. The Enttec OpenDMX hardware this app exists for
+# requires that driver -- "we've got the hardware we've got" (owner ruling,
+# 2026-07-07). Clarified to a LicenseRef and allowed in the list above.
+[[licenses.clarify]]
+name = "libftd2xx-ffi"
+expression = "LicenseRef-FTDI-D2XX"
+license-files = [{ path = "LICENSE", hash = 0x0d4f9606 }]
+
+[bans]
+# Duplicate versions are common in a large tree (tauri especially); surface
+# them without failing the build.
+multiple-versions = "warn"
+wildcards = "warn"
+# Path and git deps in our own workspace use version pins, not registry
+# wildcards; do not flag them.
+allow-wildcard-paths = true
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+# John's own gtk-rs-core patch branch (the glib 0.18 fix feeding the
+# tao/muda gtk4 campaign) is the one sanctioned git dependency.
+
+# Only crates.io by default; flag anything else for review.
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = ["https://github.com/johncarmack1984/gtk-rs-core"]


### PR DESCRIPTION
Closes the last deferred deny gate. `deny.toml` carries the libftd2xx-ffi clarify (FTDI's proprietary D2XX terms as `LicenseRef-FTDI-D2XX` -- the Enttec hardware requires that driver; ruling recorded with date), reasoned advisory ignores (rsa Marvin via the JWT verifier is verification-only; the legacy aws-smithy rustls-0.21 edge is unused at runtime, same posture as vegify/orrery), and the sanctioned gtk-rs-core git source. Rider fixes: the lux crate's `license` field becomes valid SPDX (`GPL-3.0-only`) + `publish = false`, and keyring moves off a yanked patch (4.1.3 -> 4.1.4). All four deny checks green locally; wire tests green.