### PR TITLE
ci: build and upload the iOS app to TestFlight on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,16 @@ name: release
 
 # release-please maintains a release PR (version bump + CHANGELOG) from
 # conventional-commit history. Merging it cuts a vX.Y.Z tag + GitHub Release,
-# which triggers the macOS build to attach the .dmg. The build is also runnable
-# on demand for an existing tag via workflow_dispatch.
+# which triggers the macOS build to attach the .dmg and the iOS build to ship
+# the release to TestFlight. Both are also runnable on demand for an existing
+# tag via workflow_dispatch.
 on:
   push:
     branches: [main]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag to build and attach the macOS bundle to (e.g. v0.1.0)"
+        description: "Existing release tag to build the Apple artifacts for: attaches the macOS bundle, re-uploads iOS to TestFlight (e.g. v0.1.0)"
         required: true
 
 permissions: {}
@@ -485,4 +486,183 @@ jobs:
             -f state=success -f environment=backend  \
             -f description="Lambdas deployed + smoked for $TAG" >/dev/null
           echo "recorded backend deployment $id ($TAG)"
+
+  # Builds and signs the iOS App Store .ipa and stages it as a workflow
+  # artifact — in parallel with the backend (terraform + Lambdas), since a
+  # staged artifact touches nothing. The ASC UPLOAD is deliberately deferred
+  # to publish-ios: TestFlight has no draft state, so the upload itself is the
+  # publish, and it must wait behind the same gates that hold back the macOS
+  # artifacts. The .ipa is an artifact leaf like build-macos — its failure
+  # never blocks the backend, and a re-run/dispatch rebuilds it safely
+  # (publish-ios tolerates Apple's duplicate rejection).
+  #
+  # Signing is Xcode automatic/cloud signing: the ASC API key + team id from
+  # the shared lux/apple-signing secret let xcodebuild mint the App Store
+  # distribution cert + profile on the fly — no .p12 and no provisioning
+  # profile enter the runner. CFBundleShortVersionString/CFBundleVersion are
+  # restamped from tauri.conf.json's version (release-please bumps it), so
+  # every release is a unique TestFlight build string with no injection step.
+  build-ios:
+    needs: [release-please, ci]
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (needs.release-please.outputs.release_created == 'true' && needs.ci.result == 'success')) }}
+    runs-on: macos-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write # AWS OIDC, to read the Apple signing secret
+    env:
+      TAG: ${{ github.event.inputs.tag || needs.release-please.outputs.tag_name }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Select the newest Xcode 26 (App Store Connect requires the iOS 26 SDK)
+        # macos-latest still DEFAULTS to Xcode 16.4 / iOS 18.5 SDK, which ASC
+        # rejects at upload (altool 409: "must be built with the iOS 26 SDK or
+        # later"). The image ships several 26.x versions; pick the newest
+        # present so image updates keep working without edits here.
+        run: |
+          set -euo pipefail
+          xcode=$(find /Applications -maxdepth 1 -name 'Xcode_26*.app' | sort -V | tail -n1)
+          sudo xcode-select -s "$xcode"
+          echo "selected $xcode"
+          xcodebuild -version
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: apps/desktop/package.json
+
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          targets: aarch64-apple-ios
+
+      # rust-cache only, no sccache: the Rust compile runs inside Xcode's
+      # "Build Rust Code" script phase, where the GHA cache credentials
+      # sccache's backend needs are one env-propagation hop too fragile.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: "."
+
+      - run: bun install --frozen-lockfile
+        working-directory: apps/desktop
+
+      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6
+        with:
+          role-to-assume: arn:aws:iam::735853783919:role/lux-release-signing
+          aws-region: us-west-1
+
+      - name: Load Apple signing secret (ASC API key for cloud signing)
+        # Same lux/apple-signing JSON build-macos uses, but iOS App Store
+        # signing needs only the ASC API key + team id. `tauri ios build`
+        # reads the team from APPLE_DEVELOPMENT_TEAM (NOT APPLE_TEAM_ID, which
+        # is tauri-action's macOS-notarization var); the API key rides in as
+        # APPLE_API_KEY/APPLE_API_KEY_ID + APPLE_API_ISSUER + APPLE_API_KEY_PATH.
+        run: |
+          s=$(aws secretsmanager get-secret-value --secret-id lux/apple-signing --query SecretString --output text)
+          {
+            echo "APPLE_DEVELOPMENT_TEAM=$(printf '%s' "$s" | jq -r '.team_id')"
+            echo "APPLE_API_ISSUER=$(printf '%s' "$s" | jq -r '.api_issuer_id')"
+            echo "APPLE_API_KEY=$(printf '%s' "$s" | jq -r '.api_key_id')"
+            echo "APPLE_API_KEY_ID=$(printf '%s' "$s" | jq -r '.api_key_id')"
+          } >> "$GITHUB_ENV"
+          printf '%s' "$s" | jq -r '.api_key' > "$RUNNER_TEMP/asc_api_key.p8"
+          echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/asc_api_key.p8" >> "$GITHUB_ENV"
+
+      - name: Build + export the App Store .ipa
+        working-directory: apps/desktop
+        run: |
+          set -euo pipefail
+          bun run tauri ios build --export-method app-store-connect
+          ipa=$(find src-tauri/gen/apple/build -name '*.ipa' | head -1)
+          test -n "$ipa" || { echo "::error::tauri ios build produced no .ipa"; exit 1; }
+          # Prove which identity actually signed the shipped app: tauri's
+          # interim codesign uses a placeholder ("Apple Distribution: Tauri
+          # (unset)") that the App Store export re-signs with the
+          # cloud-managed distribution identity.
+          unzip -qo "$ipa" -d "$RUNNER_TEMP/ipa-inspect"
+          codesign -dvv "$RUNNER_TEMP/ipa-inspect/Payload/"*.app 2>&1 | grep -E 'Authority|TeamIdentifier' \
+            || echo "::warning::could not read the ipa's code signature"
+          cp "$ipa" "$RUNNER_TEMP/lux.ipa"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ios-ipa
+          path: ${{ runner.temp }}/lux.ipa
+          retention-days: 1
+
+  # The .ipa already exists (build-ios staged it) — "publishing" is the altool
+  # push to App Store Connect. Gated on build-macos succeeding, which on the
+  # release path already sits behind deploy-lambdas + its smokes: TestFlight
+  # has no draft state, so this sequencing is what keeps a release whose
+  # backend or desktop didn't ship away from testers. On a workflow_dispatch
+  # rebuild the same order holds, and an already-uploaded build lands in the
+  # duplicate-tolerant path below.
+  publish-ios:
+    needs: [release-please, build-ios, build-macos]
+    if: ${{ always() && needs.build-ios.result == 'success' && needs.build-macos.result == 'success' }}
+    runs-on: macos-latest # xcrun altool is Apple's uploader — macOS only (the default Xcode is fine for uploads)
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write # AWS OIDC, to read the ASC API key
+      deployments: write # record the TestFlight publish (API, not environment: — see the record step)
+    env:
+      TAG: ${{ github.event.inputs.tag || needs.release-please.outputs.tag_name }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ios-ipa
+          path: ${{ runner.temp }}
+
+      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6
+        with:
+          role-to-assume: arn:aws:iam::735853783919:role/lux-release-signing
+          aws-region: us-west-1
+
+      - name: Load the ASC API key (upload credential)
+        run: |
+          s=$(aws secretsmanager get-secret-value --secret-id lux/apple-signing --query SecretString --output text)
+          {
+            echo "APPLE_API_ISSUER=$(printf '%s' "$s" | jq -r '.api_issuer_id')"
+            echo "APPLE_API_KEY=$(printf '%s' "$s" | jq -r '.api_key_id')"
+          } >> "$GITHUB_ENV"
+          printf '%s' "$s" | jq -r '.api_key' > "$RUNNER_TEMP/asc_api_key.p8"
+
+      - name: Upload to TestFlight (duplicate-tolerant for re-runs)
+        run: |
+          set -euo pipefail
+          # altool discovers the key as AuthKey_<keyid>.p8 under ~/.appstoreconnect/private_keys.
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          cp "$RUNNER_TEMP/asc_api_key.p8" "$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY}.p8"
+          rc=0
+          out=$(xcrun altool --upload-app --type ios --file "$RUNNER_TEMP/lux.ipa" \
+            --apiKey "$APPLE_API_KEY" --apiIssuer "$APPLE_API_ISSUER" 2>&1) || rc=$?
+          echo "$out"
+          if [ "$rc" -ne 0 ]; then
+            # A dispatch re-run of a tag whose build may already be on ASC —
+            # Apple rejects the duplicate, and that rejection IS the desired
+            # end state, not a failure.
+            echo "$out" | grep -qiE 'already been uploaded|already exists|redundant binary|previously uploaded' \
+              && { echo "build already on App Store Connect — treating as published"; exit 0; }
+            exit "$rc"
+          fi
+
+      # Record what is live in the repo's Deployments view. Done via the API,
+      # NOT a job-level `environment:` key — that key rewrites the OIDC subject
+      # to repo:…:environment:…, which the role trusts (pinned to the main ref)
+      # would reject, breaking the AWS credentials above.
+      - name: Record TestFlight deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ env.TAG }}
+        run: |
+          set -euo pipefail
+          body=$(jq -nc --arg ref "$GITHUB_SHA" --arg desc "$TAG" \
+            '{ref:$ref, environment:"testflight", production_environment:true, auto_merge:false, required_contexts:[], description:$desc}')
+          id=$(gh api -X POST "repos/$GITHUB_REPOSITORY/deployments" --input - <<<"$body" --jq '.id')
+          gh api -X POST "repos/$GITHUB_REPOSITORY/deployments/$id/statuses" \
+            -f state=success -f environment=testflight \
+            -f description="iOS build uploaded to TestFlight for $TAG" >/dev/null
+          echo "recorded testflight deployment $id ($TAG)"
 


### PR DESCRIPTION
Extends the release pipeline to ship each release to TestFlight, following the build-time-artifact model: the .ipa is built early and in parallel, but the upload — TestFlight's only publish step, since it has no draft state — waits behind the same gates as the macOS artifacts.

## New jobs

- **build-ios** (needs `release-please` + `ci`): selects the newest Xcode 26 (ASC rejects uploads built with older SDKs), builds and exports an App Store `.ipa` via `tauri ios build --export-method app-store-connect`, and stages it as a workflow artifact. Runs in parallel with `terraform-apply`/`deploy-lambdas` — a staged artifact touches nothing. Signing is Xcode automatic/cloud signing from the shared `lux/apple-signing` secret (ASC API key + team id, read via the existing `lux-release-signing` OIDC role); no .p12 or provisioning profile enters the runner. Versions need no injection step: `tauri ios build` restamps `CFBundleShortVersionString`/`CFBundleVersion` from `tauri.conf.json`, which release-please bumps, so every release is a unique TestFlight build string.
- **publish-ios** (needs `build-ios` + `build-macos`): uploads the staged `.ipa` with `xcrun altool`. Gating on `build-macos` — which on the release path already sits behind `deploy-lambdas` and its smokes — keeps a release whose backend or desktop didn't ship away from testers. The upload is duplicate-tolerant: a dispatch re-run of an already-uploaded tag treats Apple's duplicate rejection as the desired end state. Records a `testflight` deployment alongside the existing infra/backend/updater records.

`workflow_dispatch` for an existing tag now rebuilds both Apple artifacts; the iOS re-upload lands in the duplicate-tolerant path. The backend deploy is deliberately NOT gated on `build-ios` — the .ipa is an artifact leaf like the macOS build, so an iOS failure never blocks Lambdas or infra.

## Account-side prerequisites (satisfied)

The upload target exists and matches: the App Store Connect app record ("lux for dmx") is bound to `com.johncarmack.lux`, which is registered as an explicit App ID in the developer portal. Development builds ride the wildcard team profile, but App Store distribution requires the explicit App ID — cloud signing mints the distribution cert + profile against it on the fly.

No PR gate changes: the iOS compile is exercised only on the release path, keeping PR CI on ubuntu runners.