### PR TITLE
build(ios): move project.yml into a bundle.iOS.template so re-init preserves customizations

### DIFF
--- a/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/lux.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		6DF90FDE7A6A99B512BF4C9A /* account.rs */ = {isa = PBXFileReference; path = account.rs; sourceTree = "<group>"; };
 		702DA0D8C7FE131C11FC162A /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		719C305B0E09C6286608C1A2 /* buffer.rs */ = {isa = PBXFileReference; path = buffer.rs; sourceTree = "<group>"; };
+		72BB8F21FEC510A12D94B9A4 /* settings.rs */ = {isa = PBXFileReference; path = settings.rs; sourceTree = "<group>"; };
 		7E12A3D64A4681D3D1C5B38E /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		875FDB81D677B35CCE19C8A3 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		90D526E9C081ACDBFBA3A30D /* channels.rs */ = {isa = PBXFileReference; path = channels.rs; sourceTree = "<group>"; };
@@ -103,6 +104,7 @@
 				91D705F0C0650E85740F6C5D /* main.rs */,
 				00E956AA67F8F4C53E9C8D30 /* nudge.rs */,
 				4AF4BAEB9E80F20D9EF0EC9F /* remote.rs */,
+				72BB8F21FEC510A12D94B9A4 /* settings.rs */,
 				FE41F2EEAC3FFC3CCA4FC84F /* setup.rs */,
 				92111F847FCD365ABA6BC31A /* sync.rs */,
 				9920BC880C3C183D6E36ACA9 /* tray.rs */,
@@ -400,7 +402,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncarmack.lux;
-				PRODUCT_NAME = "lux";
+				PRODUCT_NAME = lux;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;
@@ -490,7 +492,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncarmack.lux;
-				PRODUCT_NAME = "lux";
+				PRODUCT_NAME = lux;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;

--- a/apps/desktop/src-tauri/gen/apple/lux_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/lux_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.2</string>
+	<string>0.17.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.12.2</string>
+	<string>0.17.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/apps/desktop/src-tauri/ios/project.yml.hbs
+++ b/apps/desktop/src-tauri/ios/project.yml.hbs
@@ -6,9 +6,9 @@
 # The CLI resolves the template path against the process cwd, so the
 # tauri.conf.json value assumes the canonical invocation: `bun run tauri`
 # from apps/desktop.
-name: lux
+name: {{app.name}}
 options:
-  bundleIdPrefix: com.johncarmack.lux
+  bundleIdPrefix: {{app.identifier}}
   # Pinned rather than templated: bundle > iOS > minimumSystemVersion is unset
   # (the CLI default drifted to 13.0 after this project scaffolded at 14.0).
   deploymentTarget:
@@ -19,15 +19,15 @@ options:
   # breaks the Rust build phase, auto-architectures fights the per-arch
   # libapp.a layout).
   xcodeVersion: "26.6"
-fileGroups: [../../src]
+fileGroups: [{{join file-groups}}]
 configs:
   debug: debug
   release: release
 settingGroups:
   app:
     base:
-      PRODUCT_NAME: lux
-      PRODUCT_BUNDLE_IDENTIFIER: com.johncarmack.lux
+      PRODUCT_NAME: {{app.stylized-name}}
+      PRODUCT_BUNDLE_IDENTIFIER: {{app.identifier}}
 targetTemplates:
   app:
     type: application
@@ -40,13 +40,13 @@ targetTemplates:
     settings:
       groups: [app]
 targets:
-  lux_iOS:
+  {{app.name}}_iOS:
     type: application
     platform: iOS
     # Keeps the generated product reference named lux.app (matching
     # PRODUCT_NAME and the scheme's runnable) — without it xcodegen names the
     # product after the target, and Xcode's Run action asserts on the mismatch.
-    productName: lux
+    productName: {{app.stylized-name}}
     sources:
       - path: Sources
       - path: Assets.xcassets
@@ -55,13 +55,17 @@ targets:
       # resource and the pbxproj stays independent of local build state.
       - path: Externals
         excludes: ["**"]
-      - path: lux_iOS
-      - path: assets
+      - path: {{app.name}}_iOS
+      - path: {{app.asset-dir}}
         buildPhase: resources
         type: folder
+      {{~#each asset-catalogs}}
+      - {{prefix-path this}}{{/each}}
+      {{~#each ios-additional-targets}}
+      - path: {{prefix-path this}}{{/each}}
       - path: LaunchScreen.storyboard
     info:
-      path: lux_iOS/Info.plist
+      path: {{app.name}}_iOS/Info.plist
       properties:
         LSRequiresIPhoneOS: true
         # xcodegen regenerates Info.plist from these properties — every custom
@@ -83,10 +87,12 @@ targets:
         # Cosmetic: `tauri ios build` restamps both values (source Info.plist
         # included) from tauri.conf.json's version on every build, so these only
         # need to be valid, not current.
-        CFBundleShortVersionString: 0.17.0
-        CFBundleVersion: "0.17.0"
+        CFBundleShortVersionString: {{apple.bundle-version-short}}
+        CFBundleVersion: "{{apple.bundle-version}}"
+        {{~#each apple.plist-pairs}}
+        {{this.key}}: {{this.value}}{{/each}}
     entitlements:
-      path: lux_iOS/lux_iOS.entitlements
+      path: {{app.name}}_iOS/{{app.name}}_iOS.entitlements
       # xcodegen regenerates this file from these properties on every build
       # (same as Info.plist above) — a key set only in the .entitlements file
       # is silently wiped. Multicast Networking is Apple-granted (request
@@ -97,6 +103,11 @@ targets:
       environmentVariables:
         RUST_BACKTRACE: full
         RUST_LOG: info
+      {{~#if ios-command-line-arguments}}
+      commandLineArguments:
+      {{~#each ios-command-line-arguments}}
+        "{{this}}": true
+      {{/each}}{{~/if}}
     settings:
       base:
         # Device signing: Xcode's automatic management, pinned to the team so
@@ -109,27 +120,42 @@ targets:
         # An accepted Xcode "recommended settings" pass once flipped this on.
         ENABLE_USER_SCRIPT_SANDBOXING: false
         ENABLE_BITCODE: false
-        ARCHS: [arm64]
-        VALID_ARCHS: arm64 
+        ARCHS: [{{join ios-valid-archs}}]
+        VALID_ARCHS: {{~#each ios-valid-archs}} {{this}} {{/each}}
         LIBRARY_SEARCH_PATHS[arch=x86_64]: $(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)
         LIBRARY_SEARCH_PATHS[arch=arm64]: $(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)
         ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: true
         EXCLUDED_ARCHS[sdk=iphoneos*]: x86_64
       groups: [app]
     dependencies:
-      - framework: libapp.a
+      - framework: {{ lib-output-file-name }}
         embed: false
+      {{~#each ios-libraries}}
+      - framework: {{this}}
+        embed: false{{/each}}{{#if ios-vendor-frameworks}}{{~#each ios-vendor-frameworks}}
+      - framework: {{this}}{{/each}}{{/if}}{{#if ios-vendor-sdks}}{{~#each ios-vendor-sdks}}
+      - sdk: {{prefix-path this}}{{/each}}{{/if}}
       - sdk: CoreGraphics.framework
       - sdk: Metal.framework
       - sdk: MetalKit.framework
       - sdk: QuartzCore.framework
       - sdk: Security.framework
-      - sdk: UIKit.framework
+      - sdk: UIKit.framework{{#if this.ios-frameworks}}{{~#each ios-frameworks}}
+      - sdk: {{this}}.framework{{/each}}{{/if}}
       - sdk: WebKit.framework
-    preBuildScripts:
-      - script: bun tauri ios xcode-script -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
+    preBuildScripts:{{#each ios-pre-build-scripts}}{{#if this.path}}
+      - path {{this.path}}{{/if}}{{#if this.script}}
+      - script: {{this.script}}{{/if}}{{#if this.name}}
+        name: {{this.name}}{{/if}}{{#if this.input-files}}
+        inputFiles: {{~#each this.input-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.output-files}}
+        outputFiles: {{~#each this.output-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.shell}}
+        shell: {{this.shell}}{{/if}}{{#if this.based-on-dependency-analysis}}
+        basedOnDependencyAnalysis: {{this.based-on-dependency-analysis}}{{/if}}{{/each}}
+      - script: {{ tauri-binary }} {{ tauri-binary-args-str }} -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
         name: Build Rust Code
         basedOnDependencyAnalysis: false
         outputFiles:
-          - $(SRCROOT)/Externals/x86_64/${CONFIGURATION}/libapp.a
-          - $(SRCROOT)/Externals/arm64/${CONFIGURATION}/libapp.a
+          - $(SRCROOT)/Externals/x86_64/${CONFIGURATION}/{{ lib-output-file-name }}
+          - $(SRCROOT)/Externals/arm64/${CONFIGURATION}/{{ lib-output-file-name }}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -43,7 +43,10 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "iOS": {
+      "template": "src-tauri/ios/project.yml.hbs"
+    }
   },
   "plugins": {
     "shell": {


### PR DESCRIPTION
## What

Promotes the customized `gen/apple/project.yml` into a committed XcodeGen template (`src-tauri/ios/project.yml.hbs`) wired through `bundle > iOS > template`, so a full `tauri ios init` reproduces every customization instead of silently dropping them: the pinned signing team, `NSLocalNetworkUsageDescription`, export-compliance, orientations, the Apple-granted multicast entitlement (#137), the Xcode-26 upgrade stamp, the `productName` pin, and the Externals excludes.

Tauri's handlebars variables are re-introduced where the generated file held resolved literals (identifier, product name, bundle versions, lib name, the `tauri-binary` invocation, arch lists), and the upstream template's conditional blocks are kept so future config-driven values (frameworks, plist pairs, command-line arguments) still render. Two deliberate deviations, documented inline:

- The deployment target stays a pinned literal `14.0` — `bundle > iOS > minimumSystemVersion` is unset and the CLI default drifted to 13.0 after this project scaffolded.
- The stock `settingGroups` development-team conditional is dropped; the target-level `DEVELOPMENT_TEAM` pin is the signing mechanism and doesn't vary with the environment at init time.

The regenerated `project.yml`, `Info.plist`, and `project.pbxproj` from the verification run are committed as the new canonical state, so the committed tree now equals the template's render.

## Verification

- `bun run tauri ios init --ci` completes and regenerates `gen/apple`; the resulting `project.yml` matches the previously committed file except the documented cosmetic `CFBundle*` restamp (0.12.2 → 0.17.0, rewritten by every `tauri ios build` anyway) and the new header comment.
- `Info.plist` picked up the same restamp; `project.pbxproj` additionally picked up the recently added `settings.rs` source (the committed pbxproj predated it) and a cosmetic `PRODUCT_NAME` quoting change.
- `tauri ios build` does not re-render `project.yml`, so release/TestFlight builds are unaffected by this change; the template only takes effect on the next re-init.

## Notes

- The CLI resolves the template path against the process cwd (`crates/tauri-cli/src/mobile/ios/project.rs` reads the config value verbatim), so `tauri.conf.json` assumes the canonical `bun run tauri` invocation from `apps/desktop`. Resolving it against the Tauri config directory instead would make a reasonable upstream fix.

Closes #138