### PR TITLE
feat: slider orientation setting with a vertical console desk default

### DIFF
--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use lux_wire::{
     DeleteUserDataResponse, ListSetupsResponse, SetupRecord, TombstoneResponse, UpsertSetupBody,
-    WriteResponse,
+    UpsertSettingsBody, WriteResponse,
 };
 use reqwest::{Client, StatusCode};
 use serde::de::DeserializeOwned;
@@ -33,6 +33,7 @@ use uuid::Uuid;
 
 use crate::account::LuxAccount;
 use crate::cmd::CmdEvent;
+use crate::settings::UserSettings;
 use crate::setup::{LuxSetups, PendingDelete, Setup};
 
 // --- sync status (drives the UI indicator) -----------------------------------
@@ -61,6 +62,12 @@ pub struct LuxSync {
     in_flight: AtomicBool,
     /// Held while a backoff retry loop is alive, so only one runs at a time.
     retrying: AtomicBool,
+    /// Set when `PUT /settings` 404s — a sync-api from before settings existed
+    /// (a dev build against prod, or a backend rollback). Settings sync pauses
+    /// for the session instead of pinning the indicator at Offline with a
+    /// doomed retry loop; setups keep syncing. Cleared only by restart, which
+    /// retries the claim once against a possibly-upgraded server.
+    settings_unsupported: AtomicBool,
 }
 
 impl LuxSync {
@@ -82,6 +89,8 @@ enum SyncError {
     Unauthorized,
     /// Conditional write lost a race; reconcile on the next pull.
     Conflict,
+    /// The server doesn't know the route — an older deployment.
+    NotFound,
     Other(String),
 }
 
@@ -90,6 +99,7 @@ impl std::fmt::Display for SyncError {
         match self {
             SyncError::Unauthorized => write!(f, "unauthorized"),
             SyncError::Conflict => write!(f, "conflict"),
+            SyncError::NotFound => write!(f, "not found"),
             SyncError::Other(e) => write!(f, "{e}"),
         }
     }
@@ -160,17 +170,20 @@ fn reconcile(local: Vec<Setup>, remote: &[SetupRecord]) -> Vec<Setup> {
     merged
 }
 
+// The settings counterpart lives in `crate::settings::reconcile`, applied
+// atomically under the store lock by `LuxSetups::merge_remote_settings`.
+
 // --- HTTP (one call each; owned token so the future is self-contained) -------
 
-async fn list(client: &Client, base: &str, token: String) -> Result<Vec<SetupRecord>, SyncError> {
+/// The whole pull: setups plus the settings record, one request.
+async fn list(client: &Client, base: &str, token: String) -> Result<ListSetupsResponse, SyncError> {
     let resp = client
         .get(format!("{base}/{}", lux_wire::SETUPS_SEGMENT))
         .bearer_auth(token)
         .send()
         .await
         .map_err(|e| SyncError::Other(e.to_string()))?;
-    let body: ListSetupsResponse = read_json(resp).await?;
-    Ok(body.setups)
+    read_json(resp).await
 }
 
 async fn upsert(
@@ -219,6 +232,27 @@ async fn tombstone(
     Ok(())
 }
 
+async fn upsert_settings(
+    client: &Client,
+    base: &str,
+    token: String,
+    settings: &UserSettings,
+    base_updated_at: Option<i64>,
+) -> Result<WriteResponse, SyncError> {
+    let body = UpsertSettingsBody {
+        data: serde_json::to_value(settings).map_err(|e| SyncError::Other(e.to_string()))?,
+        base_updated_at,
+    };
+    let resp = client
+        .put(format!("{base}/{}", lux_wire::SETTINGS_SEGMENT))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| SyncError::Other(e.to_string()))?;
+    read_json(resp).await
+}
+
 async fn delete_user_data(
     client: &Client,
     base: &str,
@@ -237,6 +271,7 @@ async fn read_json<T: DeserializeOwned>(resp: reqwest::Response) -> Result<T, Sy
     match resp.status() {
         StatusCode::UNAUTHORIZED => Err(SyncError::Unauthorized),
         StatusCode::CONFLICT => Err(SyncError::Conflict),
+        StatusCode::NOT_FOUND => Err(SyncError::NotFound),
         status if status.is_success() => resp
             .json::<T>()
             .await
@@ -257,10 +292,22 @@ async fn refresh(app: &AppHandle) -> Result<String, SyncError> {
         .map_err(SyncError::Other)
 }
 
-/// Push every dirty setup, then flush pending delete tombstones. On a 401 the
-/// token is refreshed once and the call retried. Conflicts are left for the next
-/// pull to reconcile. Persists the store afterward so cleared dirty flags stick.
+/// Push every dirty setup, then flush pending delete tombstones and the
+/// settings blob. On a 401 the token is refreshed once and the call retried.
+/// Conflicts are left for the next pull to reconcile. Persists the store
+/// afterward so cleared dirty flags stick.
 async fn push_all(app: &AppHandle, client: &Client, base: &str, token: &mut String) {
+    // Never push a store bound to a *different* account than the one signed
+    // in: between a new account signing in and `pull_and_push` rebinding the
+    // store, everything in it is still the previous user's — a push landing in
+    // that window (a background retry loop, a mutation-triggered push) would
+    // claim their data into the new account. The pull path stays open (it is
+    // what rebinds); its own push_all call runs after the rebind.
+    let bound = app.state::<LuxSetups>().bound_email();
+    if bound.is_some() && bound != app.state::<LuxAccount>().email() {
+        return;
+    }
+
     for setup in app.state::<LuxSetups>().dirty_for_push() {
         let mut result = upsert(client, base, token.clone(), &setup).await;
         if matches!(result, Err(SyncError::Unauthorized)) {
@@ -299,7 +346,48 @@ async fn push_all(app: &AppHandle, client: &Client, base: &str, token: &mut Stri
         }
     }
 
+    if let Some((settings, base_updated_at)) = settings_to_push(app) {
+        let mut result = upsert_settings(client, base, token.clone(), &settings, base_updated_at).await;
+        if matches!(result, Err(SyncError::Unauthorized)) {
+            if let Ok(fresh) = refresh(app).await {
+                *token = fresh;
+                result =
+                    upsert_settings(client, base, token.clone(), &settings, base_updated_at).await;
+            }
+        }
+        match result {
+            Ok(w) => app
+                .state::<LuxSetups>()
+                .mark_settings_pushed(settings, w.updated_at),
+            Err(SyncError::Conflict) => {
+                log::info!("settings push conflict; reconciling on next pull")
+            }
+            Err(SyncError::NotFound) => {
+                log::info!("sync-api has no settings route yet; pausing settings sync this session");
+                app.state::<LuxSync>()
+                    .settings_unsupported
+                    .store(true, Ordering::SeqCst);
+            }
+            Err(e) => log::warn!("settings push failed: {e}"),
+        }
+    }
+
     crate::setup::save(app, &app.state::<LuxSetups>());
+}
+
+/// The pending settings push, unless the server already told us it has no
+/// settings route (see [`LuxSync::settings_unsupported`]) — without that gate a
+/// pre-settings server would pin the indicator at Offline behind a doomed
+/// retry loop.
+fn settings_to_push(app: &AppHandle) -> Option<(UserSettings, Option<i64>)> {
+    if app
+        .state::<LuxSync>()
+        .settings_unsupported
+        .load(Ordering::SeqCst)
+    {
+        return None;
+    }
+    app.state::<LuxSetups>().settings_for_push()
 }
 
 /// Pull the account's setups, reconcile them into the local store (claiming
@@ -325,7 +413,11 @@ async fn pull_and_push(app: &AppHandle) {
         .is_some_and(|bound| bound != email);
 
     let client = Client::new();
-    let remote = match list(&client, &base, token.clone()).await {
+    // One request pulls everything: the setups and the settings record. A
+    // failed pull degrades to "no remote" — nothing is adopted, and the push
+    // side can't clobber newer remote state because its conditional writes
+    // still carry their concurrency bases.
+    let pulled = match list(&client, &base, token.clone()).await {
         Err(SyncError::Unauthorized) => {
             let Ok(fresh) = refresh(app).await else {
                 log::warn!("sync pull failed: could not refresh token");
@@ -338,20 +430,27 @@ async fn pull_and_push(app: &AppHandle) {
     }
     .unwrap_or_else(|e| {
         log::warn!("sync pull failed: {e}");
-        Vec::new()
+        ListSetupsResponse {
+            setups: Vec::new(),
+            settings: None,
+        }
     });
 
-    // For a different account, start from their cloud state only (don't merge the
-    // previous user's local setups, and don't push them to this account).
+    // For a different account, start from their cloud state only: don't merge
+    // the previous user's local setups (or push them to this account), and
+    // drop their settings values and sync metadata entirely.
     let local = if different_account {
         app.state::<LuxSetups>().reset_for_new_account();
+        app.state::<LuxSetups>().reset_settings_for_account_switch();
         Vec::new()
     } else {
         app.state::<LuxSetups>().all()
     };
 
-    let merged = reconcile(local, &remote);
+    let merged = reconcile(local, &pulled.setups);
     app.state::<LuxSetups>().replace_with_merged(merged, email);
+    app.state::<LuxSetups>()
+        .merge_remote_settings(pulled.settings.as_ref());
     crate::cmd::broadcast_synced_state(app);
 
     push_all(app, &client, &base, &mut token).await;
@@ -391,10 +490,12 @@ fn syncable(app: &AppHandle) -> bool {
 }
 
 /// True when nothing is waiting to reach the cloud (no dirty setups, no pending
-/// delete tombstones).
+/// delete tombstones, no pushable settings).
 fn fully_flushed(app: &AppHandle) -> bool {
     let setups = app.state::<LuxSetups>();
-    setups.dirty_for_push().is_empty() && setups.pending_deletes().is_empty()
+    setups.dirty_for_push().is_empty()
+        && setups.pending_deletes().is_empty()
+        && settings_to_push(app).is_none()
 }
 
 /// Close out a push/pull cycle: `Synced` if everything reached the cloud, else
@@ -625,6 +726,7 @@ mod tests {
 
             let remote = list(&client, &base, token.clone()).await.expect("list");
             let found = remote
+                .setups
                 .iter()
                 .find(|c| c.id == id.to_string())
                 .expect("setup present after upsert");

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -6,6 +6,7 @@ use crate::{
     channels::LuxChannels,
     devices::{self, DmxDeviceInfo, DmxOutput},
     fixture::{self, ChannelDef, Fixture, FixturePreset},
+    settings::{SliderOrientation, UserSettings},
     setup::{self, LuxSetups, SetupSummary},
     sync::*,
 };
@@ -73,6 +74,13 @@ pub trait CmdMethods {
     ) -> Result<Vec<SetupSummary>, String>;
     fn delete_setup(&self, app_handle: AppHandle, id: String) -> Result<Vec<SetupSummary>, String>;
     fn set_active_setup(&self, app_handle: AppHandle, id: String) -> Result<SetupSummary, String>;
+    // User settings — persisted locally and cloud-synced when signed in.
+    fn get_settings(&self, app_handle: AppHandle) -> Result<UserSettings, String>;
+    fn set_slider_orientation(
+        &self,
+        app_handle: AppHandle,
+        orientation: SliderOrientation,
+    ) -> Result<UserSettings, String>;
     // Accounts — Cognito identity (gates cloud sync; no-op when COGNITO_* unset).
     fn auth_status(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
     fn sign_up(&self, app_handle: AppHandle, email: String, password: String)
@@ -117,6 +125,9 @@ pub enum CmdEvent {
     SetupsChanged {
         setups: Vec<SetupSummary>,
         active_setup_id: String,
+    },
+    SettingsChanged {
+        settings: UserSettings,
     },
     AuthChanged {
         status: AuthStatus,
@@ -284,6 +295,20 @@ impl CmdMethods for CmdEndpoint {
         Ok(setups.active_summary())
     }
 
+    fn get_settings(&self, app_handle: AppHandle) -> Result<UserSettings, String> {
+        Ok(app_handle.state::<LuxSetups>().settings())
+    }
+
+    fn set_slider_orientation(
+        &self,
+        app_handle: AppHandle,
+        orientation: SliderOrientation,
+    ) -> Result<UserSettings, String> {
+        let setups = app_handle.state::<LuxSetups>();
+        setups.set_slider_orientation(orientation);
+        commit_settings(&app_handle, setups.inner())
+    }
+
     fn auth_status(&self, app_handle: AppHandle) -> Result<AuthStatus, String> {
         Ok(app_handle.state::<LuxAccount>().status())
     }
@@ -399,6 +424,17 @@ fn commit_patch(app: &AppHandle, setups: &LuxSetups) -> Result<Vec<Fixture>, Str
     Ok(fixtures)
 }
 
+/// Persist the store and broadcast the new user settings to the UI.
+fn commit_settings(app: &AppHandle, setups: &LuxSetups) -> Result<UserSettings, String> {
+    setup::save(app, setups);
+    let settings = setups.settings();
+    CmdEvent::SettingsChanged { settings }
+        .emit(app)
+        .map_err(|e| format!("Failed to emit settings_changed event: {e}"))?;
+    crate::cloud::schedule_push(app);
+    Ok(settings)
+}
+
 /// Persist the store and broadcast the setup list + active id to the UI.
 fn commit_setups(app: &AppHandle, setups: &LuxSetups) -> Result<Vec<SetupSummary>, String> {
     setup::save(app, setups);
@@ -429,6 +465,10 @@ pub fn broadcast_synced_state(app: &AppHandle) {
     let _ = CmdEvent::PatchSet {
         setup_id: active_id,
         fixtures: setups.active_fixtures(),
+    }
+    .emit(app);
+    let _ = CmdEvent::SettingsChanged {
+        settings: setups.settings(),
     }
     .emit(app);
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod lock;
 mod logger;
 mod nudge;
 mod remote;
+mod settings;
 mod setup;
 mod sync;
 #[cfg(desktop)]

--- a/apps/desktop/src-tauri/src/settings.rs
+++ b/apps/desktop/src-tauri/src/settings.rs
@@ -1,0 +1,253 @@
+//! User-level preferences: one small [`UserSettings`] blob per user, persisted
+//! in the [`crate::setup::SetupStore`] and cloud-synced whole (last-writer-wins
+//! by server timestamp, like a setup). The pure merge decision lives here as
+//! [`reconcile`]; [`crate::setup::LuxSetups::merge_remote_settings`] applies it
+//! atomically under the store lock.
+//!
+//! On the wire the blob is opaque — the sync-api round-trips it as JSON
+//! (`lux_wire::SettingsRecord::data`) and only this crate types it — so adding
+//! a setting here never requires a server deploy. To keep that evolution safe
+//! in both directions, every field carries
+//! `#[serde(default, deserialize_with = "ok_or_default")]`: a missing field
+//! (older client's blob on a newer one) and an unreadable *value* (a newer
+//! client's enum variant, or a corrupted write, on an older one) both degrade
+//! to that field's default instead of failing the whole blob — and with it the
+//! whole `setups.json` — on a downgrade. Unknown fields are ignored as usual.
+//! The tests at the bottom pin all of this.
+
+use lux_wire::SettingsRecord;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+/// Which way the universe desk's faders run: vertical sliders in a
+/// horizontally-scrolling desk (the classic lighting-console layout, and the
+/// default), or horizontal sliders in a vertically-scrolling list.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum SliderOrientation {
+    #[default]
+    Vertical,
+    Horizontal,
+}
+
+/// The user's synced preferences. Add fields with
+/// `#[serde(default, deserialize_with = "ok_or_default")]` only — see the
+/// module docs for why.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct UserSettings {
+    // specta(type): ok_or_default doesn't change the wire type — it only
+    // degrades unreadable input — so pin the export to the field's own type.
+    #[serde(default, deserialize_with = "ok_or_default")]
+    #[specta(type = SliderOrientation)]
+    pub slider_orientation: SliderOrientation,
+}
+
+/// Field-level fault tolerance: a present-but-unreadable value (an enum
+/// variant from a newer client, a wrong type from a corrupted write) degrades
+/// to the field's default instead of failing the containing document's parse.
+/// (`#[serde(default)]` alone only covers a *missing* field.)
+fn ok_or_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: serde::de::DeserializeOwned + Default,
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    Ok(T::deserialize(value).unwrap_or_default())
+}
+
+// --- cloud merge (pure; applied under the store lock by LuxSetups) ----------
+
+/// What a pull decided about the settings blob.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Merge {
+    /// Local state already agrees with (or outranks) the cloud — change nothing.
+    KeepLocal,
+    /// The cloud's blob wins (LWW): adopt these values at this server timestamp.
+    Adopt(UserSettings, i64),
+    /// Keep the local values but advance the concurrency base to this server
+    /// timestamp, so the next push lands as a conditional overwrite instead of
+    /// a doomed create. Used when local outranks remote (a claim) or when the
+    /// remote blob won't parse (a dirty push then repairs it).
+    Rebase(i64),
+}
+
+/// Decide whether the cloud's settings blob should replace the local one — the
+/// same last-writer-wins-by-server-`updatedAt` rule as the setups `reconcile`,
+/// applied to the account's single settings record.
+///
+/// The one deliberate divergence from plain LWW: a **dirty local edit that was
+/// never synced** (`base` = `None`) outranks whatever the account has stored —
+/// an explicit choice made seconds ago on this device must not silently revert
+/// to a record written months ago elsewhere. It rebases onto the remote
+/// timestamp so its claim push succeeds conditionally.
+pub fn reconcile(base: Option<i64>, dirty: bool, remote: Option<&SettingsRecord>) -> Merge {
+    let Some(r) = remote else {
+        // Nothing in the cloud yet; a claim push (if pending) creates it.
+        return Merge::KeepLocal;
+    };
+    let parsed = serde_json::from_value::<UserSettings>(r.data.clone()).ok();
+    match base {
+        // Never synced on this device (fresh install, account switch, or
+        // post-account-deletion): a clean store adopts the account's record; a
+        // dirty edit claims over it; an unparseable record just hands over its
+        // timestamp (no adoption, no wedge — see Merge::Rebase).
+        None => match (dirty, parsed) {
+            (false, Some(settings)) => Merge::Adopt(settings, r.updated_at),
+            _ => Merge::Rebase(r.updated_at),
+        },
+        Some(base) => {
+            if r.updated_at <= base {
+                // Remote is our own base (or older) — local state stands; a
+                // dirty edit re-pushes on the base it already holds.
+                Merge::KeepLocal
+            } else {
+                // Remote is newer: LWW gives it the win, even over a dirty
+                // local edit (mirrors the setups rule). If it won't parse,
+                // take only its timestamp so a dirty push can repair it.
+                match parsed {
+                    Some(settings) => Merge::Adopt(settings, r.updated_at),
+                    None => Merge::Rebase(r.updated_at),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn defaults_to_vertical() {
+        assert_eq!(
+            UserSettings::default().slider_orientation,
+            SliderOrientation::Vertical
+        );
+    }
+
+    #[test]
+    fn json_shape_is_pinned() {
+        // This exact JSON crosses the wire inside `SettingsRecord::data` and is
+        // what older/newer clients parse of each other — a change here is a
+        // compatibility decision, not a refactor.
+        assert_eq!(
+            serde_json::to_string(&UserSettings::default()).unwrap(),
+            r#"{"sliderOrientation":"vertical"}"#
+        );
+        let horizontal: UserSettings =
+            serde_json::from_str(r#"{"sliderOrientation":"horizontal"}"#).unwrap();
+        assert_eq!(
+            horizontal.slider_orientation,
+            SliderOrientation::Horizontal
+        );
+    }
+
+    #[test]
+    fn tolerates_missing_and_unknown_fields() {
+        // Older client's blob (field absent) → default.
+        let empty: UserSettings = serde_json::from_str("{}").unwrap();
+        assert_eq!(empty.slider_orientation, SliderOrientation::Vertical);
+
+        // Newer client's blob (extra field) → still parses.
+        let future: UserSettings =
+            serde_json::from_str(r#"{"sliderOrientation":"horizontal","theme":"dark"}"#).unwrap();
+        assert_eq!(future.slider_orientation, SliderOrientation::Horizontal);
+    }
+
+    #[test]
+    fn unreadable_values_degrade_to_default() {
+        // A future client writes a variant this build doesn't know. The
+        // `ok_or_default` fallback keeps the blob — and the whole setups.json
+        // it is embedded in — parseable on a downgrade.
+        let future: UserSettings =
+            serde_json::from_str(r#"{"sliderOrientation":"grid"}"#).unwrap();
+        assert_eq!(future.slider_orientation, SliderOrientation::Vertical);
+
+        // So does a wrong-typed value from a corrupted write.
+        let corrupt: UserSettings =
+            serde_json::from_str(r#"{"sliderOrientation":42}"#).unwrap();
+        assert_eq!(corrupt.slider_orientation, SliderOrientation::Vertical);
+    }
+
+    // -- reconcile --
+
+    fn record(data: serde_json::Value, updated_at: i64) -> SettingsRecord {
+        SettingsRecord {
+            data,
+            rev: 1,
+            updated_at,
+        }
+    }
+
+    fn horizontal(updated_at: i64) -> SettingsRecord {
+        record(json!({ "sliderOrientation": "horizontal" }), updated_at)
+    }
+
+    #[test]
+    fn no_remote_keeps_local() {
+        assert_eq!(reconcile(None, false, None), Merge::KeepLocal);
+        assert_eq!(reconcile(Some(100), true, None), Merge::KeepLocal);
+    }
+
+    #[test]
+    fn first_pull_of_a_clean_store_adopts_remote() {
+        let r = horizontal(100);
+        assert_eq!(
+            reconcile(None, false, Some(&r)),
+            Merge::Adopt(
+                UserSettings {
+                    slider_orientation: SliderOrientation::Horizontal
+                },
+                100
+            )
+        );
+    }
+
+    #[test]
+    fn never_synced_dirty_edit_claims_over_the_stored_record() {
+        // An explicit edit made before first sync outranks the account's old
+        // record; rebasing lets its push land conditionally instead of 409ing.
+        let r = horizontal(100);
+        assert_eq!(reconcile(None, true, Some(&r)), Merge::Rebase(100));
+    }
+
+    #[test]
+    fn remote_newer_wins_even_over_dirty() {
+        let r = horizontal(200);
+        let adopt = Merge::Adopt(
+            UserSettings {
+                slider_orientation: SliderOrientation::Horizontal,
+            },
+            200,
+        );
+        assert_eq!(reconcile(Some(100), false, Some(&r)), adopt);
+        assert_eq!(reconcile(Some(100), true, Some(&r)), adopt);
+    }
+
+    #[test]
+    fn dirty_on_latest_base_is_kept_for_repush() {
+        let r = horizontal(100);
+        assert_eq!(reconcile(Some(100), true, Some(&r)), Merge::KeepLocal);
+    }
+
+    #[test]
+    fn in_sync_is_a_no_op() {
+        let r = record(json!({ "sliderOrientation": "vertical" }), 100);
+        assert_eq!(reconcile(Some(100), false, Some(&r)), Merge::KeepLocal);
+    }
+
+    #[test]
+    fn unparseable_remote_rebases_instead_of_wedging() {
+        // Garbage in the cloud (any writer bug): never adopt it, but take its
+        // timestamp so a dirty local push conditionally overwrites — without
+        // this, a never-synced claim 409s forever and sync sticks at Offline.
+        let bad = record(json!("not an object"), 200);
+        assert_eq!(reconcile(None, false, Some(&bad)), Merge::Rebase(200));
+        assert_eq!(reconcile(None, true, Some(&bad)), Merge::Rebase(200));
+        assert_eq!(reconcile(Some(100), true, Some(&bad)), Merge::Rebase(200));
+        // In-sync-or-older garbage changes nothing.
+        assert_eq!(reconcile(Some(200), false, Some(&bad)), Merge::KeepLocal);
+    }
+}

--- a/apps/desktop/src-tauri/src/setup.rs
+++ b/apps/desktop/src-tauri/src/setup.rs
@@ -21,6 +21,8 @@ use specta::Type;
 use tauri::{Manager, Runtime};
 
 use crate::fixture::{self, ChannelDef, Fixture};
+use crate::settings::{self, SliderOrientation, UserSettings};
+use lux_wire::SettingsRecord;
 
 /// Current on-disk schema version for `setups.json`. Bump when the shape changes
 /// and add a step to [`migrate_version`].
@@ -79,6 +81,17 @@ pub struct SetupStore {
     /// the delete propagates to other devices. Drained as each push succeeds.
     #[serde(default)]
     pub pending_deletes: Vec<PendingDelete>,
+    /// User-level preferences, cloud-synced as one blob (LWW). Defaults keep
+    /// older `setups.json` readable.
+    #[serde(default)]
+    pub settings: UserSettings,
+    /// Server timestamp of the last settings push/pull — the settings blob's
+    /// optimistic-concurrency base, mirroring [`Setup::updated_at`].
+    #[serde(default)]
+    pub settings_updated_at: Option<i64>,
+    /// Local settings edits not yet pushed to the cloud.
+    #[serde(default)]
+    pub settings_dirty: bool,
 }
 
 /// A local delete awaiting a cloud tombstone.
@@ -141,6 +154,9 @@ impl SetupStore {
             setups: vec![setup],
             bound_email: None,
             pending_deletes: Vec::new(),
+            settings: UserSettings::default(),
+            settings_updated_at: None,
+            settings_dirty: false,
         }
     }
 
@@ -332,6 +348,78 @@ impl LuxSetups {
         Ok(())
     }
 
+    // -- user settings (persisted with the store, synced as one blob) --
+
+    pub fn settings(&self) -> UserSettings {
+        self.store.lock_or_recover().settings
+    }
+
+    pub fn set_slider_orientation(&self, orientation: SliderOrientation) -> UserSettings {
+        let mut store = self.store.lock_or_recover();
+        if store.settings.slider_orientation != orientation {
+            store.settings.slider_orientation = orientation;
+            store.settings_dirty = true;
+        }
+        store.settings
+    }
+
+    /// The settings blob plus its concurrency base, when the cloud doesn't have
+    /// it yet: explicit local edits, or settings that have never been synced
+    /// (so first sign-in claims them, exactly like a never-synced setup).
+    pub fn settings_for_push(&self) -> Option<(UserSettings, Option<i64>)> {
+        let store = self.store.lock_or_recover();
+        (store.settings_dirty || store.settings_updated_at.is_none())
+            .then_some((store.settings, store.settings_updated_at))
+    }
+
+    /// Record a successful settings push: store the server timestamp and clear
+    /// dirty — unless another local edit landed while the push was in flight.
+    /// The base only ever advances: a stalled response resolving after a pull
+    /// already adopted a newer server state must not rewind it (a rewound base
+    /// makes every subsequent push a guaranteed conflict).
+    pub fn mark_settings_pushed(&self, pushed: UserSettings, updated_at: i64) {
+        let mut store = self.store.lock_or_recover();
+        if store.settings_updated_at.is_none_or(|base| updated_at > base) {
+            store.settings_updated_at = Some(updated_at);
+        }
+        if store.settings == pushed {
+            store.settings_dirty = false;
+        }
+    }
+
+    /// Merge the cloud's settings record into the store — read, decide
+    /// ([`settings::reconcile`]), and apply under one lock, so a
+    /// `set_slider_orientation` landing mid-pull can never be overwritten by a
+    /// decision made against a stale snapshot.
+    pub fn merge_remote_settings(&self, remote: Option<&SettingsRecord>) {
+        let mut store = self.store.lock_or_recover();
+        match settings::reconcile(store.settings_updated_at, store.settings_dirty, remote) {
+            settings::Merge::KeepLocal => {}
+            settings::Merge::Adopt(settings, updated_at) => {
+                store.settings = settings;
+                store.settings_updated_at = Some(updated_at);
+                store.settings_dirty = false;
+            }
+            settings::Merge::Rebase(updated_at) => {
+                // Values stay; only the concurrency base advances (a pending
+                // dirty edit re-pushes on it — see `Merge::Rebase`).
+                store.settings_updated_at = Some(updated_at);
+            }
+        }
+    }
+
+    /// Forget the previous account's settings entirely — values and sync
+    /// metadata — so a *different* account signing in on this device neither
+    /// inherits them locally nor claim-pushes them into its own cloud record.
+    /// (Contrast [`Self::reset_for_new_account`], which keeps values: after
+    /// deleting your own account the device preference is still yours.)
+    pub fn reset_settings_for_account_switch(&self) {
+        let mut store = self.store.lock_or_recover();
+        store.settings = UserSettings::default();
+        store.settings_updated_at = None;
+        store.settings_dirty = false;
+    }
+
     // -- cloud sync helpers (driven by `crate::cloud`) --
 
     /// Setups with changes the cloud doesn't have yet (clones, for pushing).
@@ -408,6 +496,12 @@ impl LuxSetups {
             s.updated_at = None;
             s.dirty = false;
         }
+        // The settings *values* stay (a device preference is harmless to keep),
+        // but the sync metadata must go: a stale server timestamp from the
+        // previous account would wedge the next account's settings writes in
+        // permanent conflict.
+        store.settings_updated_at = None;
+        store.settings_dirty = false;
     }
 }
 
@@ -662,6 +756,149 @@ mod tests {
         let id = setups.create("Edge".into(), 0).unwrap(); // 0 clamps up to 1
         setups.set_active(id).unwrap();
         assert_eq!(setups.active_universe(), 1);
+    }
+
+    // -- user settings --
+
+    #[test]
+    fn settings_default_vertical_and_absent_fields_parse() {
+        let setups: LuxSetups = SetupStore::default().into();
+        assert_eq!(
+            setups.settings().slider_orientation,
+            SliderOrientation::Vertical
+        );
+
+        // A pre-settings store (no settings fields at all) still parses, with
+        // defaults — the shipped-stores compatibility guarantee.
+        let old = serde_json::to_string(&SetupStore::default()).unwrap();
+        let stripped = {
+            let mut v: serde_json::Value = serde_json::from_str(&old).unwrap();
+            let obj = v.as_object_mut().unwrap();
+            obj.remove("settings");
+            obj.remove("settingsUpdatedAt");
+            obj.remove("settingsDirty");
+            v.to_string()
+        };
+        let store = parse_store(&stripped).unwrap();
+        assert_eq!(
+            store.settings.slider_orientation,
+            SliderOrientation::Vertical
+        );
+        assert_eq!(store.settings_updated_at, None);
+        assert!(!store.settings_dirty);
+    }
+
+    /// The store's settings sync fields, for asserting bookkeeping.
+    fn settings_state(setups: &LuxSetups) -> (UserSettings, Option<i64>, bool) {
+        let store = setups.store.lock_or_recover();
+        (
+            store.settings,
+            store.settings_updated_at,
+            store.settings_dirty,
+        )
+    }
+
+    fn settings_record(orientation: &str, updated_at: i64) -> SettingsRecord {
+        SettingsRecord {
+            data: serde_json::json!({ "sliderOrientation": orientation }),
+            rev: 1,
+            updated_at,
+        }
+    }
+
+    #[test]
+    fn set_slider_orientation_marks_dirty_only_on_change() {
+        let setups: LuxSetups = SetupStore::default().into();
+
+        // Setting the value it already has is not an edit.
+        setups.set_slider_orientation(SliderOrientation::Vertical);
+        assert!(setups.settings_for_push().is_some()); // never synced → claims
+        assert!(!settings_state(&setups).2);
+
+        let updated = setups.set_slider_orientation(SliderOrientation::Horizontal);
+        assert_eq!(updated.slider_orientation, SliderOrientation::Horizontal);
+        assert!(settings_state(&setups).2);
+    }
+
+    #[test]
+    fn settings_push_bookkeeping() {
+        let setups: LuxSetups = SetupStore::default().into();
+        let edited = setups.set_slider_orientation(SliderOrientation::Horizontal);
+
+        setups.mark_settings_pushed(edited, 100);
+        let (_, base, dirty) = settings_state(&setups);
+        assert_eq!(base, Some(100));
+        assert!(!dirty);
+        assert!(setups.settings_for_push().is_none());
+
+        // A push confirmation for a stale blob keeps the newer edit dirty.
+        let newer = setups.set_slider_orientation(SliderOrientation::Vertical);
+        setups.mark_settings_pushed(edited, 150);
+        assert!(settings_state(&setups).2);
+        setups.mark_settings_pushed(newer, 200);
+        assert!(!settings_state(&setups).2);
+
+        // A stalled push response resolving after a pull advanced the base
+        // must not rewind it (every later push would 409 on the stale base).
+        setups.merge_remote_settings(Some(&settings_record("horizontal", 500)));
+        setups.mark_settings_pushed(newer, 200);
+        assert_eq!(settings_state(&setups).1, Some(500));
+    }
+
+    #[test]
+    fn merge_adopts_a_newer_remote_and_clears_dirty() {
+        let setups: LuxSetups = SetupStore::default().into();
+        let edited = setups.set_slider_orientation(SliderOrientation::Vertical);
+        setups.mark_settings_pushed(edited, 100);
+
+        setups.merge_remote_settings(Some(&settings_record("horizontal", 300)));
+        let (settings, base, dirty) = settings_state(&setups);
+        assert_eq!(settings.slider_orientation, SliderOrientation::Horizontal);
+        assert_eq!(base, Some(300));
+        assert!(!dirty);
+    }
+
+    #[test]
+    fn merge_rebases_a_never_synced_dirty_edit_for_its_claim_push() {
+        let setups: LuxSetups = SetupStore::default().into();
+        setups.set_slider_orientation(SliderOrientation::Horizontal);
+
+        // The account already has a (stale) record: the local explicit edit
+        // survives, and only the concurrency base advances so its push lands.
+        setups.merge_remote_settings(Some(&settings_record("vertical", 100)));
+        let (settings, base, dirty) = settings_state(&setups);
+        assert_eq!(settings.slider_orientation, SliderOrientation::Horizontal);
+        assert_eq!(base, Some(100));
+        assert!(dirty);
+        assert_eq!(setups.settings_for_push(), Some((settings, Some(100))));
+    }
+
+    #[test]
+    fn reset_for_new_account_keeps_settings_but_clears_their_sync_state() {
+        let setups: LuxSetups = SetupStore::default().into();
+        let edited = setups.set_slider_orientation(SliderOrientation::Horizontal);
+        setups.mark_settings_pushed(edited, 100);
+
+        setups.reset_for_new_account();
+        let (settings, base, dirty) = settings_state(&setups);
+        assert_eq!(settings.slider_orientation, SliderOrientation::Horizontal);
+        assert_eq!(base, None);
+        assert!(!dirty);
+    }
+
+    #[test]
+    fn account_switch_resets_settings_entirely() {
+        let setups: LuxSetups = SetupStore::default().into();
+        let edited = setups.set_slider_orientation(SliderOrientation::Horizontal);
+        setups.mark_settings_pushed(edited, 100);
+
+        // A different account signing in must not inherit — or claim-push —
+        // the previous user's preferences.
+        setups.reset_settings_for_account_switch();
+        let (settings, base, dirty) = settings_state(&setups);
+        assert_eq!(settings, UserSettings::default());
+        assert_eq!(base, None);
+        assert!(!dirty);
     }
 
     // -- `load_from_dir` against a real (temp) directory --

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -85,6 +85,16 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  get_settings(): Promise<UserSettings> {
+    return invoke("cmd.get_settings");
+  },
+
+  /** @throws {string} */
+  set_slider_orientation(orientation: SliderOrientation): Promise<UserSettings> {
+    return invoke("cmd.set_slider_orientation", { orientation });
+  },
+
+  /** @throws {string} */
   auth_status(): Promise<AuthStatus> {
     return invoke("cmd.auth_status");
   },
@@ -157,7 +167,7 @@ export const sync = {
   },
 };
 
-export type CmdEvent = { type: "channelDataSet"; channels: LuxChannel[] } | { type: "patchSet"; setup_id: string; fixtures: Fixture[] } | { type: "setupsChanged"; setups: SetupSummary[]; active_setup_id: string } | { type: "authChanged"; status: AuthStatus } | { type: "syncStatusChanged"; state: SyncState } | { type: "dmxDevicesChanged"; devices: DmxDeviceInfo[] };
+export type CmdEvent = { type: "channelDataSet"; channels: LuxChannel[] } | { type: "patchSet"; setup_id: string; fixtures: Fixture[] } | { type: "setupsChanged"; setups: SetupSummary[]; active_setup_id: string } | { type: "settingsChanged"; settings: UserSettings } | { type: "authChanged"; status: AuthStatus } | { type: "syncStatusChanged"; state: SyncState } | { type: "dmxDevicesChanged"; devices: DmxDeviceInfo[] };
 
 export type SyncEvent = { type: "bufferSet"; buffer: number[] };
 
@@ -168,6 +178,7 @@ export const events = {
         listen<{ channels: LuxChannel[] }>("cmd:channelDataSet", (event) => callback({ type: "channelDataSet", ...event.payload })),
         listen<{ setup_id: string; fixtures: Fixture[] }>("cmd:patchSet", (event) => callback({ type: "patchSet", ...event.payload })),
         listen<{ setups: SetupSummary[]; active_setup_id: string }>("cmd:setupsChanged", (event) => callback({ type: "setupsChanged", ...event.payload })),
+        listen<{ settings: UserSettings }>("cmd:settingsChanged", (event) => callback({ type: "settingsChanged", ...event.payload })),
         listen<{ status: AuthStatus }>("cmd:authChanged", (event) => callback({ type: "authChanged", ...event.payload })),
         listen<{ state: SyncState }>("cmd:syncStatusChanged", (event) => callback({ type: "syncStatusChanged", ...event.payload })),
         listen<{ devices: DmxDeviceInfo[] }>("cmd:dmxDevicesChanged", (event) => callback({ type: "dmxDevicesChanged", ...event.payload })),
@@ -266,6 +277,13 @@ export type SetupSummary = {
 	active: boolean,
 };
 
+/**
+ *  Which way the universe desk's faders run: vertical sliders in a
+ *  horizontally-scrolling desk (the classic lighting-console layout, and the
+ *  default), or horizontal sliders in a vertically-scrolling list.
+ */
+export type SliderOrientation = "vertical" | "horizontal";
+
 /**  Coarse cloud-sync state for the nav indicator. */
 export type SyncState = 
 /**  Signed out, or signed in with nothing left to sync. */
@@ -276,3 +294,12 @@ export type SyncState =
 "synced" | 
 /**  The last attempt couldn't reach the cloud; a backoff retry is running. */
 "offline";
+
+/**
+ *  The user's synced preferences. Add fields with
+ *  `#[serde(default, deserialize_with = "ok_or_default")]` only — see the
+ *  module docs for why.
+ */
+export type UserSettings = {
+	sliderOrientation?: SliderOrientation,
+};

--- a/apps/desktop/src/components/control-grid/desk-column.tsx
+++ b/apps/desktop/src/components/control-grid/desk-column.tsx
@@ -5,16 +5,16 @@ import { cn, lightColorVariants } from "@/lib/utils";
 import useChannelFader from "./use-channel-fader";
 
 /**
- * One channel of the horizontally-oriented desk: a colored channel-number
- * badge, the label, a 0/255 toggle, and the value slider, laid out as a row.
- * Rendered inside the virtualized grid, so only the visible rows mount.
+ * One channel of the vertically-oriented desk: the same badge / label / 0-255
+ * toggle / slider as DeskRow, stacked into a console-style fader strip.
+ * Rendered inside the virtualized grid, so only the visible columns mount.
  */
-const DeskRow = ({ channel }: { channel: ChannelProps }) => {
+const DeskColumn = ({ channel }: { channel: ChannelProps }) => {
   const { channelNumber, label, labelColor } = channel;
   const { values, drag, toggle } = useChannelFader(channel);
 
   return (
-    <div className="flex h-full w-full items-center gap-3 px-3">
+    <div className="flex h-full w-full flex-col items-center gap-2 px-1 py-3">
       <div
         className={cn(
           "shrink-0 text-xs tabular-nums",
@@ -23,27 +23,28 @@ const DeskRow = ({ channel }: { channel: ChannelProps }) => {
       >
         {channelNumber}
       </div>
-      <span className="w-20 shrink-0 truncate text-right text-sm text-muted-foreground">
+      <span className="w-full shrink-0 truncate text-center text-xs text-muted-foreground">
         {label}
       </span>
       <Button
         onClick={toggle}
         variant="outline"
         size="sm"
-        className="w-14 shrink-0 tabular-nums"
+        className="h-7 w-12 shrink-0 px-0 text-xs tabular-nums"
       >
         {values[0].toString().padStart(3, "0")}
       </Button>
       <Slider
+        orientation="vertical"
         aria-label={`Channel ${channelNumber} (${label})`}
         value={values}
         onValueChange={drag}
         max={255}
         step={1}
-        className="flex-1"
+        className="min-h-0 flex-1"
       />
     </div>
   );
 };
 
-export default DeskRow;
+export default DeskColumn;

--- a/apps/desktop/src/components/control-grid/grid.tsx
+++ b/apps/desktop/src/components/control-grid/grid.tsx
@@ -1,43 +1,79 @@
 import { useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import useLuxState from "@/hooks/useLuxState";
+import useSettings from "@/hooks/useSettings";
+import { cn } from "@/lib/utils";
 import DeskRow from "./desk-row";
+import DeskColumn from "./desk-column";
 
-// Fixed row height drives the virtualizer; rows are uniform faders.
+// Fixed lane sizes drive the virtualizer; rows and columns are uniform faders.
 const ROW_HEIGHT = 48;
+const COLUMN_WIDTH = 64;
+
+type Channels = ReturnType<typeof useLuxState>;
 
 /**
- * The universe desk: every DMX512 channel as a fader, virtualized so 512 rows
+ * The universe desk: every DMX512 channel as a fader, virtualized so 512 lanes
  * scroll smoothly while only the ~visible handful mount. Channels 1–6 are the
  * labelled RGBAW fixture (also driven by the color picker); 7–512 are raw.
+ *
+ * The "slider orientation" user setting picks the layout: vertical faders in a
+ * horizontally-scrolling desk (the default, like a lighting console), or
+ * horizontal faders in a vertically-scrolling list. The desk waits for the
+ * settings read — rendering the default while it's in flight would flash the
+ * wrong layout (and remount the virtualizer) for horizontal users on every
+ * launch.
  */
 export default function ControlGrid() {
   const data = useLuxState();
+  const settings = useSettings();
+
+  if (!data.length || settings === null) {
+    return (
+      <div className="mt-4 w-full max-w-xl rounded-md border py-10 text-center text-muted-foreground">
+        {/* Blank while queries settle; "No channels" only once we know. */}
+        {settings === null ? " " : "No channels"}
+      </div>
+    );
+  }
+
+  const vertical = (settings.sliderOrientation ?? "vertical") === "vertical";
+  // key: flipping the orientation remounts the desk, giving the virtualizer a
+  // fresh instance instead of mutating one across axes.
+  return (
+    <Desk
+      key={vertical ? "vertical" : "horizontal"}
+      data={data}
+      vertical={vertical}
+    />
+  );
+}
+
+/** One virtualized desk along either axis; see ControlGrid for the layouts. */
+function Desk({ data, vertical }: { data: Channels; vertical: boolean }) {
   const parentRef = useRef<HTMLDivElement>(null);
 
   const virtualizer = useVirtualizer({
     count: data.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => ROW_HEIGHT,
+    estimateSize: () => (vertical ? COLUMN_WIDTH : ROW_HEIGHT),
     overscan: 10,
+    horizontal: vertical,
   });
-
-  if (!data.length) {
-    return (
-      <div className="mt-4 w-full max-w-xl rounded-md border py-10 text-center text-muted-foreground">
-        No channels
-      </div>
-    );
-  }
+  const total = `${virtualizer.getTotalSize()}px`;
 
   return (
     <div
       ref={parentRef}
-      className="mt-4 h-[68vh] w-full max-w-xl overflow-auto rounded-md border"
+      className={cn(
+        "mt-4 h-[68vh] w-full overflow-auto rounded-md border",
+        // Horizontal rows read badly at full width; columns want all of it.
+        !vertical && "max-w-xl"
+      )}
     >
       <div
-        className="relative w-full"
-        style={{ height: `${virtualizer.getTotalSize()}px` }}
+        className={cn("relative", vertical ? "h-full" : "w-full")}
+        style={vertical ? { width: total } : { height: total }}
       >
         {virtualizer.getVirtualItems().map((item) => {
           const channel = data[item.index];
@@ -45,13 +81,27 @@ export default function ControlGrid() {
             <div
               key={channel.id}
               data-index={item.index}
-              className="absolute left-0 top-0 w-full"
-              style={{
-                height: `${item.size}px`,
-                transform: `translateY(${item.start}px)`,
-              }}
+              className={cn(
+                "absolute left-0 top-0",
+                vertical ? "h-full" : "w-full"
+              )}
+              style={
+                vertical
+                  ? {
+                      width: `${item.size}px`,
+                      transform: `translateX(${item.start}px)`,
+                    }
+                  : {
+                      height: `${item.size}px`,
+                      transform: `translateY(${item.start}px)`,
+                    }
+              }
             >
-              <DeskRow channel={channel} />
+              {vertical ? (
+                <DeskColumn channel={channel} />
+              ) : (
+                <DeskRow channel={channel} />
+              )}
             </div>
           );
         })}

--- a/apps/desktop/src/components/control-grid/use-channel-fader.ts
+++ b/apps/desktop/src/components/control-grid/use-channel-fader.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import type { ChannelProps } from "@/global";
+import { setChannelValue } from "@/lib/actions";
+import useThrottle from "@/hooks/useThrottle";
+
+/**
+ * The state machine behind one channel fader, shared by the horizontal
+ * (DeskRow) and vertical (DeskColumn) layouts: local slider state for smooth
+ * drags, a throttled IPC write, re-sync from out-of-band changes, and a 0/255
+ * toggle.
+ */
+export default function useChannelFader(channel: ChannelProps) {
+  const { channelNumber, value } = channel;
+  const [values, setValues] = useState([value]);
+
+  // Drags/clicks fire continuously; keep the UI immediate but throttle the
+  // hardware/IPC write so we don't flood the DMX render path.
+  const sendValue = useThrottle((next: number) => {
+    setChannelValue({ channelNumber, value: next }).catch((e) =>
+      toast.error(String(e))
+    );
+  }, 40);
+
+  // Re-sync when the value changes from elsewhere (color picker, remote, or the
+  // optimistic echo of our own write); harmless mid-drag since that echo equals
+  // what we just sent.
+  useEffect(() => {
+    setValues([value]);
+  }, [value]);
+
+  const drag = (next: number[]) => {
+    setValues(next);
+    sendValue(next[0]);
+  };
+
+  const toggle = () => {
+    const next = values[0] === 0 ? 255 : 0;
+    setValues([next]);
+    sendValue(next);
+  };
+
+  return { values, drag, toggle };
+}

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import { Trash2 } from "lucide-react";
 import { createTauRPCProxy, type Fixture } from "@/bindings";
 import useLuxRefresh from "@/hooks/useLuxRefresh";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import FixtureChannel from "./fixture-channel";
 import FixtureColor from "./fixture-color";
@@ -52,7 +53,14 @@ export default function FixtureCard({
     channels.length === 1 ? `Channel ${address}` : `Channels ${address}-${end}`;
 
   return (
-    <section className="rounded-xl border bg-card p-5">
+    // Vertical mode: the card hugs its fader strips instead of stretching to
+    // the container, so cards pack side by side in the scrolling bank.
+    <section
+      className={cn(
+        "rounded-xl border bg-card p-5",
+        vertical && "w-fit shrink-0"
+      )}
+    >
       <header className="mb-3 flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
           <input
@@ -90,12 +98,7 @@ export default function FixtureCard({
         </div>
       )}
 
-      {/* Vertical strips scroll sideways when a fixture outgrows the card. */}
-      <div
-        className={
-          vertical ? "flex gap-1 overflow-x-auto pb-1" : "flex flex-col gap-0.5"
-        }
-      >
+      <div className={vertical ? "flex gap-1" : "flex flex-col gap-0.5"}>
         {channels.map((channel, i) => (
           <FixtureChannel
             key={`${id}-${i}`}

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -12,9 +12,11 @@ const COLOR_ROLES = ["Red", "Green", "Blue"] as const;
 export default function FixtureCard({
   fixture,
   buffer,
+  vertical,
 }: {
   fixture: Fixture;
   buffer: number[] | null;
+  vertical: boolean;
 }) {
   const { id, name, address, channels } = fixture;
   const end = address + channels.length - 1;
@@ -88,7 +90,12 @@ export default function FixtureCard({
         </div>
       )}
 
-      <div className="flex flex-col gap-0.5">
+      {/* Vertical strips scroll sideways when a fixture outgrows the card. */}
+      <div
+        className={
+          vertical ? "flex gap-1 overflow-x-auto pb-1" : "flex flex-col gap-0.5"
+        }
+      >
         {channels.map((channel, i) => (
           <FixtureChannel
             key={`${id}-${i}`}
@@ -96,6 +103,7 @@ export default function FixtureCard({
             role={channel.role}
             label={channel.label}
             value={buffer?.[address + i - 1] ?? 0}
+            vertical={vertical}
           />
         ))}
       </div>

--- a/apps/desktop/src/components/fixtures/fixture-channel.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-channel.tsx
@@ -20,18 +20,22 @@ const ROLE_DOT: Record<LuxLabelColor, string> = {
 /**
  * One channel inside a fixture card: address, role dot, label, slider, value.
  * Deliberately lighter than the universe desk's row — no bordered number badge,
- * no boxed value button. The value is a quiet 0/full toggle.
+ * no boxed value button. The value is a quiet 0/full toggle. Follows the
+ * "slider orientation" setting: a horizontal row, or a compact vertical fader
+ * strip (same element order as the desk's column: meta above, fader below).
  */
 export default function FixtureChannel({
   address,
   role,
   label,
   value,
+  vertical = false,
 }: {
   address: number;
   role: LuxLabelColor;
   label: string;
   value: number;
+  vertical?: boolean;
 }) {
   const [values, setValues] = useState([value]);
   useEffect(() => setValues([value]), [value]);
@@ -53,6 +57,40 @@ export default function FixtureChannel({
     send(next);
   };
 
+  const slider = (
+    <Slider
+      orientation={vertical ? "vertical" : "horizontal"}
+      aria-label={`${label} (channel ${address})`}
+      value={values}
+      onValueChange={drag}
+      max={255}
+      step={1}
+      className={vertical ? undefined : "flex-1"}
+    />
+  );
+
+  if (vertical) {
+    return (
+      <div className="flex w-14 shrink-0 flex-col items-center gap-1.5 py-1">
+        <span className="text-xs tabular-nums text-muted-foreground/60">
+          {address}
+        </span>
+        <span className={cn("size-2.5 shrink-0 rounded-full", ROLE_DOT[role])} />
+        <span className="w-full truncate text-center text-xs">{label}</span>
+        <button
+          type="button"
+          onClick={toggle}
+          title="Toggle 0 / full"
+          className="text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {values[0].toString().padStart(3, "0")}
+        </button>
+        {/* The strip sets the fader's height; the slider fills it. */}
+        <div className="h-36 pt-1">{slider}</div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center gap-3 py-1.5">
       <span className="w-4 text-right text-xs tabular-nums text-muted-foreground/60">
@@ -60,14 +98,7 @@ export default function FixtureChannel({
       </span>
       <span className={cn("size-2.5 shrink-0 rounded-full", ROLE_DOT[role])} />
       <span className="w-16 shrink-0 truncate text-sm">{label}</span>
-      <Slider
-        aria-label={`${label} (channel ${address})`}
-        value={values}
-        onValueChange={drag}
-        max={255}
-        step={1}
-        className="flex-1"
-      />
+      {slider}
       <button
         type="button"
         onClick={toggle}

--- a/apps/desktop/src/components/fixtures/fixtures-view.tsx
+++ b/apps/desktop/src/components/fixtures/fixtures-view.tsx
@@ -30,7 +30,15 @@ export default function FixturesView() {
             No fixtures patched yet. Add one to get started.
           </div>
         ) : (
-          <div className="flex flex-col gap-4">
+          // Vertical faders make the whole view a console: cards sit side by
+          // side at content width and the bank scrolls sideways.
+          <div
+            className={
+              (settings.sliderOrientation ?? "vertical") === "vertical"
+                ? "flex gap-4 overflow-x-auto pb-2"
+                : "flex flex-col gap-4"
+            }
+          >
             {[...fixtures]
               .sort((a, b) => a.address - b.address)
               .map((fixture) => (

--- a/apps/desktop/src/components/fixtures/fixtures-view.tsx
+++ b/apps/desktop/src/components/fixtures/fixtures-view.tsx
@@ -1,11 +1,15 @@
 import useFixtures from "@/hooks/useFixtures";
 import useBuffer from "@/hooks/useBuffer";
+import useSettings from "@/hooks/useSettings";
 import FixtureCard from "./fixture-card";
 import NewFixture from "./new-fixture";
 
 export default function FixturesView() {
   const fixtures = useFixtures();
   const buffer = useBuffer();
+  // Read once here and pass down, so N cards don't each subscribe; like the
+  // desk, wait for the read so the stored layout is the first one painted.
+  const settings = useSettings();
   const count = fixtures?.length ?? 0;
 
   return (
@@ -20,6 +24,7 @@ export default function FixturesView() {
       </div>
 
       {fixtures !== null &&
+        settings !== null &&
         (fixtures.length === 0 ? (
           <div className="rounded-xl border border-dashed py-16 text-center text-sm text-muted-foreground">
             No fixtures patched yet. Add one to get started.
@@ -29,7 +34,14 @@ export default function FixturesView() {
             {[...fixtures]
               .sort((a, b) => a.address - b.address)
               .map((fixture) => (
-                <FixtureCard key={fixture.id} fixture={fixture} buffer={buffer} />
+                <FixtureCard
+                  key={fixture.id}
+                  fixture={fixture}
+                  buffer={buffer}
+                  vertical={
+                    (settings.sliderOrientation ?? "vertical") === "vertical"
+                  }
+                />
               ))}
           </div>
         ))}

--- a/apps/desktop/src/components/settings-menu.tsx
+++ b/apps/desktop/src/components/settings-menu.tsx
@@ -1,0 +1,59 @@
+import { toast } from "sonner";
+import { Settings } from "lucide-react";
+import type { SliderOrientation } from "@/bindings";
+import { useSliderOrientation } from "@/hooks/useSettings";
+import { setSliderOrientation } from "@/lib/actions";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+/**
+ * App settings in the nav — user preferences that persist on this device and
+ * sync to the account when signed in. Currently: the desk's fader orientation.
+ */
+export default function SettingsMenu() {
+  const orientation = useSliderOrientation();
+
+  const onOrientationChange = (value: string) => {
+    setSliderOrientation(value as SliderOrientation).catch((e) =>
+      toast.error(String(e))
+    );
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="px-2 text-muted-foreground hover:text-foreground"
+          aria-label="Settings"
+        >
+          <Settings className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuLabel className="font-normal text-muted-foreground">
+          Slider orientation
+        </DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={orientation}
+          onValueChange={onOrientationChange}
+        >
+          <DropdownMenuRadioItem value="vertical">
+            Vertical
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="horizontal">
+            Horizontal
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/desktop/src/components/ui/slider.tsx
+++ b/apps/desktop/src/components/ui/slider.tsx
@@ -10,13 +10,13 @@ const Slider = React.forwardRef<
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
-      "relative flex w-full touch-none select-none items-center",
+      "relative flex touch-none select-none items-center data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
       className
     )}
     {...props}
   >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    <SliderPrimitive.Track className="relative grow overflow-hidden rounded-full bg-secondary data-[orientation=horizontal]:h-2 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-2">
+      <SliderPrimitive.Range className="absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full" />
     </SliderPrimitive.Track>
     <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>

--- a/apps/desktop/src/hooks/useSettings.ts
+++ b/apps/desktop/src/hooks/useSettings.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createTauRPCProxy,
+  type SliderOrientation,
+  type UserSettings,
+} from "@/bindings";
+
+/** Query key for the user's synced settings. */
+export const SETTINGS_QUERY_KEY = ["settings"] as const;
+
+/**
+ * The user's settings (persisted locally, cloud-synced when signed in). `null`
+ * until the first read resolves.
+ *
+ * The setter in `lib/actions` pushes the settings the backend returns straight
+ * into the cache (the iOS-safe path); on desktop the `settingsChanged` event is
+ * also honored as a fast path so a cloud pull from another device shows live.
+ */
+export default function useSettings(): UserSettings | null {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    queryKey: SETTINGS_QUERY_KEY,
+    queryFn: () => createTauRPCProxy().cmd.get_settings(),
+  });
+
+  useEffect(() => {
+    const unlisten = createTauRPCProxy().cmd.event.on((event) => {
+      if (event.type === "settingsChanged") {
+        queryClient.setQueryData(SETTINGS_QUERY_KEY, event.settings);
+      }
+    });
+    return () => {
+      // .catch: if registration itself rejected (webview teardown), cleanup
+      // must not surface an unhandled rejection.
+      unlisten.then((f) => f()).catch(() => {});
+    };
+  }, [queryClient]);
+
+  return data ?? null;
+}
+
+/**
+ * The desk's fader orientation, defaulting to vertical (the classic
+ * lighting-console layout) while settings load or when the field is absent.
+ */
+export function useSliderOrientation(): SliderOrientation {
+  return useSettings()?.sliderOrientation ?? "vertical";
+}

--- a/apps/desktop/src/lib/actions.ts
+++ b/apps/desktop/src/lib/actions.ts
@@ -1,6 +1,7 @@
-import { createTauRPCProxy } from "@/bindings";
+import { createTauRPCProxy, type SliderOrientation } from "@/bindings";
 import { queryClient } from "@/lib/query-client";
 import { BUFFER_QUERY_KEY } from "@/hooks/useBuffer";
+import { SETTINGS_QUERY_KEY } from "@/hooks/useSettings";
 
 /**
  * Set one channel's value. Pushes the buffer the backend returns straight into
@@ -20,4 +21,20 @@ async function setChannelValue({
   return buffer;
 }
 
-export { setChannelValue };
+/**
+ * Flip the desk's fader orientation. Same cache-through pattern as
+ * {@link setChannelValue}: the returned settings land in the query cache
+ * directly, so the grid re-lays-out without waiting on the `settingsChanged`
+ * event (undelivered to the webview on iOS).
+ */
+async function setSliderOrientation(orientation: SliderOrientation) {
+  const taurpc = createTauRPCProxy();
+  const settings = await taurpc.cmd.set_slider_orientation(orientation);
+  // Kill any in-flight settings refetch first: one that started before the
+  // backend committed would resolve after this write and revert the cache.
+  await queryClient.cancelQueries({ queryKey: SETTINGS_QUERY_KEY });
+  queryClient.setQueryData(SETTINGS_QUERY_KEY, settings);
+  return settings;
+}
+
+export { setChannelValue, setSliderOrientation };

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { Updater } from "@/components/updater";
 import SetupSwitcher from "@/components/setup-switcher";
 import AccountMenu from "@/components/account-menu";
+import SettingsMenu from "@/components/settings-menu";
 import SyncIndicator from "@/components/sync-indicator";
 import useSyncOnFocus from "@/hooks/useSyncOnFocus";
 
@@ -29,6 +30,7 @@ function RootLayout() {
           </Link>
           <div className="ml-auto flex items-center gap-3">
             <SyncIndicator />
+            <SettingsMenu />
             <AccountMenu />
           </div>
         </nav>

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -27,6 +27,9 @@ pub const BASE_UPDATED_AT_QUERY: &str = "baseUpdatedAt";
 /// item in their partition ahead of Cognito account deletion.
 pub const USER_SEGMENT: &str = "user";
 
+/// The path segment both sides build the `/settings` routes from.
+pub const SETTINGS_SEGMENT: &str = "settings";
+
 /// One setup as it crosses the wire (an element of [`ListSetupsResponse`]).
 ///
 /// `fixtures` is deliberately opaque here: the server round-trips it as JSON
@@ -49,10 +52,16 @@ pub struct SetupRecord {
     pub deleted: bool,
 }
 
-/// Response to `GET /setups`.
+/// Response to `GET /setups` — the whole pull in one request.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListSetupsResponse {
     pub setups: Vec<SetupRecord>,
+    /// The account's settings record, riding the same partition query so a
+    /// pull never needs a second round trip. `None` until the account's first
+    /// settings push; also absent (defaulted) in replies from servers that
+    /// predate settings, which old-shaped clients likewise ignore.
+    #[serde(default)]
+    pub settings: Option<SettingsRecord>,
 }
 
 /// Request body for `PUT /setups/{id}`.
@@ -85,6 +94,36 @@ pub struct TombstoneResponse {
     pub deleted: bool,
 }
 
+/// The user's settings blob as it crosses the wire — one record per account,
+/// last-writer-wins as a whole.
+///
+/// `data` is deliberately opaque here, exactly like [`SetupRecord::fixtures`]:
+/// the server round-trips it as JSON and only the desktop gives it a concrete
+/// type, so adding a new setting never requires a server deploy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettingsRecord {
+    pub data: Value,
+    /// Server-side write counter. Informational on the client today; the
+    /// last-writer-wins authority is `updated_at`.
+    pub rev: i64,
+    /// Server-assigned epoch millis of the last write (never a client clock).
+    pub updated_at: i64,
+}
+
+/// Request body for `PUT /settings`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpsertSettingsBody {
+    /// The desktop's settings blob, opaque on the wire (see [`SettingsRecord`]).
+    pub data: Value,
+    /// The client's last-known server `updated_at` for the settings record —
+    /// the optimistic-concurrency token. `None` means "create; fail if it
+    /// exists".
+    #[serde(default)]
+    pub base_updated_at: Option<i64>,
+}
+
 /// Response to a successful `DELETE /user` — the server-side data wipe that
 /// precedes deleting the Cognito user (in-app account deletion).
 #[derive(Debug, Serialize, Deserialize)]
@@ -112,10 +151,16 @@ pub mod nudge {
     //! best-effort by design: a missed frame is healed by the existing
     //! pull-on-focus/reconnect safety nets.
 
-    /// `{"changed":"setups"}` — the only frame currently published. Opaque by
+    /// `{"changed":"setups"}` — published after a setup write. Opaque by
     /// design; see the module docs.
     pub fn setups_changed_frame() -> String {
         serde_json::json!({ "changed": "setups" }).to_string()
+    }
+
+    /// `{"changed":"settings"}` — published after a settings write. The label
+    /// only aids log readability; clients treat every frame identically.
+    pub fn settings_changed_frame() -> String {
+        serde_json::json!({ "changed": "settings" }).to_string()
     }
 
     /// The per-user nudge topic. The IoT custom authorizer scopes each
@@ -184,8 +229,26 @@ mod tests {
 
     #[test]
     fn list_response_shape() {
-        let body = ListSetupsResponse { setups: vec![] };
-        assert_eq!(serde_json::to_string(&body).unwrap(), r#"{"setups":[]}"#);
+        let body = ListSetupsResponse {
+            setups: vec![],
+            settings: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&body).unwrap(),
+            r#"{"setups":[],"settings":null}"#
+        );
+
+        // A reply from a server that predates settings still parses.
+        let old: ListSetupsResponse = serde_json::from_str(r#"{"setups":[]}"#).unwrap();
+        assert!(old.settings.is_none());
+
+        let with: ListSetupsResponse = serde_json::from_str(
+            r#"{"setups":[],"settings":{"data":{"sliderOrientation":"horizontal"},"rev":1,"updatedAt":42}}"#,
+        )
+        .unwrap();
+        let record = with.settings.unwrap();
+        assert_eq!(record.updated_at, 42);
+        assert_eq!(record.data["sliderOrientation"], "horizontal");
     }
 
     #[test]
@@ -240,6 +303,40 @@ mod tests {
     }
 
     #[test]
+    fn settings_record_shape() {
+        let record = SettingsRecord {
+            data: json!({ "sliderOrientation": "vertical" }),
+            rev: 2,
+            updated_at: 1719000000000,
+        };
+        assert_eq!(
+            serde_json::to_string(&record).unwrap(),
+            r#"{"data":{"sliderOrientation":"vertical"},"rev":2,"updatedAt":1719000000000}"#
+        );
+    }
+
+    #[test]
+    fn upsert_settings_body_shape() {
+        // `baseUpdatedAt: null` (not omitted) mirrors the setups body — pinned.
+        let create = UpsertSettingsBody {
+            data: json!({ "sliderOrientation": "vertical" }),
+            base_updated_at: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&create).unwrap(),
+            r#"{"data":{"sliderOrientation":"vertical"},"baseUpdatedAt":null}"#
+        );
+
+        let update: UpsertSettingsBody =
+            serde_json::from_str(r#"{"data":{},"baseUpdatedAt":42}"#).unwrap();
+        assert_eq!(update.base_updated_at, Some(42));
+
+        // A body without the field at all still parses.
+        let bare: UpsertSettingsBody = serde_json::from_str(r#"{"data":{}}"#).unwrap();
+        assert_eq!(bare.base_updated_at, None);
+    }
+
+    #[test]
     fn delete_user_data_response_shape() {
         let body = DeleteUserDataResponse { deleted_items: 3 };
         assert_eq!(
@@ -262,6 +359,7 @@ mod tests {
     #[test]
     fn nudge_frame_and_topics() {
         assert_eq!(nudge::setups_changed_frame(), r#"{"changed":"setups"}"#);
+        assert_eq!(nudge::settings_changed_frame(), r#"{"changed":"settings"}"#);
         assert_eq!(nudge::user_topic("abc-123"), "lux/sync/user/abc-123");
         assert_eq!(nudge::client_id_prefix("abc-123"), "lux-sync-abc-123-");
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,6 +24,6 @@ The code is environment-agnostic: every environment value — Cognito pool/clien
 
 ## Sync model (server-authoritative, nudged pull)
 
-Setups are edited locally (offline-first) and pushed with optimistic concurrency; the server assigns `updatedAt` (last-writer-wins) and deletes are soft tombstones. Pulls reconcile on sign-in, startup, window focus, and reconnect, with exponential-backoff retry while offline.
+Setups — and the user's settings blob, which syncs whole as a single record — are edited locally (offline-first) and pushed with optimistic concurrency; the server assigns `updatedAt` (last-writer-wins) and setup deletes are soft tombstones. Pulls reconcile on sign-in, startup, window focus, and reconnect, with exponential-backoff retry while offline.
 
 After each committed write the sync-api publishes a tiny opaque frame to the writer's own topic (`lux/sync/user/<sub>`). Each signed-in device keeps one open MQTT-over-WebSocket connection to IoT Core (`nudge.rs`), authorized per-user by the `lux-sync-auth` custom authorizer, and treats **any** frame as "pull now" — the frame is never parsed; the HTTP pull stays the authoritative sync. IoT Core is the connection holder, so the estate stays serverless while getting standing-connection push.

--- a/services/sync-api/src/main.rs
+++ b/services/sync-api/src/main.rs
@@ -11,9 +11,11 @@
 //! desktop deserializes with — so the two sides cannot drift.
 //!
 //! Routes (all under the Function URL):
-//! - `GET    /setups`        — list the caller's setups (incl. tombstones)
+//! - `GET    /setups`        — the whole pull: the caller's setups (incl.
+//!   tombstones) plus their settings record, from one partition query
 //! - `PUT    /setups/{id}`   — create/update one, optimistic-concurrency on `baseUpdatedAt`
 //! - `DELETE /setups/{id}?baseUpdatedAt=N` — soft-delete (tombstone)
+//! - `PUT    /settings`      — create/update the settings record, optimistic-concurrency on `baseUpdatedAt`
 //! - `DELETE /user`          — hard-delete the caller's whole partition (account deletion)
 //!
 //! After each committed write the handler publishes a tiny opaque nudge frame
@@ -28,7 +30,7 @@ use std::sync::Arc;
 use aws_config::BehaviorVersion;
 use lambda_http::{run, service_fn, Body, Error, Request, RequestExt, Response};
 use lux_wire::{
-    DeleteUserDataResponse, ErrorResponse, ListSetupsResponse, TombstoneResponse, UpsertSetupBody,
+    DeleteUserDataResponse, ErrorResponse, TombstoneResponse, UpsertSetupBody, UpsertSettingsBody,
     WriteResponse,
 };
 use serde::{Deserialize, Serialize};
@@ -124,6 +126,9 @@ async fn handle(ctx: Arc<Ctx>, req: Request) -> Result<Response<Body>, Error> {
         ("DELETE", [seg, id]) if *seg == lux_wire::SETUPS_SEGMENT => {
             tombstone(&ctx, &sub, id, &req).await
         }
+        ("PUT", [seg]) if *seg == lux_wire::SETTINGS_SEGMENT => {
+            upsert_settings(&ctx, &sub, &req).await
+        }
         ("DELETE", [seg]) if *seg == lux_wire::USER_SEGMENT => delete_user_data(&ctx, &sub).await,
         _ => reply(404, error("not found")),
     }
@@ -131,7 +136,7 @@ async fn handle(ctx: Arc<Ctx>, req: Request) -> Result<Response<Body>, Error> {
 
 async fn list(ctx: &Ctx, sub: &str) -> Result<Response<Body>, Error> {
     match store::list(&ctx.ddb, &ctx.table, sub).await {
-        Ok(setups) => reply(200, ListSetupsResponse { setups }),
+        Ok(body) => reply(200, body),
         Err(e) => {
             tracing::error!("list failed: {e}");
             reply(500, error("internal"))
@@ -146,7 +151,7 @@ async fn upsert(ctx: &Ctx, sub: &str, id: &str, req: &Request) -> Result<Respons
     };
     match store::upsert(&ctx.ddb, &ctx.table, sub, id, &body, now_millis()).await {
         Ok(res) => {
-            nudge(ctx, sub).await;
+            nudge(ctx, sub, lux_wire::nudge::setups_changed_frame()).await;
             reply(
                 200,
                 WriteResponse {
@@ -163,6 +168,36 @@ async fn upsert(ctx: &Ctx, sub: &str, id: &str, req: &Request) -> Result<Respons
     }
 }
 
+async fn upsert_settings(ctx: &Ctx, sub: &str, req: &Request) -> Result<Response<Body>, Error> {
+    let body: UpsertSettingsBody = match parse_body(req) {
+        Ok(b) => b,
+        Err(e) => return reply(400, error(&e)),
+    };
+    // The blob is opaque but must at least be an object: anything else could
+    // never parse as a client's settings, and one bad write would leave every
+    // device permanently unable to adopt the record.
+    if !body.data.is_object() {
+        return reply(400, error("settings data must be a JSON object"));
+    }
+    match store::upsert_settings(&ctx.ddb, &ctx.table, sub, &body, now_millis()).await {
+        Ok(res) => {
+            nudge(ctx, sub, lux_wire::nudge::settings_changed_frame()).await;
+            reply(
+                200,
+                WriteResponse {
+                    updated_at: res.updated_at,
+                    rev: res.rev,
+                },
+            )
+        }
+        Err(StoreError::Conflict) => reply(409, error("conflict")),
+        Err(StoreError::Internal(e)) => {
+            tracing::error!("settings upsert failed: {e}");
+            reply(500, error("internal"))
+        }
+    }
+}
+
 async fn tombstone(ctx: &Ctx, sub: &str, id: &str, req: &Request) -> Result<Response<Body>, Error> {
     let base = req
         .query_string_parameters()
@@ -170,7 +205,7 @@ async fn tombstone(ctx: &Ctx, sub: &str, id: &str, req: &Request) -> Result<Resp
         .and_then(|s| s.parse::<i64>().ok());
     match store::tombstone(&ctx.ddb, &ctx.table, sub, id, base, now_millis()).await {
         Ok(updated_at) => {
-            nudge(ctx, sub).await;
+            nudge(ctx, sub, lux_wire::nudge::setups_changed_frame()).await;
             reply(
                 200,
                 TombstoneResponse {
@@ -201,12 +236,13 @@ async fn delete_user_data(ctx: &Ctx, sub: &str) -> Result<Response<Body>, Error>
     }
 }
 
-/// Best-effort change nudge: publish the opaque `{"changed":"setups"}` frame to
-/// the caller's own topic so their other devices pull now. Never fails the
-/// request — a missed nudge is healed by the app's pull-on-focus/reconnect
-/// safety nets. (All of the user's connected devices get the frame, including
-/// the writer; its re-pull is coalesced client-side and harmless.)
-async fn nudge(ctx: &Ctx, sub: &str) {
+/// Best-effort change nudge: publish an opaque frame to the caller's own topic
+/// so their other devices pull now. Never fails the request — a missed nudge is
+/// healed by the app's pull-on-focus/reconnect safety nets. (All of the user's
+/// connected devices get the frame, including the writer; its re-pull is
+/// coalesced client-side and harmless. The frame's label only aids logs —
+/// clients treat every frame identically.)
+async fn nudge(ctx: &Ctx, sub: &str, frame: String) {
     let Some(iot) = &ctx.iot else { return };
     let topic = lux_wire::nudge::user_topic(sub);
     if let Err(e) = iot
@@ -214,7 +250,7 @@ async fn nudge(ctx: &Ctx, sub: &str) {
         .topic(&topic)
         .qos(0)
         .payload(aws_sdk_iotdataplane::primitives::Blob::new(
-            lux_wire::nudge::setups_changed_frame().into_bytes(),
+            frame.into_bytes(),
         ))
         .send()
         .await

--- a/services/sync-api/src/store.rs
+++ b/services/sync-api/src/store.rs
@@ -1,16 +1,20 @@
-//! DynamoDB persistence for a user's setups.
+//! DynamoDB persistence for a user's setups and settings.
 //!
-//! One item per setup: `pk = USER#<sub>`, `sk = SETUP#<setupId>`. `updatedAt`
-//! (epoch millis, assigned here on the server — never the client clock) is the
+//! One item per setup: `pk = USER#<sub>`, `sk = SETUP#<setupId>`, plus at most
+//! one settings item per user at `sk = SETTINGS`. `updatedAt` (epoch millis,
+//! assigned here on the server — never the client clock) is the
 //! last-writer-wins authority and the optimistic-concurrency token; writes are
-//! conditional on it. Fixtures are stored as an opaque JSON string so this layer
-//! stays agnostic to the app's fixture schema. Deletes are soft tombstones
-//! (`deleted = true`) so other devices learn of them on their next pull.
+//! conditional on it. Fixtures and the settings blob are stored as opaque JSON
+//! strings so this layer stays agnostic to the app's schemas. Setup deletes are
+//! soft tombstones (`deleted = true`) so other devices learn of them on their
+//! next pull.
 
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::types::{AttributeValue, ReturnValue};
 use aws_sdk_dynamodb::Client;
-use lux_wire::{SetupRecord, UpsertSetupBody};
+use lux_wire::{
+    ListSetupsResponse, SettingsRecord, SetupRecord, UpsertSetupBody, UpsertSettingsBody,
+};
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -45,8 +49,15 @@ fn sk(setup_id: &str) -> String {
     format!("SETUP#{setup_id}")
 }
 
-/// All of a user's setups, including tombstones (the client filters them).
-pub async fn list(ddb: &Client, table: &str, sub: &str) -> Result<Vec<SetupRecord>, StoreError> {
+/// Sort key of the user's single settings item. `list` surfaces it alongside
+/// the setups (one query serves the whole pull) and `delete_all` wipes it with
+/// the rest of the partition.
+const SETTINGS_SK: &str = "SETTINGS";
+
+/// The whole pull in one partition query: all of a user's setups (including
+/// tombstones — the client filters them) plus their settings record if one
+/// exists.
+pub async fn list(ddb: &Client, table: &str, sub: &str) -> Result<ListSetupsResponse, StoreError> {
     let out = ddb
         .query()
         .table_name(table)
@@ -57,11 +68,33 @@ pub async fn list(ddb: &Client, table: &str, sub: &str) -> Result<Vec<SetupRecor
         .map_err(internal)?;
 
     let mut setups = Vec::new();
+    let mut settings = None;
     for item in out.items() {
-        // Only setup items; skip any per-user META row that may share the pk.
         let Some(sk_val) = s(item, "sk") else {
             continue;
         };
+        if sk_val == SETTINGS_SK {
+            // Surface the record only with a real timestamp: an item missing
+            // `updatedAt` has no last-writer-wins authority, and serving 0
+            // would hand clients a base no conditional write can ever match.
+            // Treated as absent, the client's claim push repairs the item
+            // (see the create condition in `upsert_settings`).
+            if let Some(updated_at) = n(item, "updatedAt") {
+                settings = Some(SettingsRecord {
+                    // An unreadable stored blob surfaces as `null` — never as
+                    // a parseable empty object, which clients would adopt as a
+                    // silent settings reset. `null` fails their parse, so they
+                    // keep local values and repair the record on the next push.
+                    data: s(item, "data")
+                        .and_then(|raw| serde_json::from_str(&raw).ok())
+                        .unwrap_or(Value::Null),
+                    rev: n(item, "rev").unwrap_or(0),
+                    updated_at,
+                });
+            }
+            continue;
+        }
+        // Only setup items; skip any other per-user row that may share the pk.
         let Some(id) = sk_val.strip_prefix("SETUP#") else {
             continue;
         };
@@ -80,7 +113,7 @@ pub async fn list(ddb: &Client, table: &str, sub: &str) -> Result<Vec<SetupRecor
                 .unwrap_or(false),
         });
     }
-    Ok(setups)
+    Ok(ListSetupsResponse { setups, settings })
 }
 
 /// Create or update one setup with optimistic concurrency. With `base_updated_at`
@@ -123,6 +156,57 @@ pub async fn upsert(
             .condition_expression("#updatedAt = :base")
             .expression_attribute_values(":base", AttributeValue::N(base.to_string())),
         None => req.condition_expression("attribute_not_exists(pk)"),
+    };
+
+    let out = req.send().await.map_err(conflict_or_internal)?;
+    let attrs = out
+        .attributes()
+        .ok_or_else(|| StoreError::Internal("no attributes returned".into()))?;
+    Ok(WriteResult {
+        updated_at: n(attrs, "updatedAt").unwrap_or(now),
+        rev: n(attrs, "rev").unwrap_or(0),
+    })
+}
+
+/// Create or update the user's settings record with the same optimistic
+/// concurrency as [`upsert`]: with `base_updated_at` set, the write only lands
+/// if the stored `updatedAt` still matches it; without it, only if the record
+/// does not yet exist.
+pub async fn upsert_settings(
+    ddb: &Client,
+    table: &str,
+    sub: &str,
+    body: &UpsertSettingsBody,
+    now: i64,
+) -> Result<WriteResult, StoreError> {
+    let mut req = ddb
+        .update_item()
+        .table_name(table)
+        .key("pk", AttributeValue::S(pk(sub)))
+        .key("sk", AttributeValue::S(SETTINGS_SK.into()))
+        .update_expression(
+            "SET #data = :data, #updatedAt = :now, #rev = if_not_exists(#rev, :zero) + :one",
+        )
+        .expression_attribute_names("#data", "data")
+        .expression_attribute_names("#updatedAt", "updatedAt")
+        .expression_attribute_names("#rev", "rev")
+        .expression_attribute_values(":data", AttributeValue::S(body.data.to_string()))
+        .expression_attribute_values(":now", AttributeValue::N(now.to_string()))
+        .expression_attribute_values(":zero", AttributeValue::N("0".into()))
+        .expression_attribute_values(":one", AttributeValue::N("1".into()))
+        .return_values(ReturnValue::AllNew);
+
+    req = match body.base_updated_at {
+        Some(base) => req
+            .condition_expression("#updatedAt = :base")
+            .expression_attribute_values(":base", AttributeValue::N(base.to_string())),
+        // Create — or repair an item that lost its `updatedAt`: such a record
+        // has no last-writer-wins authority (and `list` hides it), so any
+        // client's claim may overwrite it; without this arm it would 409
+        // every claim forever.
+        None => req.condition_expression(
+            "attribute_not_exists(pk) OR attribute_not_exists(#updatedAt)",
+        ),
     };
 
     let out = req.send().await.map_err(conflict_or_internal)?;


### PR DESCRIPTION
## What

Adds a per-user **slider orientation** setting: vertical faders in horizontally-scrolling layouts (the new default), or the previous horizontal rows. It applies to the universe desk and to the channel controls inside fixture cards. Changed from a gear menu in the nav; persists locally and syncs across devices when signed in.

## How

- **Local**: a `UserSettings` blob lives in `setups.json` beside the setups, with the same `updated_at`/`dirty` sync bookkeeping a `Setup` carries. Every field is individually fault-tolerant (`ok_or_default`): an unknown value written by a newer client degrades to the field default on downgrade instead of failing the whole store parse.
- **Wire**: `SettingsRecord` is opaque on the wire (like `fixtures`), so future settings need no server deploy. The record rides `ListSetupsResponse` — the partition query already returned the item, so a pull stays one request. `PUT /settings` is the only new route; golden tests pin every new shape, and the change is a new optional field only, parseable by shipped clients.
- **Sync**: whole-blob last-writer-wins by server `updatedAt`, with claim semantics for never-synced state: a dirty local edit made before first sync rebases onto the remote timestamp and wins, mirroring how never-synced setups are claimed; an unparseable remote blob is never adopted and hands over only its timestamp so a later push repairs it. The merge decision is pure (`settings::reconcile`, unit-tested) and applied atomically under the store lock, so a concurrent edit can't be clobbered by a stale snapshot.
- **Hardening**: pushes are gated on the store being bound to the signed-in account, closing the window where a background retry could claim the previous user's data into a freshly signed-in account (covers setups too). Against a sync-api that predates `/settings`, settings pushes pause for the session instead of pinning the sync indicator at Offline. `mark_settings_pushed` only ever advances the concurrency base. The server rejects non-object settings payloads and hides a timestamp-less record so a corrupted item heals on the next claim.
- **UI**: one virtualized `Desk` component drives either axis (`@tanstack/react-virtual` horizontal mode), remounted via an orientation key; fixture cards render channels as compact vertical fader strips in a sideways-scrolling bank, reading the setting once per view. Both views wait for the settings read so the stored layout is the first one painted. Fader drag/toggle state is shared between the desk's row and column layouts (`useChannelFader`); `ui/slider.tsx` gains `data-[orientation=vertical]` variants — Radix stamps `data-orientation` on every part, so untouched horizontal consumers render unchanged.

## Compatibility

- Old desktop ↔ new sync-api: unaffected (new response field ignored; no new calls made).
- New desktop ↔ old sync-api (the dev window before the next release deploys the Lambda): the pull degrades to "no remote settings", the settings claim 404s once and pauses for the session, and setups sync is untouched.
- Older `setups.json` stores parse with defaults; a downgraded build parses a newer store (field-level tolerance).

## Verification

- `cargo test --workspace --locked` — all suites, including the new lux-wire goldens, the `settings::reconcile` decision table, store bookkeeping, and the bindings drift guard
- `cargo clippy --workspace -- -D warnings`
- `bun run build` / `typecheck` / `lint` in `apps/desktop`
- Verified in the dev app: the universe desk and fixture cards render vertically by default and flip from the gear menu.
- Still to check at the rig: drag faders against live hardware and confirm the setting follows a second signed-in device.