### PR TITLE
fix: collapsible fixture cards

### DIFF
--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -74,6 +74,15 @@ pub trait CmdMethods {
     ) -> Result<Vec<SetupSummary>, String>;
     fn delete_setup(&self, app_handle: AppHandle, id: String) -> Result<Vec<SetupSummary>, String>;
     fn set_active_setup(&self, app_handle: AppHandle, id: String) -> Result<SetupSummary, String>;
+    // Collapsed fixture cards — device-local UI state, persisted with the
+    // store but never synced.
+    fn get_collapsed_fixtures(&self, app_handle: AppHandle) -> Result<Vec<String>, String>;
+    fn set_fixture_collapsed(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        collapsed: bool,
+    ) -> Result<Vec<String>, String>;
     // User settings — persisted locally and cloud-synced when signed in.
     fn get_settings(&self, app_handle: AppHandle) -> Result<UserSettings, String>;
     fn set_slider_orientation(
@@ -293,6 +302,29 @@ impl CmdMethods for CmdEndpoint {
         activate(&app_handle, setups.inner())?;
         commit_setups(&app_handle, setups.inner())?;
         Ok(setups.active_summary())
+    }
+
+    fn get_collapsed_fixtures(&self, app_handle: AppHandle) -> Result<Vec<String>, String> {
+        Ok(app_handle
+            .state::<LuxSetups>()
+            .collapsed_fixture_ids()
+            .iter()
+            .map(uuid::Uuid::to_string)
+            .collect())
+    }
+
+    fn set_fixture_collapsed(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        collapsed: bool,
+    ) -> Result<Vec<String>, String> {
+        let id = parse_fixture_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        let ids = setups.set_fixture_collapsed(id, collapsed);
+        // Local UI state only: persist, but nothing to emit or push.
+        setup::save(&app_handle, setups.inner());
+        Ok(ids.iter().map(uuid::Uuid::to_string).collect())
     }
 
     fn get_settings(&self, app_handle: AppHandle) -> Result<UserSettings, String> {

--- a/apps/desktop/src-tauri/src/fixture.rs
+++ b/apps/desktop/src-tauri/src/fixture.rs
@@ -80,7 +80,7 @@ pub fn presets() -> Vec<FixturePreset> {
                 ch(Blue, "Blue"),
                 ch(Amber, "Amber"),
                 ch(White, "White"),
-                ch(Brightness, "Brightness"),
+                ch(Brightness, "Dimmer"),
             ],
         ),
         preset(

--- a/apps/desktop/src-tauri/src/fixture.rs
+++ b/apps/desktop/src-tauri/src/fixture.rs
@@ -80,7 +80,7 @@ pub fn presets() -> Vec<FixturePreset> {
                 ch(Blue, "Blue"),
                 ch(Amber, "Amber"),
                 ch(White, "White"),
-                ch(Brightness, "Dimmer"),
+                ch(Brightness, "Brightness"),
             ],
         ),
         preset(

--- a/apps/desktop/src-tauri/src/setup.rs
+++ b/apps/desktop/src-tauri/src/setup.rs
@@ -81,6 +81,12 @@ pub struct SetupStore {
     /// the delete propagates to other devices. Drained as each push succeeds.
     #[serde(default)]
     pub pending_deletes: Vec<PendingDelete>,
+    /// Fixture cards the user collapsed — device-local UI state (like
+    /// `active_setup_id`, deliberately not cloud-synced: each device keeps its
+    /// own density). Absence means expanded, so new fixtures start expanded.
+    #[serde(default)]
+    #[specta(type = Vec<String>)]
+    pub collapsed_fixture_ids: Vec<uuid::Uuid>,
     /// User-level preferences, cloud-synced as one blob (LWW). Defaults keep
     /// older `setups.json` readable.
     #[serde(default)]
@@ -154,6 +160,7 @@ impl SetupStore {
             setups: vec![setup],
             bound_email: None,
             pending_deletes: Vec::new(),
+            collapsed_fixture_ids: Vec::new(),
             settings: UserSettings::default(),
             settings_updated_at: None,
             settings_dirty: false,
@@ -346,6 +353,36 @@ impl LuxSetups {
         }
         store.active_setup_id = id;
         Ok(())
+    }
+
+    // -- collapsed fixture cards (persisted with the store, never synced) --
+
+    pub fn collapsed_fixture_ids(&self) -> Vec<uuid::Uuid> {
+        self.store.lock_or_recover().collapsed_fixture_ids.clone()
+    }
+
+    /// Record one card's collapse state and return the new set. Prunes ids
+    /// whose fixtures no longer exist in any setup, so the list can't grow
+    /// unboundedly as fixtures are deleted.
+    pub fn set_fixture_collapsed(&self, id: uuid::Uuid, collapsed: bool) -> Vec<uuid::Uuid> {
+        let mut store = self.store.lock_or_recover();
+        let live = |fid: &uuid::Uuid| {
+            store
+                .setups
+                .iter()
+                .any(|s| s.fixtures.iter().any(|f| f.id == *fid))
+        };
+        let mut ids: Vec<uuid::Uuid> = store
+            .collapsed_fixture_ids
+            .iter()
+            .copied()
+            .filter(|c| *c != id && live(c))
+            .collect();
+        if collapsed {
+            ids.push(id);
+        }
+        store.collapsed_fixture_ids = ids.clone();
+        ids
     }
 
     // -- user settings (persisted with the store, synced as one blob) --
@@ -756,6 +793,30 @@ mod tests {
         let id = setups.create("Edge".into(), 0).unwrap(); // 0 clamps up to 1
         setups.set_active(id).unwrap();
         assert_eq!(setups.active_universe(), 1);
+    }
+
+    // -- collapsed fixture cards --
+
+    #[test]
+    fn collapse_state_round_trips_and_prunes_dead_fixtures() {
+        let setups: LuxSetups = SetupStore::default().into();
+        let fixture_id = setups.active_fixtures()[0].id;
+        let ghost = uuid::Uuid::new_v4(); // never a real fixture
+
+        assert_eq!(setups.set_fixture_collapsed(fixture_id, true), vec![fixture_id]);
+        // A stale id (deleted fixture) is dropped on the next write.
+        {
+            let mut store = setups.store.lock_or_recover();
+            store.collapsed_fixture_ids.push(ghost);
+        }
+        assert_eq!(setups.set_fixture_collapsed(fixture_id, true), vec![fixture_id]);
+
+        // Expanding removes it; the store round-trips through JSON.
+        assert!(setups.set_fixture_collapsed(fixture_id, false).is_empty());
+        setups.set_fixture_collapsed(fixture_id, true);
+        let json = serde_json::to_string(&setups.snapshot()).unwrap();
+        let back = parse_store(&json).unwrap();
+        assert_eq!(back.collapsed_fixture_ids, vec![fixture_id]);
     }
 
     // -- user settings --

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -85,6 +85,16 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  get_collapsed_fixtures(): Promise<string[]> {
+    return invoke("cmd.get_collapsed_fixtures");
+  },
+
+  /** @throws {string} */
+  set_fixture_collapsed(id: string, collapsed: boolean): Promise<string[]> {
+    return invoke("cmd.set_fixture_collapsed", { id, collapsed });
+  },
+
+  /** @throws {string} */
   get_settings(): Promise<UserSettings> {
     return invoke("cmd.get_settings");
   },

--- a/apps/desktop/src/components/color-picker/color-trigger.tsx
+++ b/apps/desktop/src/components/color-picker/color-trigger.tsx
@@ -26,25 +26,26 @@ export default function ColorTrigger({
   const light = colord(fill).lighten(luminance).toRgbString();
   const background = `radial-gradient(${light} 0, ${fill} ${spread}%)`;
   const boxShadow = `0 0 ${spread}px ${light}`;
-  // label="" renders a bare swatch (compact contexts): sized to the minimum
-  // touch target (44px) with zero padding, so the hit area is exactly the
-  // visible circle — no invisible margin to open the picker by accident.
+  // The swatch is always the 44px minimum touch target — the same circle
+  // whether the card is expanded or collapsed. label="" renders it bare with
+  // zero padding, so the hit area is exactly the visible circle — no
+  // invisible margin to open the picker by accident.
   const bare = !label;
   return (
     <PopoverTrigger asChild>
       <Button
         variant="ghost"
         aria-label={label || "Color"}
-        className={cn(bare ? "size-11 rounded-full p-0" : "gap-3", className)}
+        className={cn(
+          bare ? "size-11 rounded-full p-0" : "h-auto gap-3 py-1.5",
+          className
+        )}
       >
         {label || null}
         {/* The faint ring keeps the swatch findable at blackout (a black
             glow-less circle would vanish into the card). */}
         <div
-          className={cn(
-            "rounded-full border border-border/60",
-            bare ? "size-11" : "size-7"
-          )}
+          className="size-11 rounded-full border border-border/60"
           style={{ background, boxShadow }}
         />
       </Button>

--- a/apps/desktop/src/components/color-picker/color-trigger.tsx
+++ b/apps/desktop/src/components/color-picker/color-trigger.tsx
@@ -36,7 +36,12 @@ export default function ColorTrigger({
         className={cn("gap-3", className)}
       >
         {label || null}
-        <div className="size-7 rounded-full" style={{ background, boxShadow }} />
+        {/* The faint ring keeps the swatch findable at blackout (a black
+            glow-less circle would vanish into the card). */}
+        <div
+          className="size-7 rounded-full border border-border/60"
+          style={{ background, boxShadow }}
+        />
       </Button>
     </PopoverTrigger>
   );

--- a/apps/desktop/src/components/color-picker/color-trigger.tsx
+++ b/apps/desktop/src/components/color-picker/color-trigger.tsx
@@ -28,8 +28,14 @@ export default function ColorTrigger({
   const boxShadow = `0 0 ${spread}px ${light}`;
   return (
     <PopoverTrigger asChild>
-      <Button variant="ghost" className={cn("gap-3", className)}>
-        {label}
+      {/* label="" renders a bare swatch (compact contexts); keep it named
+          for screen readers either way. */}
+      <Button
+        variant="ghost"
+        aria-label={label || "Color"}
+        className={cn("gap-3", className)}
+      >
+        {label || null}
         <div className="size-7 rounded-full" style={{ background, boxShadow }} />
       </Button>
     </PopoverTrigger>

--- a/apps/desktop/src/components/color-picker/color-trigger.tsx
+++ b/apps/desktop/src/components/color-picker/color-trigger.tsx
@@ -26,20 +26,25 @@ export default function ColorTrigger({
   const light = colord(fill).lighten(luminance).toRgbString();
   const background = `radial-gradient(${light} 0, ${fill} ${spread}%)`;
   const boxShadow = `0 0 ${spread}px ${light}`;
+  // label="" renders a bare swatch (compact contexts): sized to the minimum
+  // touch target (44px) with zero padding, so the hit area is exactly the
+  // visible circle — no invisible margin to open the picker by accident.
+  const bare = !label;
   return (
     <PopoverTrigger asChild>
-      {/* label="" renders a bare swatch (compact contexts); keep it named
-          for screen readers either way. */}
       <Button
         variant="ghost"
         aria-label={label || "Color"}
-        className={cn("gap-3", className)}
+        className={cn(bare ? "size-11 rounded-full p-0" : "gap-3", className)}
       >
         {label || null}
         {/* The faint ring keeps the swatch findable at blackout (a black
             glow-less circle would vanish into the card). */}
         <div
-          className="size-7 rounded-full border border-border/60"
+          className={cn(
+            "rounded-full border border-border/60",
+            bare ? "size-11" : "size-7"
+          )}
           style={{ background, boxShadow }}
         />
       </Button>

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { createTauRPCProxy, type Fixture } from "@/bindings";
 import useLuxRefresh from "@/hooks/useLuxRefresh";
+import { setFixtureCollapsed } from "@/lib/actions";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import FixtureChannel from "./fixture-channel";
@@ -36,10 +37,12 @@ export default function FixtureCard({
   fixture,
   buffer,
   vertical,
+  collapsed,
 }: {
   fixture: Fixture;
   buffer: number[] | null;
   vertical: boolean;
+  collapsed: boolean;
 }) {
   const { id, name, address, channels } = fixture;
   const hasColor = COLOR_ROLES.every((role) =>
@@ -47,7 +50,10 @@ export default function FixtureCard({
   );
   const dimmerIndex = channels.findIndex((c) => c.role === "Brightness");
 
-  const [expanded, setExpanded] = useState(true);
+  // Collapse state persists (device-local, in setups.json); the view owns the
+  // source of truth and this just requests the flip.
+  const setCollapsed = (next: boolean) =>
+    setFixtureCollapsed(id, next).catch((e) => toast.error(String(e)));
   // The collapse axis follows the layout: the vertical console shrinks a card
   // sideways, the horizontal list shrinks it downward — the icons say which.
   const CollapseIcon = vertical ? ChevronsRightLeft : ChevronsDownUp;
@@ -104,11 +110,11 @@ export default function FixtureCard({
     Number.isFinite(parsedDraft) && parsedDraft >= 1 ? parsedDraft : address;
   const previewEnd = previewStart + channels.length - 1;
 
-  if (!expanded) {
+  if (collapsed) {
     const expandButton = (
       <button
         type="button"
-        onClick={() => setExpanded(true)}
+        onClick={() => setCollapsed(false)}
         aria-expanded={false}
         aria-label={`Expand ${name}`}
         title={name}
@@ -209,7 +215,7 @@ export default function FixtureCard({
           className="size-8 shrink-0 text-muted-foreground/60 hover:text-foreground"
           aria-label={`Collapse ${name}`}
           aria-expanded
-          onClick={() => setExpanded(false)}
+          onClick={() => setCollapsed(true)}
         >
           <CollapseIcon className="size-4" />
         </Button>

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -1,12 +1,6 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import {
-  ChevronsDownUp,
-  ChevronsLeftRight,
-  ChevronsRightLeft,
-  ChevronsUpDown,
-  Trash2,
-} from "lucide-react";
+import { ChevronsDownUp, ChevronsRightLeft, Trash2 } from "lucide-react";
 import { createTauRPCProxy, type Fixture } from "@/bindings";
 import useLuxRefresh from "@/hooks/useLuxRefresh";
 import { setFixtureCollapsed } from "@/lib/actions";
@@ -55,9 +49,8 @@ export default function FixtureCard({
   const setCollapsed = (next: boolean) =>
     setFixtureCollapsed(id, next).catch((e) => toast.error(String(e)));
   // The collapse axis follows the layout: the vertical console shrinks a card
-  // sideways, the horizontal list shrinks it downward — the icons say which.
+  // sideways, the horizontal list shrinks it downward — the icon says which.
   const CollapseIcon = vertical ? ChevronsRightLeft : ChevronsDownUp;
-  const ExpandIcon = vertical ? ChevronsLeftRight : ChevronsUpDown;
 
   const refresh = useLuxRefresh();
 
@@ -111,27 +104,26 @@ export default function FixtureCard({
   const previewEnd = previewStart + channels.length - 1;
 
   // The collapsed card is the expanded card's anatomy at strip width: same
-  // padding and header row (initials + channel span where name + span sit,
-  // the expand control in the collapse control's corner), the color row in
-  // its usual slot, and the fader stretching so card bottoms stay level.
+  // padding and header row (initials + channel span where name + span sit),
+  // the color row in its usual slot, and the fader stretching so card
+  // bottoms stay level. The whole surface expands — no dedicated button;
+  // only the live controls (swatch, fader, value toggle) keep their jobs.
   if (collapsed) {
-    const expandButton = (
-      <Button
-        variant="ghost"
-        size="icon"
-        className="size-8 shrink-0 text-muted-foreground/60 hover:text-foreground"
-        aria-label={`Expand ${name}`}
-        aria-expanded={false}
-        onClick={() => setCollapsed(false)}
-      >
-        <ExpandIcon className="size-4" />
-      </Button>
-    );
+    const expandOnSurfaceClick = (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement;
+      // Interactive controls handle their own clicks. `.touch-none` is the
+      // slider root (track clicks start a drag); the picker popover is
+      // portaled, so its clicks never reach the card at all.
+      if (target.closest("button, input, [role='slider'], .touch-none")) return;
+      setCollapsed(false);
+    };
     const nameButton = (
       <button
         type="button"
         onClick={() => setCollapsed(false)}
         title={name}
+        aria-label={`Expand ${name}`}
+        aria-expanded={false}
         className="truncate font-semibold transition-colors hover:text-muted-foreground"
       >
         {initials(name)}
@@ -155,13 +147,13 @@ export default function FixtureCard({
 
     if (vertical) {
       return (
-        <section className="flex w-fit shrink-0 flex-col rounded-xl border bg-card p-5">
-          <header className="mb-3 flex items-start justify-between gap-2">
-            <div className="min-w-0">
-              {nameButton}
-              {spanLine}
-            </div>
-            {expandButton}
+        <section
+          onClick={expandOnSurfaceClick}
+          className="flex w-fit shrink-0 cursor-pointer flex-col rounded-xl border bg-card p-5"
+        >
+          <header className="mb-3">
+            {nameButton}
+            {spanLine}
           </header>
           {hasColor && (
             <div className="mb-1">
@@ -173,14 +165,16 @@ export default function FixtureCard({
       );
     }
     return (
-      <section className="rounded-xl border bg-card px-5 py-3">
+      <section
+        onClick={expandOnSurfaceClick}
+        className="cursor-pointer rounded-xl border bg-card px-5 py-3"
+      >
         <div className="flex items-center gap-3">
           {nameButton}
           {hasColor && (
             <FixtureColor fixture={fixture} buffer={buffer} label="" />
           )}
           <div className="min-w-0 flex-1">{dimmer}</div>
-          {expandButton}
         </div>
       </section>
     );

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -134,14 +134,15 @@ export default function FixtureCard({
         {channels.length === 1 ? address : `${address}-${previewEnd}`}
       </p>
     );
+    // Role-derived label: whatever the stored channel is called, the strip a
+    // collapsed card surfaces is the fixture's brightness by definition.
     const dimmer = dimmerIndex >= 0 && (
       <FixtureChannel
         address={address + dimmerIndex}
         role={channels[dimmerIndex].role}
-        label={channels[dimmerIndex].label}
+        label="Brightness"
         value={buffer?.[address + dimmerIndex - 1] ?? 0}
         vertical={vertical}
-        hideLabel
       />
     );
 
@@ -149,9 +150,9 @@ export default function FixtureCard({
       return (
         <section
           onClick={expandOnSurfaceClick}
-          className="flex w-fit shrink-0 cursor-pointer flex-col rounded-xl border bg-card p-5"
+          className="flex w-fit shrink-0 cursor-pointer flex-col items-center rounded-xl border bg-card p-5"
         >
-          <header className="mb-3">
+          <header className="mb-3 flex flex-col items-center">
             {nameButton}
             {spanLine}
           </header>

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -110,19 +110,37 @@ export default function FixtureCard({
     Number.isFinite(parsedDraft) && parsedDraft >= 1 ? parsedDraft : address;
   const previewEnd = previewStart + channels.length - 1;
 
+  // The collapsed card is the expanded card's anatomy at strip width: same
+  // padding and header row (initials + channel span where name + span sit,
+  // the expand control in the collapse control's corner), the color row in
+  // its usual slot, and the fader stretching so card bottoms stay level.
   if (collapsed) {
     const expandButton = (
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-8 shrink-0 text-muted-foreground/60 hover:text-foreground"
+        aria-label={`Expand ${name}`}
+        aria-expanded={false}
+        onClick={() => setCollapsed(false)}
+      >
+        <ExpandIcon className="size-4" />
+      </Button>
+    );
+    const nameButton = (
       <button
         type="button"
         onClick={() => setCollapsed(false)}
-        aria-expanded={false}
-        aria-label={`Expand ${name}`}
         title={name}
-        className="flex items-center gap-1 font-semibold transition-colors hover:text-muted-foreground"
+        className="truncate font-semibold transition-colors hover:text-muted-foreground"
       >
         {initials(name)}
-        <ExpandIcon className="size-3.5 text-muted-foreground/60" />
       </button>
+    );
+    const spanLine = (
+      <p className="text-xs tabular-nums text-muted-foreground">
+        {channels.length === 1 ? address : `${address}-${previewEnd}`}
+      </p>
     );
     const dimmer = dimmerIndex >= 0 && (
       <FixtureChannel
@@ -137,28 +155,32 @@ export default function FixtureCard({
 
     if (vertical) {
       return (
-        <section className="w-fit shrink-0 rounded-xl border bg-card p-3">
-          <div className="flex flex-col items-center gap-2">
+        <section className="flex w-fit shrink-0 flex-col rounded-xl border bg-card p-5">
+          <header className="mb-3 flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              {nameButton}
+              {spanLine}
+            </div>
             {expandButton}
-            {/* pl-2 cancels the trigger's -ml-2 so the swatch centers. */}
-            {hasColor && (
-              <div className="pl-2">
-                <FixtureColor fixture={fixture} buffer={buffer} label="" />
-              </div>
-            )}
-            {dimmer}
-          </div>
+          </header>
+          {hasColor && (
+            <div className="mb-1">
+              <FixtureColor fixture={fixture} buffer={buffer} label="" />
+            </div>
+          )}
+          <div className="flex min-h-0 flex-1">{dimmer}</div>
         </section>
       );
     }
     return (
       <section className="rounded-xl border bg-card px-5 py-3">
         <div className="flex items-center gap-3">
-          {expandButton}
+          {nameButton}
           {hasColor && (
             <FixtureColor fixture={fixture} buffer={buffer} label="" />
           )}
           <div className="min-w-0 flex-1">{dimmer}</div>
+          {expandButton}
         </div>
       </section>
     );

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Trash2 } from "lucide-react";
+import { ChevronsDownUp, ChevronsUpDown, Trash2 } from "lucide-react";
 import { createTauRPCProxy, type Fixture } from "@/bindings";
 import useLuxRefresh from "@/hooks/useLuxRefresh";
 import { cn } from "@/lib/utils";
@@ -10,6 +10,22 @@ import FixtureColor from "./fixture-color";
 
 const COLOR_ROLES = ["Red", "Green", "Blue"] as const;
 
+/** "Living Room" → "LR", "Fixture 12" → "F12": word initials, whole numbers. */
+function initials(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .map((word) => (/^\d+$/.test(word) ? word : word[0].toUpperCase()))
+    .join("")
+    .slice(0, 4);
+}
+
+/**
+ * One patched fixture. Expanded: inline-renamable name, delete, the color
+ * wheel, and every channel. Collapsed: just the live essentials — the name's
+ * initials, the color wheel, and the Brightness fader (when the fixture has
+ * one); everything editorial waits behind expand.
+ */
 export default function FixtureCard({
   fixture,
   buffer,
@@ -24,6 +40,9 @@ export default function FixtureCard({
   const hasColor = COLOR_ROLES.every((role) =>
     channels.some((c) => c.role === role)
   );
+  const dimmerIndex = channels.findIndex((c) => c.role === "Brightness");
+
+  const [expanded, setExpanded] = useState(true);
 
   const refresh = useLuxRefresh();
 
@@ -51,6 +70,57 @@ export default function FixtureCard({
 
   const span =
     channels.length === 1 ? `Channel ${address}` : `Channels ${address}-${end}`;
+
+  if (!expanded) {
+    const expandButton = (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        aria-expanded={false}
+        aria-label={`Expand ${name}`}
+        title={name}
+        className="flex items-center gap-1 font-semibold transition-colors hover:text-muted-foreground"
+      >
+        {initials(name)}
+        <ChevronsUpDown className="size-3.5 text-muted-foreground/60" />
+      </button>
+    );
+    const dimmer = dimmerIndex >= 0 && (
+      <FixtureChannel
+        address={address + dimmerIndex}
+        role={channels[dimmerIndex].role}
+        label={channels[dimmerIndex].label}
+        value={buffer?.[address + dimmerIndex - 1] ?? 0}
+        vertical={vertical}
+      />
+    );
+
+    if (vertical) {
+      return (
+        <section className="w-fit shrink-0 rounded-xl border bg-card p-3">
+          <div className="flex flex-col items-center gap-2">
+            {expandButton}
+            {/* pl-2 cancels the trigger's -ml-2 so the swatch centers. */}
+            {hasColor && (
+              <div className="pl-2">
+                <FixtureColor fixture={fixture} buffer={buffer} />
+              </div>
+            )}
+            {dimmer}
+          </div>
+        </section>
+      );
+    }
+    return (
+      <section className="rounded-xl border bg-card px-5 py-3">
+        <div className="flex items-center gap-3">
+          {expandButton}
+          {hasColor && <FixtureColor fixture={fixture} buffer={buffer} />}
+          <div className="min-w-0 flex-1">{dimmer}</div>
+        </div>
+      </section>
+    );
+  }
 
   return (
     // Vertical mode: the card hugs its fader strips instead of stretching to
@@ -81,6 +151,16 @@ export default function FixtureCard({
             {span}
           </p>
         </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8 shrink-0 text-muted-foreground/60 hover:text-foreground"
+          aria-label={`Collapse ${name}`}
+          aria-expanded
+          onClick={() => setExpanded(false)}
+        >
+          <ChevronsDownUp className="size-4" />
+        </Button>
         <Button
           variant="ghost"
           size="icon"

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { ChevronsDownUp, ChevronsUpDown, Trash2 } from "lucide-react";
+import {
+  ChevronsDownUp,
+  ChevronsLeftRight,
+  ChevronsRightLeft,
+  ChevronsUpDown,
+  Trash2,
+} from "lucide-react";
 import { createTauRPCProxy, type Fixture } from "@/bindings";
 import useLuxRefresh from "@/hooks/useLuxRefresh";
 import { cn } from "@/lib/utils";
@@ -36,13 +42,16 @@ export default function FixtureCard({
   vertical: boolean;
 }) {
   const { id, name, address, channels } = fixture;
-  const end = address + channels.length - 1;
   const hasColor = COLOR_ROLES.every((role) =>
     channels.some((c) => c.role === role)
   );
   const dimmerIndex = channels.findIndex((c) => c.role === "Brightness");
 
   const [expanded, setExpanded] = useState(true);
+  // The collapse axis follows the layout: the vertical console shrinks a card
+  // sideways, the horizontal list shrinks it downward — the icons say which.
+  const CollapseIcon = vertical ? ChevronsRightLeft : ChevronsDownUp;
+  const ExpandIcon = vertical ? ChevronsLeftRight : ChevronsUpDown;
 
   const refresh = useLuxRefresh();
 
@@ -68,8 +77,32 @@ export default function FixtureCard({
       .catch((e) => toast.error(String(e)));
   };
 
-  const span =
-    channels.length === 1 ? `Channel ${address}` : `Channels ${address}-${end}`;
+  // Inline-editable start channel, same interaction as the name. The channel
+  // count comes from the channel defs, so the range moves as one block; the
+  // backend validates bounds and overlaps and its message surfaces as a toast.
+  const [addressDraft, setAddressDraft] = useState(String(address));
+  useEffect(() => setAddressDraft(String(address)), [address]);
+
+  const readdress = (next: string) => {
+    const parsed = Number.parseInt(next.trim(), 10);
+    if (!Number.isFinite(parsed) || parsed < 1 || parsed === address) {
+      setAddressDraft(String(address));
+      return;
+    }
+    createTauRPCProxy()
+      .cmd.update_fixture(id, name, parsed, channels)
+      .then(refresh)
+      .catch((e) => {
+        setAddressDraft(String(address));
+        toast.error(String(e));
+      });
+  };
+
+  // The span's end previews the draft while it's a plausible start.
+  const parsedDraft = Number.parseInt(addressDraft, 10);
+  const previewStart =
+    Number.isFinite(parsedDraft) && parsedDraft >= 1 ? parsedDraft : address;
+  const previewEnd = previewStart + channels.length - 1;
 
   if (!expanded) {
     const expandButton = (
@@ -82,7 +115,7 @@ export default function FixtureCard({
         className="flex items-center gap-1 font-semibold transition-colors hover:text-muted-foreground"
       >
         {initials(name)}
-        <ChevronsUpDown className="size-3.5 text-muted-foreground/60" />
+        <ExpandIcon className="size-3.5 text-muted-foreground/60" />
       </button>
     );
     const dimmer = dimmerIndex >= 0 && (
@@ -147,8 +180,24 @@ export default function FixtureCard({
             aria-label="Fixture name"
             className="-ml-1 w-full truncate rounded-sm border border-transparent bg-transparent px-1 font-semibold outline-none transition-colors hover:border-border focus:border-border"
           />
-          <p className="px-1 text-xs tabular-nums text-muted-foreground">
-            {span}
+          <p className="flex items-center px-1 text-xs tabular-nums text-muted-foreground">
+            {channels.length === 1 ? "Channel" : "Channels"}
+            <input
+              value={addressDraft}
+              onChange={(e) => setAddressDraft(e.target.value)}
+              onBlur={() => readdress(addressDraft)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.currentTarget.blur();
+                if (e.key === "Escape") {
+                  setAddressDraft(String(address));
+                  e.currentTarget.blur();
+                }
+              }}
+              inputMode="numeric"
+              aria-label="Fixture start channel"
+              className="ml-1 w-9 rounded-sm border border-transparent bg-transparent px-1 text-xs tabular-nums outline-none transition-colors hover:border-border focus:border-border"
+            />
+            {channels.length > 1 && <span>-{previewEnd}</span>}
           </p>
         </div>
         <Button
@@ -159,7 +208,7 @@ export default function FixtureCard({
           aria-expanded
           onClick={() => setExpanded(false)}
         >
-          <ChevronsDownUp className="size-4" />
+          <CollapseIcon className="size-4" />
         </Button>
         <Button
           variant="ghost"

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -125,6 +125,7 @@ export default function FixtureCard({
         label={channels[dimmerIndex].label}
         value={buffer?.[address + dimmerIndex - 1] ?? 0}
         vertical={vertical}
+        hideLabel
       />
     );
 

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -48,6 +48,18 @@ export default function FixtureCard({
   // source of truth and this just requests the flip.
   const setCollapsed = (next: boolean) =>
     setFixtureCollapsed(id, next).catch((e) => toast.error(String(e)));
+
+  // Both states toggle on a surface click. Interactive controls handle their
+  // own clicks (`.touch-none` is the slider root — track clicks start a
+  // drag; the picker popover is portaled so its clicks never reach the
+  // card), and a click that ends a text selection (dragging through the
+  // name/address inputs) is not a toggle.
+  const toggleOnSurfaceClick = (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+    if (target.closest("button, input, [role='slider'], .touch-none")) return;
+    if (window.getSelection()?.toString()) return;
+    setCollapsed(!collapsed);
+  };
   // The collapse axis follows the layout: the vertical console shrinks a card
   // sideways, the horizontal list shrinks it downward — the icon says which.
   const CollapseIcon = vertical ? ChevronsRightLeft : ChevronsDownUp;
@@ -109,14 +121,6 @@ export default function FixtureCard({
   // bottoms stay level. The whole surface expands — no dedicated button;
   // only the live controls (swatch, fader, value toggle) keep their jobs.
   if (collapsed) {
-    const expandOnSurfaceClick = (e: React.MouseEvent) => {
-      const target = e.target as HTMLElement;
-      // Interactive controls handle their own clicks. `.touch-none` is the
-      // slider root (track clicks start a drag); the picker popover is
-      // portaled, so its clicks never reach the card at all.
-      if (target.closest("button, input, [role='slider'], .touch-none")) return;
-      setCollapsed(false);
-    };
     const nameButton = (
       <button
         type="button"
@@ -148,7 +152,7 @@ export default function FixtureCard({
     if (vertical) {
       return (
         <section
-          onClick={expandOnSurfaceClick}
+          onClick={toggleOnSurfaceClick}
           className="flex w-fit shrink-0 cursor-pointer flex-col items-center rounded-xl border bg-card p-5"
         >
           <header className="mb-3 flex flex-col items-center">
@@ -166,7 +170,7 @@ export default function FixtureCard({
     }
     return (
       <section
-        onClick={expandOnSurfaceClick}
+        onClick={toggleOnSurfaceClick}
         className="cursor-pointer rounded-xl border bg-card px-5 py-3"
       >
         <div className="flex items-center gap-3">
@@ -182,10 +186,12 @@ export default function FixtureCard({
 
   return (
     // Vertical mode: the card hugs its fader strips instead of stretching to
-    // the container, so cards pack side by side in the scrolling bank.
+    // the container, so cards pack side by side in the scrolling bank. The
+    // surface click-toggles just like the collapsed form.
     <section
+      onClick={toggleOnSurfaceClick}
       className={cn(
-        "rounded-xl border bg-card p-5",
+        "cursor-pointer rounded-xl border bg-card p-5",
         vertical && "w-fit shrink-0"
       )}
     >

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -185,14 +185,14 @@ export default function FixtureCard({
   }
 
   return (
-    // Vertical mode: the card hugs its fader strips instead of stretching to
-    // the container, so cards pack side by side in the scrolling bank. The
-    // surface click-toggles just like the collapsed form.
+    // Vertical mode: the card hugs its fader strips widthwise, packs side by
+    // side in the scrolling bank, and lets the strips absorb the bank's full
+    // height. The surface click-toggles just like the collapsed form.
     <section
       onClick={toggleOnSurfaceClick}
       className={cn(
         "cursor-pointer rounded-xl border bg-card p-5",
-        vertical && "w-fit shrink-0"
+        vertical && "flex min-h-0 w-fit shrink-0 flex-col"
       )}
     >
       <header className="mb-3 flex items-start justify-between gap-2">
@@ -258,7 +258,11 @@ export default function FixtureCard({
         </div>
       )}
 
-      <div className={vertical ? "flex gap-1" : "flex flex-col gap-0.5"}>
+      <div
+        className={
+          vertical ? "flex min-h-0 flex-1 gap-1" : "flex flex-col gap-0.5"
+        }
+      >
         {channels.map((channel, i) => (
           <FixtureChannel
             key={`${id}-${i}`}

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -134,15 +134,14 @@ export default function FixtureCard({
         {channels.length === 1 ? address : `${address}-${previewEnd}`}
       </p>
     );
-    // Role-derived label: whatever the stored channel is called, the strip a
-    // collapsed card surfaces is the fixture's brightness by definition.
     const dimmer = dimmerIndex >= 0 && (
       <FixtureChannel
         address={address + dimmerIndex}
         role={channels[dimmerIndex].role}
-        label="Brightness"
+        label={channels[dimmerIndex].label}
         value={buffer?.[address + dimmerIndex - 1] ?? 0}
         vertical={vertical}
+        hideLabel
       />
     );
 

--- a/apps/desktop/src/components/fixtures/fixture-card.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-card.tsx
@@ -136,7 +136,7 @@ export default function FixtureCard({
             {/* pl-2 cancels the trigger's -ml-2 so the swatch centers. */}
             {hasColor && (
               <div className="pl-2">
-                <FixtureColor fixture={fixture} buffer={buffer} />
+                <FixtureColor fixture={fixture} buffer={buffer} label="" />
               </div>
             )}
             {dimmer}
@@ -148,7 +148,9 @@ export default function FixtureCard({
       <section className="rounded-xl border bg-card px-5 py-3">
         <div className="flex items-center gap-3">
           {expandButton}
-          {hasColor && <FixtureColor fixture={fixture} buffer={buffer} />}
+          {hasColor && (
+            <FixtureColor fixture={fixture} buffer={buffer} label="" />
+          )}
           <div className="min-w-0 flex-1">{dimmer}</div>
         </div>
       </section>

--- a/apps/desktop/src/components/fixtures/fixture-channel.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-channel.tsx
@@ -30,12 +30,16 @@ export default function FixtureChannel({
   label,
   value,
   vertical = false,
+  hideLabel = false,
 }: {
   address: number;
   role: LuxLabelColor;
   label: string;
   value: number;
   vertical?: boolean;
+  /** Skip the visible label (collapsed cards — the fader is self-evident);
+   * the accessible name keeps it either way. */
+  hideLabel?: boolean;
 }) {
   const [values, setValues] = useState([value]);
   useEffect(() => setValues([value]), [value]);
@@ -76,7 +80,9 @@ export default function FixtureChannel({
           {address}
         </span>
         <span className={cn("size-2.5 shrink-0 rounded-full", ROLE_DOT[role])} />
-        <span className="w-full truncate text-center text-xs">{label}</span>
+        {!hideLabel && (
+          <span className="w-full truncate text-center text-xs">{label}</span>
+        )}
         <button
           type="button"
           onClick={toggle}
@@ -97,7 +103,9 @@ export default function FixtureChannel({
         {address}
       </span>
       <span className={cn("size-2.5 shrink-0 rounded-full", ROLE_DOT[role])} />
-      <span className="w-16 shrink-0 truncate text-sm">{label}</span>
+      {!hideLabel && (
+        <span className="w-16 shrink-0 truncate text-sm">{label}</span>
+      )}
       {slider}
       <button
         type="button"

--- a/apps/desktop/src/components/fixtures/fixture-channel.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-channel.tsx
@@ -91,9 +91,13 @@ export default function FixtureChannel({
         >
           {values[0].toString().padStart(3, "0")}
         </button>
-        {/* min-h floors the fader; flex-1 lets it fill taller cards (a
-            collapsed card stretched level with its expanded neighbors). */}
-        <div className="min-h-36 flex-1 pt-1">{slider}</div>
+        {/* h-36 is the fader's base height AND the definite box the slider's
+            internal h-full resolves against (a min-height-derived height is
+            not "definite" to WebKit, which zeroes the track). `grow` — not
+            flex-1, whose basis:0 would override the height — lets the fader
+            fill taller cards (a collapsed card stretched level with its
+            expanded neighbors). */}
+        <div className="h-36 grow pt-1">{slider}</div>
       </div>
     );
   }

--- a/apps/desktop/src/components/fixtures/fixture-channel.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-channel.tsx
@@ -30,16 +30,12 @@ export default function FixtureChannel({
   label,
   value,
   vertical = false,
-  hideLabel = false,
 }: {
   address: number;
   role: LuxLabelColor;
   label: string;
   value: number;
   vertical?: boolean;
-  /** Skip the visible label (collapsed cards — the fader is self-evident);
-   * the accessible name keeps it either way. */
-  hideLabel?: boolean;
 }) {
   const [values, setValues] = useState([value]);
   useEffect(() => setValues([value]), [value]);
@@ -80,9 +76,7 @@ export default function FixtureChannel({
           {address}
         </span>
         <span className={cn("size-2.5 shrink-0 rounded-full", ROLE_DOT[role])} />
-        {!hideLabel && (
-          <span className="w-full truncate text-center text-xs">{label}</span>
-        )}
+        <span className="w-full truncate text-center text-xs">{label}</span>
         <button
           type="button"
           onClick={toggle}
@@ -108,9 +102,7 @@ export default function FixtureChannel({
         {address}
       </span>
       <span className={cn("size-2.5 shrink-0 rounded-full", ROLE_DOT[role])} />
-      {!hideLabel && (
-        <span className="w-16 shrink-0 truncate text-sm">{label}</span>
-      )}
+      <span className="w-16 shrink-0 truncate text-sm">{label}</span>
       {slider}
       <button
         type="button"

--- a/apps/desktop/src/components/fixtures/fixture-channel.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-channel.tsx
@@ -75,7 +75,7 @@ export default function FixtureChannel({
 
   if (vertical) {
     return (
-      <div className="flex w-14 shrink-0 flex-col items-center gap-1.5 py-1">
+      <div className="flex h-full w-14 shrink-0 flex-col items-center gap-1.5 py-1">
         <span className="text-xs tabular-nums text-muted-foreground/60">
           {address}
         </span>
@@ -91,8 +91,9 @@ export default function FixtureChannel({
         >
           {values[0].toString().padStart(3, "0")}
         </button>
-        {/* The strip sets the fader's height; the slider fills it. */}
-        <div className="h-36 pt-1">{slider}</div>
+        {/* min-h floors the fader; flex-1 lets it fill taller cards (a
+            collapsed card stretched level with its expanded neighbors). */}
+        <div className="min-h-36 flex-1 pt-1">{slider}</div>
       </div>
     );
   }

--- a/apps/desktop/src/components/fixtures/fixture-channel.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-channel.tsx
@@ -30,12 +30,16 @@ export default function FixtureChannel({
   label,
   value,
   vertical = false,
+  hideLabel = false,
 }: {
   address: number;
   role: LuxLabelColor;
   label: string;
   value: number;
   vertical?: boolean;
+  /** Skip the visible label (collapsed cards — the fader is self-evident);
+   * the accessible name keeps it either way. */
+  hideLabel?: boolean;
 }) {
   const [values, setValues] = useState([value]);
   useEffect(() => setValues([value]), [value]);
@@ -76,7 +80,9 @@ export default function FixtureChannel({
           {address}
         </span>
         <span className={cn("size-2.5 shrink-0 rounded-full", ROLE_DOT[role])} />
-        <span className="w-full truncate text-center text-xs">{label}</span>
+        {!hideLabel && (
+          <span className="w-full truncate text-center text-xs">{label}</span>
+        )}
         <button
           type="button"
           onClick={toggle}
@@ -102,7 +108,9 @@ export default function FixtureChannel({
         {address}
       </span>
       <span className={cn("size-2.5 shrink-0 rounded-full", ROLE_DOT[role])} />
-      <span className="w-16 shrink-0 truncate text-sm">{label}</span>
+      {!hideLabel && (
+        <span className="w-16 shrink-0 truncate text-sm">{label}</span>
+      )}
       {slider}
       <button
         type="button"

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -34,9 +34,12 @@ function roleAddress(fixture: Fixture, role: LuxLabelColor): number | null {
 export default function FixtureColor({
   fixture,
   buffer,
+  label,
 }: {
   fixture: Fixture;
   buffer: number[] | null;
+  /** Trigger label; pass "" for a bare swatch (collapsed cards). */
+  label?: string;
 }) {
   const r = roleAddress(fixture, "Red");
   const g = roleAddress(fixture, "Green");
@@ -88,7 +91,12 @@ export default function FixtureColor({
 
   return (
     <Popover>
-      <ColorTrigger color={color} luminance={luminance} className="-ml-2" />
+      <ColorTrigger
+        color={color}
+        luminance={luminance}
+        label={label}
+        className="-ml-2"
+      />
       <PopoverContent align="start">
         <RgbaColorPicker className="mx-auto" color={color} onChange={onChange} />
         <div className="mt-3">

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -91,11 +91,13 @@ export default function FixtureColor({
 
   return (
     <Popover>
+      {/* -ml-2 lines the labeled trigger's text up with card content; the
+          bare swatch has no padding to compensate for. */}
       <ColorTrigger
         color={color}
         luminance={luminance}
         label={label}
-        className="-ml-2"
+        className={label === "" ? undefined : "-ml-2"}
       />
       <PopoverContent align="start">
         <RgbaColorPicker className="mx-auto" color={color} onChange={onChange} />

--- a/apps/desktop/src/components/fixtures/fixtures-view.tsx
+++ b/apps/desktop/src/components/fixtures/fixtures-view.tsx
@@ -1,5 +1,6 @@
 import useFixtures from "@/hooks/useFixtures";
 import useBuffer from "@/hooks/useBuffer";
+import useCollapsedFixtures from "@/hooks/useCollapsedFixtures";
 import useSettings from "@/hooks/useSettings";
 import FixtureCard from "./fixture-card";
 import NewFixture from "./new-fixture";
@@ -8,8 +9,9 @@ export default function FixturesView() {
   const fixtures = useFixtures();
   const buffer = useBuffer();
   // Read once here and pass down, so N cards don't each subscribe; like the
-  // desk, wait for the read so the stored layout is the first one painted.
+  // desk, wait for the reads so the stored layout is the first one painted.
   const settings = useSettings();
+  const collapsed = useCollapsedFixtures();
   const count = fixtures?.length ?? 0;
 
   return (
@@ -25,6 +27,7 @@ export default function FixturesView() {
 
       {fixtures !== null &&
         settings !== null &&
+        collapsed !== null &&
         (fixtures.length === 0 ? (
           <div className="rounded-xl border border-dashed py-16 text-center text-sm text-muted-foreground">
             No fixtures patched yet. Add one to get started.
@@ -49,6 +52,7 @@ export default function FixturesView() {
                   vertical={
                     (settings.sliderOrientation ?? "vertical") === "vertical"
                   }
+                  collapsed={collapsed.has(fixture.id)}
                 />
               ))}
           </div>

--- a/apps/desktop/src/components/fixtures/fixtures-view.tsx
+++ b/apps/desktop/src/components/fixtures/fixtures-view.tsx
@@ -2,6 +2,7 @@ import useFixtures from "@/hooks/useFixtures";
 import useBuffer from "@/hooks/useBuffer";
 import useCollapsedFixtures from "@/hooks/useCollapsedFixtures";
 import useSettings from "@/hooks/useSettings";
+import { cn } from "@/lib/utils";
 import FixtureCard from "./fixture-card";
 import NewFixture from "./new-fixture";
 
@@ -13,9 +14,17 @@ export default function FixturesView() {
   const settings = useSettings();
   const collapsed = useCollapsedFixtures();
   const count = fixtures?.length ?? 0;
+  const vertical =
+    settings !== null && (settings.sliderOrientation ?? "vertical") === "vertical";
 
   return (
-    <div className="flex w-full max-w-2xl flex-col gap-5 px-4 pb-16 pt-2">
+    // Vertical console mode fills the available height; the faders absorb it.
+    <div
+      className={cn(
+        "flex w-full max-w-2xl flex-col gap-5 px-4 pb-16 pt-2",
+        vertical && "min-h-0 flex-1"
+      )}
+    >
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
           {fixtures === null
@@ -34,11 +43,12 @@ export default function FixturesView() {
           </div>
         ) : (
           // Vertical faders make the whole view a console: cards sit side by
-          // side at content width and the bank scrolls sideways.
+          // side at content width, stretched to the bank's full height, and
+          // the bank scrolls sideways.
           <div
             className={
-              (settings.sliderOrientation ?? "vertical") === "vertical"
-                ? "flex gap-4 overflow-x-auto pb-2"
+              vertical
+                ? "flex min-h-0 flex-1 gap-4 overflow-x-auto pb-2"
                 : "flex flex-col gap-4"
             }
           >
@@ -49,9 +59,7 @@ export default function FixturesView() {
                   key={fixture.id}
                   fixture={fixture}
                   buffer={buffer}
-                  vertical={
-                    (settings.sliderOrientation ?? "vertical") === "vertical"
-                  }
+                  vertical={vertical}
                   collapsed={collapsed.has(fixture.id)}
                 />
               ))}

--- a/apps/desktop/src/hooks/useCollapsedFixtures.ts
+++ b/apps/desktop/src/hooks/useCollapsedFixtures.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { createTauRPCProxy } from "@/bindings";
+
+/** Query key for the set of collapsed fixture cards (device-local UI state). */
+export const COLLAPSED_FIXTURES_QUERY_KEY = ["collapsedFixtures"] as const;
+
+/**
+ * Which fixture cards are collapsed, as a Set of fixture ids. `null` until the
+ * first read resolves — gate rendering on it, like the settings read, so a
+ * collapsed card doesn't flash open on launch. The setter in `lib/actions`
+ * writes the backend's returned set straight into the cache.
+ */
+export default function useCollapsedFixtures(): Set<string> | null {
+  const { data } = useQuery({
+    queryKey: COLLAPSED_FIXTURES_QUERY_KEY,
+    queryFn: () => createTauRPCProxy().cmd.get_collapsed_fixtures(),
+  });
+  return data ? new Set(data) : null;
+}

--- a/apps/desktop/src/lib/actions.ts
+++ b/apps/desktop/src/lib/actions.ts
@@ -17,6 +17,11 @@ async function setChannelValue({
 }) {
   const taurpc = createTauRPCProxy();
   const buffer = await taurpc.cmd.update_channel_value(channelNumber, value);
+  // Kill any in-flight buffer refetch (window focus fires them): one that
+  // started before this write resolves after it and reverts the cache — the
+  // slider snaps back, and a view without a mount-time re-emit (fixtures)
+  // keeps showing the stale value.
+  await queryClient.cancelQueries({ queryKey: BUFFER_QUERY_KEY });
   queryClient.setQueryData(BUFFER_QUERY_KEY, buffer.buffer);
   return buffer;
 }

--- a/apps/desktop/src/lib/actions.ts
+++ b/apps/desktop/src/lib/actions.ts
@@ -1,6 +1,7 @@
 import { createTauRPCProxy, type SliderOrientation } from "@/bindings";
 import { queryClient } from "@/lib/query-client";
 import { BUFFER_QUERY_KEY } from "@/hooks/useBuffer";
+import { COLLAPSED_FIXTURES_QUERY_KEY } from "@/hooks/useCollapsedFixtures";
 import { SETTINGS_QUERY_KEY } from "@/hooks/useSettings";
 
 /**
@@ -42,4 +43,16 @@ async function setSliderOrientation(orientation: SliderOrientation) {
   return settings;
 }
 
-export { setChannelValue, setSliderOrientation };
+/**
+ * Persist one fixture card's collapse state. Cache-through like the other
+ * setters: the backend's returned set lands in the query cache directly.
+ */
+async function setFixtureCollapsed(id: string, collapsed: boolean) {
+  const taurpc = createTauRPCProxy();
+  const ids = await taurpc.cmd.set_fixture_collapsed(id, collapsed);
+  await queryClient.cancelQueries({ queryKey: COLLAPSED_FIXTURES_QUERY_KEY });
+  queryClient.setQueryData(COLLAPSED_FIXTURES_QUERY_KEY, ids);
+  return ids;
+}
+
+export { setChannelValue, setFixtureCollapsed, setSliderOrientation };


### PR DESCRIPTION
## What

Fixture cards can collapse to their live essentials, plus a set of interaction and layout refinements to the fixtures view surfaced while reviewing them, an editable channel range, and a buffer-cache race fix that presented as one-way universe↔fixture sync.

### Collapsible cards

- **Collapsed**: the name compressed to word initials (`Living Room` → `LR`, `Fixture 12` → `F12`; the full name stays as the tooltip/aria-label), the channel span, the color swatch, and the Brightness-role fader (label-free — the strip is the fixture's brightness by definition). A fixture with neither collapses to initials + span.
- **Expanded** (the default): inline rename, delete, the color wheel, and every channel — all editing beyond color and brightness lives here.
- **Both states share one anatomy and one interaction**: same padding and header structure, the same 44px touch-target color swatch (bare when collapsed, labeled when expanded, faint ring so it survives blackout), and a surface click that toggles the card — interactive controls (faders, value toggles, inputs, swatch, header buttons) keep their own clicks, the picker popover is portaled so its clicks never reach the card, and a click ending a text selection doesn't toggle. The expanded header keeps a collapse chevron (axis-aware: sideways in the console, downward in the list) as the labeled keyboard path.
- **Layout**: in the vertical console the bank fills the container height, cards stretch to it and hug their strips widthwise (content centered on the cross axis), and faders absorb the extra height; the horizontal list keeps compact rows.
- **Persistence**: collapse state lives in `setups.json` beside the other device-local UI state (deliberately not cloud-synced — each device keeps its own density); ids of deleted fixtures are pruned on the next write, and first paint waits for the read so collapsed cards don't flash open.

### Editable channel range

The expanded header's channel span is an inline-editable start channel with the same blur/Enter/Escape interaction as the name. The channel count comes from the channel defs, so the range moves as one block; the span end previews while typing, and backend placement validation (bounds, universe overflow, overlaps) surfaces as a toast.

### Buffer write vs refetch race

`setChannelValue` wrote the returned buffer into the query cache without cancelling in-flight buffer refetches. A window-focus refetch that starts before a write resolves after it and reverts the cache — the slider snaps back, and the fixtures view (which, unlike the desk, has no mount-time buffer re-emit) keeps showing the stale value, presenting as universe→fixture sync being broken. In-flight buffer queries are now cancelled before the write-through, the same guard the settings setter uses.

## Verification

- `cargo test --workspace --locked` (including the collapse-state round-trip/pruning tests and the bindings drift guard), `cargo clippy --workspace -- -D warnings`, `bun run build` / `typecheck` / `lint`.
- Reviewed iteratively in the dev app with RGBAW fixtures: collapse/expand in both orientations, surface-click toggling vs control clicks, readdressing, persistence across a restart, universe↔fixture value round-trips, full-height console layout.
- Not exercised: a Brightness-less or colorless fixture's collapsed form (initials-only path is code-reviewed, not clicked).