### PR TITLE
ci: build-mas waits for terraform-apply (secret grant ordering)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -676,9 +676,15 @@ jobs:
   # self-updater's registration out — store builds update through the store),
   # and productbuild wraps the upload package. MAS packages are deliberately
   # NOT notarized — App Store Connect ingestion does its own checks.
+  #
+  # Needs terraform-apply (unlike build-ios): this job's secret access is
+  # provisioned by terraform, so a release that changes the grant must apply it
+  # before the fetch — v0.15.0's first build-mas raced the apply and lost
+  # (AccessDenied). Dispatch runs skip terraform-apply and bypass it here, the
+  # same shape build-macos uses for deploy-lambdas.
   build-mas:
-    needs: [release-please, ci]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (needs.release-please.outputs.release_created == 'true' && needs.ci.result == 'success')) }}
+    needs: [release-please, ci, terraform-apply]
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (needs.release-please.outputs.release_created == 'true' && needs.ci.result == 'success' && needs.terraform-apply.result == 'success')) }}
     runs-on: macos-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
v0.15.0's first `build-mas` raced `terraform-apply` and lost: both jobs start after `ci`, and that release was the one applying the `lux/mas-signing` read grant the job fetches with — the secret read hit `AccessDeniedException` seconds before the policy landed. The rerun succeeded once the grant existed.

`build-mas` now needs `terraform-apply`: its secret access is provisioned by the same release's apply, so the dependency belongs in the graph (the ~1 minute serialization is noise next to the build). Dispatch runs skip `terraform-apply` and bypass the gate here — the same shape `build-macos` uses for `deploy-lambdas`. `build-ios` keeps its parallel start; its secret predates the job and isn't terraform-managed.