### PR TITLE
feat: show the app version in the footer

### DIFF
--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -34,6 +34,11 @@ function RootLayout() {
         </nav>
         <div className="flex flex-1 flex-col items-center overflow-y-auto">
           <Outlet />
+          {/* mt-auto: sits at the viewport bottom until the content is tall
+              enough to scroll, then trails it. */}
+          <footer className="mt-auto pb-3 pt-8 text-xs text-muted-foreground/70">
+            lux v{__APP_VERSION__}
+          </footer>
         </div>
       </div>
       <Toaster closeButton />

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -2,3 +2,6 @@
 
 // TypeScript 6 checks side-effect imports (TS2882); this package ships only CSS.
 declare module "@fontsource-variable/inter";
+
+// Compile-time constant from the `define` in vite.config.ts.
+declare const __APP_VERSION__: string;

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -3,6 +3,7 @@ import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
+import pkg from "./package.json";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -11,6 +12,10 @@ export default defineConfig({
     react(), babel({ presets: [reactCompilerPreset()] }),
     tailwindcss(),
   ],
+  // The release-please-stamped version (kept in lockstep with tauri.conf.json),
+  // baked in at build time: no IPC, so it renders even where the window
+  // capability excludes core:app (iOS).
+  define: { __APP_VERSION__: JSON.stringify(pkg.version) },
   // Vite 8 resolves tsconfig `paths` (the @/* alias) natively.
   resolve: { tsconfigPaths: true },
   // Tauri controls the window; keep its logs visible and don't watch the Rust side.


### PR DESCRIPTION
Adds a muted `lux vX.Y.Z` footer to the app shell — the first in-app version indicator, ahead of TestFlight distribution where testers report against build versions.

The version is baked in at build time from `package.json` via a Vite `define` (release-please keeps it in lockstep with `tauri.conf.json` and `Cargo.toml`), so there's no IPC involved and the string renders even on platforms whose window capability excludes `core:app` (iOS). The footer sits inside the scroll container with `mt-auto`: at the viewport bottom until the content is tall enough to scroll, trailing it after.