### PR TITLE
build: Mac App Store flavor (sandboxed, TestFlight-uploadable)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ dist
 
 .terraform/
 
+# Mac App Store provisioning profile (machine-local; regenerate from the ASC
+# "lux Mac App Store" profile)
+apps/desktop/src-tauri/mas/
+
 # Claude Code — local working notes, not for the public repo
 CLAUDE.md
 .claude/

--- a/apps/desktop/src-tauri/Entitlements.mas.plist
+++ b/apps/desktop/src-tauri/Entitlements.mas.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!-- Mac App Store build entitlements (the MAS flavor only — see tauri.mas.json).
+     The Developer ID .dmg build stays unsandboxed; TestFlight/App Store builds
+     must be sandboxed, and the identifier entitlements must match the embedded
+     Mac App Store provisioning profile. -->
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<!-- Outbound: sACN/Art-Net UDP, AWS (Cognito/sync/IoT-WSS). -->
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<!-- Listeners: Art-Net ArtPollReply discovery responses. -->
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<!-- The Enttec OpenDMX USB interface (FTDI, userspace via IOKit). -->
+	<key>com.apple.security.device.usb</key>
+	<true/>
+	<key>com.apple.application-identifier</key>
+	<string>T3UN6N5K6Z.com.johncarmack.lux</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>T3UN6N5K6Z</string>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>T3UN6N5K6Z.com.johncarmack.lux</string>
+	</array>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -9,10 +9,17 @@
   behind a TCC prompt. lux needs it to discover (Art-Net ArtPoll) and drive
   (sACN/E1.31 multicast) DMX nodes like the DMXKing eDMX1 Pro. Without this key
   the prompt can fail to appear and sACN output is silently blocked.
+
+  ITSAppUsesNonExemptEncryption: only standard-exempt TLS (rustls) — answers
+  App Store Connect's export-compliance question up front for Mac App Store /
+  TestFlight uploads (same declaration the iOS target makes in
+  gen/apple/project.yml). Inert in the Developer ID .dmg build.
 -->
 <plist version="1.0">
   <dict>
     <key>NSLocalNetworkUsageDescription</key>
     <string>lux discovers and controls DMX lighting nodes (Art-Net / sACN) on your local network.</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
   </dict>
 </plist>

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -35,6 +35,7 @@
   },
   "bundle": {
     "active": true,
+    "category": "public.app-category.utilities",
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",

--- a/apps/desktop/src-tauri/tauri.mas.json
+++ b/apps/desktop/src-tauri/tauri.mas.json
@@ -1,0 +1,17 @@
+{
+  "bundle": {
+    "targets": ["app"],
+    "createUpdaterArtifacts": false,
+    "macOS": {
+      "entitlements": "./Entitlements.mas.plist",
+      "files": {
+        "embedded.provisionprofile": "./mas/embedded.provisionprofile"
+      }
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": []
+    }
+  }
+}


### PR DESCRIPTION
Adds a Mac App Store build flavor alongside the Developer ID `.dmg` channel, proven by a successful TestFlight upload of v0.14.0 (macOS platform, same `com.johncarmack.lux` app record as iOS — the shared identifier is what enables universal purchase later).

## The flavor

`bun run tauri build --target universal-apple-darwin --config src-tauri/tauri.mas.json` produces a bare sandboxed `.app` (no `.dmg`, no updater artifacts), signed with the `Apple Distribution` identity and carrying the embedded Mac App Store provisioning profile; `xcrun productbuild --sign "3rd Party Mac Developer Installer: …"` wraps it into the uploadable `.pkg`.

- **`Entitlements.mas.plist`** — App Sandbox plus the capabilities lux actually uses: `network.client` (sACN/Art-Net UDP out, AWS), `network.server` (ArtPollReply discovery listener), `device.usb` (Enttec OpenDMX / FTDI), and the profile-matching identifier/keychain entitlements.
- **`tauri.mas.json`** — config merge: `targets: ["app"]`, `createUpdaterArtifacts: false`, entitlements + `embedded.provisionprofile` wiring, and `plugins.updater.endpoints: []` — store builds must not self-update, so the updater's startup check fails quietly (its error path is already caught). Compile-time removal of the plugin can follow when the flavor gets a CI leg.
- **`Info.plist`** — adds `ITSAppUsesNonExemptEncryption=false` (rustls-only, the same declaration the iOS target makes), answering the export-compliance question at upload time.
- **`tauri.conf.json`** — `bundle.category: public.app-category.utilities`; App Store Connect rejects Mac packages without `LSApplicationCategoryType` (error 90242). Inert in the `.dmg` build.
- **`.gitignore`** — `src-tauri/mas/` holds the machine-local provisioning profile (regenerate from the ASC "lux Mac App Store" profile).

## Not in this PR

CI automation (a `build-mas`/`publish-mas` pair in release.yml mirroring the iOS jobs) needs the MAS signing material available to the workflow and the compile-time updater removal; until then the flavor is a local/manual path.

## Signing prerequisites (account-side, already in place)

`Apple Distribution` + `3rd Party Mac Developer Installer` certificates (ASC ids AFL9G25JM5 / 28J7FAZ6V6) and the `MAC_APP_STORE` provisioning profile "lux Mac App Store" (3R34G5AB8G) for `com.johncarmack.lux`.