### PR TITLE
feat(ios): enable multicast networking entitlement

### DIFF
--- a/apps/desktop/src-tauri/gen/apple/lux_iOS/lux_iOS.entitlements
+++ b/apps/desktop/src-tauri/gen/apple/lux_iOS/lux_iOS.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.networking.multicast</key>
+	<true/>
+</dict>
 </plist>

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -77,6 +77,12 @@ targets:
         CFBundleVersion: "0.12.2"
     entitlements:
       path: lux_iOS/lux_iOS.entitlements
+      # xcodegen regenerates this file from these properties on every build
+      # (same as Info.plist above) — a key set only in the .entitlements file
+      # is silently wiped. Multicast Networking is Apple-granted (request
+      # URZMNY2RN8) and required to send sACN/Art-Net on-device.
+      properties:
+        com.apple.developer.networking.multicast: true
     scheme:
       environmentVariables:
         RUST_BACKTRACE: full


### PR DESCRIPTION
## What

Enable the Multicast Networking entitlement (`com.apple.developer.networking.multicast`) on the iOS target.

## Why

Apple granted the entitlement for this app. It is required to send multicast (sACN / E1.31 to `239.255.x.x:5568`) and broadcast (Art-Net ArtPoll discovery) from iOS hardware — the OS silently drops those packets without it. `sacn.rs` and `discovery.rs` already compile into the iOS binary, so this entitlement is the only thing gating on-device DMX output.

## Where it lives, and why

Declared in `gen/apple/project.yml` under `entitlements.properties`, not the standalone `lux_iOS.entitlements` file. xcodegen regenerates the entitlements file from `project.yml` on every `tauri ios build`, so a key placed only in the file is wiped — the same reason `NSLocalNetworkUsageDescription` and the signing team already live in `project.yml`. The generated `lux_iOS.entitlements` is committed in sync so the working tree stays clean after a build.

## Verification

- `xcodegen generate` writes the entitlement into `lux_iOS.entitlements`, idempotent across reruns.
- `CODE_SIGN_ENTITLEMENTS` already references that file in the pbxproj.
- The entitlement is folded into the App Store provisioning profile by Xcode automatic/cloud signing during the release build — the first signed release build is the end-to-end check.
