### PR TITLE
feat: ship Mac App Store builds to TestFlight on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,16 +2,17 @@ name: release
 
 # release-please maintains a release PR (version bump + CHANGELOG) from
 # conventional-commit history. Merging it cuts a vX.Y.Z tag + GitHub Release,
-# which triggers the macOS build to attach the .dmg and the iOS build to ship
-# the release to TestFlight. Both are also runnable on demand for an existing
-# tag via workflow_dispatch.
+# which triggers the macOS build to attach the .dmg and the iOS + Mac App
+# Store builds to ship the release to TestFlight (both platforms, one app
+# record). All are also runnable on demand for an existing tag via
+# workflow_dispatch.
 on:
   push:
     branches: [main]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag to build the Apple artifacts for: attaches the macOS bundle, re-uploads iOS to TestFlight (e.g. v0.1.0)"
+        description: "Existing release tag to build the Apple artifacts for: attaches the macOS bundle, re-uploads iOS + Mac App Store builds to TestFlight (e.g. v0.1.0)"
         required: true
 
 permissions: {}
@@ -665,4 +666,180 @@ jobs:
             -f state=success -f environment=testflight \
             -f description="iOS build uploaded to TestFlight for $TAG" >/dev/null
           echo "recorded testflight deployment $id ($TAG)"
+
+  # Builds the Mac App Store flavor and stages the installer-signed .pkg as a
+  # workflow artifact — the macOS sibling of build-ios. Unlike the iOS job
+  # there is no cloud signing here (this build doesn't go through Xcode): the
+  # Apple Distribution + Mac Installer identities come from the lux/mas-signing
+  # secret into an ephemeral keychain, tauri signs the sandboxed .app
+  # (Entitlements.mas.plist via tauri.mas.json; `--features mas` compiles the
+  # self-updater's registration out — store builds update through the store),
+  # and productbuild wraps the upload package. MAS packages are deliberately
+  # NOT notarized — App Store Connect ingestion does its own checks.
+  build-mas:
+    needs: [release-please, ci]
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (needs.release-please.outputs.release_created == 'true' && needs.ci.result == 'success')) }}
+    runs-on: macos-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write # AWS OIDC, to read the MAS signing secret
+    env:
+      TAG: ${{ github.event.inputs.tag || needs.release-please.outputs.tag_name }}
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.TAG }}
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: apps/desktop/package.json
+
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      # Same caching pair as build-macos: this flavor is a plain cargo build
+      # driven by the tauri CLI (no Xcode in the loop), so sccache applies.
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: "."
+
+      - run: bun install --frozen-lockfile
+        working-directory: apps/desktop
+
+      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6
+        with:
+          role-to-assume: arn:aws:iam::735853783919:role/lux-release-signing
+          aws-region: us-west-1
+
+      - name: Load MAS signing material into an ephemeral keychain
+        # lux/mas-signing JSON: {certificate, certificate_password,
+        # signing_identity, installer_certificate, installer_certificate_password,
+        # installer_identity, provisioning_profile} — p12s/profile base64.
+        # Passwords stay inside this step; only the identity names (public — they
+        # appear verbatim in every signature) go to GITHUB_ENV. The
+        # set-key-partition-list call is what lets codesign/productbuild use the
+        # keys without a UI prompt no runner could answer.
+        run: |
+          set -euo pipefail
+          s=$(aws secretsmanager get-secret-value --secret-id lux/mas-signing --query SecretString --output text)
+          keychain="$RUNNER_TEMP/mas-signing.keychain-db"
+          keychain_pw=$(openssl rand -base64 24)
+          security create-keychain -p "$keychain_pw" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_pw" "$keychain"
+          printf '%s' "$s" | jq -r '.certificate' | base64 -d > "$RUNNER_TEMP/mas-dist.p12"
+          printf '%s' "$s" | jq -r '.installer_certificate' | base64 -d > "$RUNNER_TEMP/mas-installer.p12"
+          security import "$RUNNER_TEMP/mas-dist.p12" -k "$keychain" \
+            -P "$(printf '%s' "$s" | jq -r '.certificate_password')" -T /usr/bin/codesign
+          security import "$RUNNER_TEMP/mas-installer.p12" -k "$keychain" \
+            -P "$(printf '%s' "$s" | jq -r '.installer_certificate_password')" -T /usr/bin/productbuild
+          rm -f "$RUNNER_TEMP/mas-dist.p12" "$RUNNER_TEMP/mas-installer.p12"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_pw" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain" login.keychain-db
+          mkdir -p apps/desktop/src-tauri/mas
+          printf '%s' "$s" | jq -r '.provisioning_profile' | base64 -d > apps/desktop/src-tauri/mas/embedded.provisionprofile
+          {
+            echo "APPLE_SIGNING_IDENTITY=$(printf '%s' "$s" | jq -r '.signing_identity')"
+            echo "MAS_INSTALLER_IDENTITY=$(printf '%s' "$s" | jq -r '.installer_identity')"
+          } >> "$GITHUB_ENV"
+
+      - name: Build the sandboxed .app and wrap the installer-signed .pkg
+        # APPLE_SIGNING_IDENTITY (tauri's signer) and MAS_INSTALLER_IDENTITY ride
+        # in from the load step via GITHUB_ENV.
+        working-directory: apps/desktop
+        run: |
+          set -euo pipefail
+          bun run tauri build --target universal-apple-darwin --features mas --config src-tauri/tauri.mas.json
+          app="$GITHUB_WORKSPACE/target/universal-apple-darwin/release/bundle/macos/lux.app"
+          # The one property that separates this flavor from the .dmg build —
+          # refuse to stage an unsandboxed package.
+          codesign -d --entitlements - "$app" 2>/dev/null | grep -q 'app-sandbox' \
+            || { echo "::error::built .app is not sandboxed — MAS flavor misconfigured"; exit 1; }
+          xcrun productbuild --sign "$MAS_INSTALLER_IDENTITY" \
+            --component "$app" /Applications "$RUNNER_TEMP/lux-mas.pkg"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mas-pkg
+          path: ${{ runner.temp }}/lux-mas.pkg
+          retention-days: 1
+
+      - name: sccache stats
+        if: ${{ always() }}
+        run: sccache --show-stats
+
+  # The macOS sibling of publish-ios: the .pkg already exists, "publishing" is
+  # the altool push to App Store Connect, behind the same build-macos gate (and
+  # transitively the backend deploys + smokes). Duplicate-tolerant so dispatch
+  # re-runs of an already-uploaded tag succeed.
+  publish-mas:
+    needs: [release-please, build-mas, build-macos]
+    if: ${{ always() && needs.build-mas.result == 'success' && needs.build-macos.result == 'success' }}
+    runs-on: macos-latest # xcrun altool is Apple's uploader — macOS only
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write # AWS OIDC, to read the ASC API key
+      deployments: write # record the TestFlight publish (API, not environment: — see the record step)
+    env:
+      TAG: ${{ github.event.inputs.tag || needs.release-please.outputs.tag_name }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mas-pkg
+          path: ${{ runner.temp }}
+
+      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6
+        with:
+          role-to-assume: arn:aws:iam::735853783919:role/lux-release-signing
+          aws-region: us-west-1
+
+      - name: Load the ASC API key (upload credential)
+        run: |
+          s=$(aws secretsmanager get-secret-value --secret-id lux/apple-signing --query SecretString --output text)
+          {
+            echo "APPLE_API_ISSUER=$(printf '%s' "$s" | jq -r '.api_issuer_id')"
+            echo "APPLE_API_KEY=$(printf '%s' "$s" | jq -r '.api_key_id')"
+          } >> "$GITHUB_ENV"
+          printf '%s' "$s" | jq -r '.api_key' > "$RUNNER_TEMP/asc_api_key.p8"
+
+      - name: Upload to TestFlight (duplicate-tolerant for re-runs)
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          cp "$RUNNER_TEMP/asc_api_key.p8" "$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY}.p8"
+          rc=0
+          out=$(xcrun altool --upload-app --type macos --file "$RUNNER_TEMP/lux-mas.pkg" \
+            --apiKey "$APPLE_API_KEY" --apiIssuer "$APPLE_API_ISSUER" 2>&1) || rc=$?
+          echo "$out"
+          if [ "$rc" -ne 0 ]; then
+            echo "$out" | grep -qiE 'already been uploaded|already exists|redundant binary|previously uploaded' \
+              && { echo "build already on App Store Connect — treating as published"; exit 0; }
+            exit "$rc"
+          fi
+
+      # Record what is live in the repo's Deployments view. Done via the API,
+      # NOT a job-level `environment:` key — that key rewrites the OIDC subject
+      # to repo:…:environment:…, which the role trusts (pinned to the main ref)
+      # would reject, breaking the AWS credentials above.
+      - name: Record TestFlight (macOS) deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ env.TAG }}
+        run: |
+          set -euo pipefail
+          body=$(jq -nc --arg ref "$GITHUB_SHA" --arg desc "$TAG" \
+            '{ref:$ref, environment:"testflight-macos", production_environment:true, auto_merge:false, required_contexts:[], description:$desc}')
+          id=$(gh api -X POST "repos/$GITHUB_REPOSITORY/deployments" --input - <<<"$body" --jq '.id')
+          gh api -X POST "repos/$GITHUB_REPOSITORY/deployments/$id/statuses" \
+            -f state=success -f environment=testflight-macos \
+            -f description="Mac App Store build uploaded to TestFlight for $TAG" >/dev/null
+          echo "recorded testflight-macos deployment $id ($TAG)"
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -102,3 +102,8 @@ keyring-core = "1"
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.
 # DO NOT REMOVE!!
 prod = ["tauri/custom-protocol"]
+# Mac App Store flavor (`tauri build --features mas --config src-tauri/tauri.mas.json`):
+# store builds must not self-update, so this leaves the updater plugin
+# unregistered. The dependency still compiles (keeps the capability set and
+# feature resolution identical); registration is what's gated.
+mas = []

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -78,8 +78,10 @@ pub async fn run() {
         .manage(cloud::LuxSync::default())
         .manage(nudge::LuxNudge::default());
     // The self-updater is desktop-only (mobile updates ship through the App
-    // Store), so add its plugin only when building for desktop.
-    #[cfg(desktop)]
+    // Store), so add its plugin only when building for desktop — and not in
+    // the Mac App Store flavor (`mas` feature), where the store owns updates
+    // and App Review rejects self-updating apps.
+    #[cfg(all(desktop, not(feature = "mas")))]
     let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
     builder
         .invoke_handler(taurpc)

--- a/infra/release-signing.tf
+++ b/infra/release-signing.tf
@@ -1,8 +1,10 @@
 # Lets the lux repo's GitHub Actions read release-time secrets from Secrets
 # Manager via OIDC — no long-lived AWS keys in GitHub. The secrets themselves
 # live only in AWS Secrets Manager (created out-of-band): the Tauri updater
-# signing key, the Apple signing material, and the release-bot GitHub App
-# private key (release-please mints an installation token from it).
+# signing key, the Apple signing material (Developer ID + ASC API key), the
+# Mac App Store signing material (Apple Distribution + installer certs and the
+# provisioning profile), and the release-bot GitHub App private key
+# (release-please mints an installation token from it).
 
 data "aws_iam_openid_connect_provider" "github" {
   url = "https://token.actions.githubusercontent.com"
@@ -18,6 +20,10 @@ data "aws_secretsmanager_secret" "apple_signing" {
 
 data "aws_secretsmanager_secret" "release_app_private_key" {
   name = "lux/release-app-private-key"
+}
+
+data "aws_secretsmanager_secret" "mas_signing" {
+  name = "lux/mas-signing"
 }
 
 resource "aws_iam_role" "release_signing" {
@@ -54,6 +60,7 @@ resource "aws_iam_role_policy" "read_updater_signing_key" {
         data.aws_secretsmanager_secret.updater_signing_key.arn,
         data.aws_secretsmanager_secret.apple_signing.arn,
         data.aws_secretsmanager_secret.release_app_private_key.arn,
+        data.aws_secretsmanager_secret.mas_signing.arn,
       ]
     }]
   })


### PR DESCRIPTION
Automates the Mac App Store leg of the release pipeline — every release now uploads a sandboxed macOS build to TestFlight alongside the iOS one, both platforms on the same app record. This is the CI follow-up to #131, which proved the flavor manually.

## Changes

- **`build-mas`** (release.yml): the macOS sibling of `build-ios`, in parallel after the `ci` gate. Unlike iOS there's no Xcode cloud signing here — this build is plain cargo via the tauri CLI, so the job loads the Apple Distribution + Mac Installer identities from the `lux/mas-signing` secret into an ephemeral keychain (`set-key-partition-list` avoids the UI prompt no runner can answer), writes the provisioning profile to the gitignored `src-tauri/mas/` path, builds with `--features mas --config src-tauri/tauri.mas.json`, asserts the product is actually sandboxed (refuses to stage otherwise), wraps it with `productbuild`, and stages the `.pkg` as a workflow artifact. sccache + rust-cache apply (no Xcode script phase in the loop).
- **`publish-mas`**: mirrors `publish-ios` — altool upload gated behind `build-macos` (and transitively the Lambda deploys + smokes), duplicate-tolerant for dispatch re-runs, recorded as a `testflight-macos` deployment.
- **`mas` cargo feature**: compiles the self-updater's registration out of store builds — App Review rejects self-updating apps; store builds update through the store. The `tauri-plugin-updater` dependency still compiles (keeping capability sets and feature resolution identical across flavors); only the `.plugin(...)` registration is gated, and the runtime `endpoints: []` neutering from #131 remains as a second layer. The `.dmg` channel keeps the updater exactly as before.
- **terraform**: `lux-release-signing` gains read on the `lux/mas-signing` secret (created out-of-band, like the other release secrets). The grant applies in the same release run that first needs it — `terraform-apply` precedes `build-mas`.

## Verification

The exact CI invocation (`tauri build --target universal-apple-darwin --features mas --config src-tauri/tauri.mas.json`) was run locally against the same secret material: builds, signs with the Apple Distribution identity, and the product carries the App Sandbox entitlement. `cargo check` passes with and without the feature. The first release after this merges is the end-to-end proof; macOS TestFlight uploads for an already-uploaded version land in the duplicate-tolerant path by design.