### PR TITLE
build: draft App Store notes on the release PR

### DIFF
--- a/.github/workflows/store-notes.yml
+++ b/.github/workflows/store-notes.yml
@@ -1,0 +1,63 @@
+# Drafts the App Store "What's New" file on the release PR: Claude writes a
+# first pass from the release's CHANGELOG section and the job commits it to
+# the PR branch as apps/desktop/store-notes/<version>.md. Edit the file in the
+# PR — the draft never overwrites a human edit (delete the file to redraft) —
+# and appstore.yml refuses to submit a version whose file is missing, so the
+# human pass is structural, not optional.
+name: store-notes
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions: {}
+
+jobs:
+  draft:
+    # Release PRs only, and never fork heads (the job assumes an OIDC role).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # push the drafted file to the release PR branch
+      id-token: write # AWS OIDC, to read the Anthropic API key
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # The real branch (not the merge ref) — the draft is pushed to it.
+          ref: ${{ github.head_ref }}
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+        with:
+          role-to-assume: arn:aws:iam::735853783919:role/lux-store-notes
+          aws-region: us-west-1
+
+      - name: Load Anthropic API key
+        run: |
+          key=$(aws secretsmanager get-secret-value --secret-id lux/anthropic-api-key --query SecretString --output text)
+          echo "::add-mask::$key"
+          echo "ANTHROPIC_API_KEY=$key" >> "$GITHUB_ENV"
+
+      - name: Draft store notes
+        run: bun scripts/draft-store-notes.ts
+
+      - name: Commit the draft (if new)
+        # A GITHUB_TOKEN push never retriggers workflows, so no loop.
+        run: |
+          if git diff --quiet && [ -z "$(git status --porcelain apps/desktop/store-notes)" ]; then
+            echo "nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add apps/desktop/store-notes
+          git commit -m "chore: draft App Store notes"
+          git push origin "HEAD:${{ github.head_ref }}"

--- a/apps/desktop/store-notes/1.1.0.md
+++ b/apps/desktop/store-notes/1.1.0.md
@@ -1,0 +1,7 @@
+Faders can now run vertically in a horizontally scrolling console layout — the new default on the universe desk and fixture cards — or stay horizontal. The choice syncs across your devices when you're signed in.
+
+Fixture cards collapse to a compact strip: just the color wheel and a brightness fader. Channel ranges can be edited in place on the card.
+
+A reading-light preset warms any amber-equipped fixture from the color wheel.
+
+Fixes a case where fader changes could briefly snap back.

--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,14 @@
   "workspaces": {
     "": {
       "name": "lux-workspace",
+      "devDependencies": {
+        "@anthropic-ai/sdk": "^0.112.1",
+        "jose": "^6.2.3",
+      },
     },
     "apps/desktop": {
       "name": "lux",
-      "version": "0.13.1",
+      "version": "1.1.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@hookform/resolvers": "^5.4.0",
@@ -109,6 +113,8 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.112.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-vPRhHWxG9gIDyI9anVET2tBkmMBOXyTpIFvQgUVveiAV0ihmQgBYzQHb/s9+pZ/FxprSWcQnj15YnRfPxOIEmg=="],
+
     "@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/compat-data": ["@babel/compat-data@8.0.0", "", {}, "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw=="],
@@ -409,6 +415,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.2" } }, "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg=="],
@@ -649,6 +657,8 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
@@ -691,11 +701,15 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -817,6 +831,8 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
@@ -826,6 +842,8 @@
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 

--- a/infra/store-notes.tf
+++ b/infra/store-notes.tf
@@ -1,0 +1,52 @@
+# Store-notes drafting: the release PR gets a Claude-drafted App Store
+# "What's New" file (workflow: store-notes.yml), which a human edits in the PR
+# before appstore.yml will submit it. The Anthropic API key lives only in
+# Secrets Manager (created out-of-band, like the other lux/* secrets).
+#
+# The role is deliberately separate from lux-release-signing: that role's
+# trust is main-ref-only because it reads the updater signing key, and no PR
+# workflow may ever assume it. Drafting runs on pull_request events (the
+# release PR), so it gets its own role scoped to this one secret.
+
+data "aws_secretsmanager_secret" "anthropic_api_key" {
+  name = "lux/anthropic-api-key"
+}
+
+resource "aws_iam_role" "store_notes" {
+  name = "lux-store-notes"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = data.aws_iam_openid_connect_provider.github.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          # pull_request-context workflows in this repo only. Same-repo PRs
+          # are maintainer-authored; fork PRs never receive OIDC here. The
+          # blast radius of this role is exactly one spend-limited API key.
+          "token.actions.githubusercontent.com:sub" = "repo:johncarmack1984/lux:pull_request"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "read_anthropic_api_key" {
+  name = "read-anthropic-api-key"
+  role = aws_iam_role.store_notes.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "secretsmanager:GetSecretValue"
+      Resource = [data.aws_secretsmanager_secret.anthropic_api_key.arn]
+    }]
+  })
+}
+
+output "store_notes_role_arn" {
+  description = "Set as role-to-assume in the store-notes workflow (AWS OIDC)."
+  value       = aws_iam_role.store_notes.arn
+}

--- a/package.json
+++ b/package.json
@@ -6,5 +6,9 @@
     "apps/site",
     "packages/ui"
   ],
-  "packageManager": "bun@1.3.3"
+  "packageManager": "bun@1.3.3",
+  "devDependencies": {
+    "@anthropic-ai/sdk": "^0.112.1",
+    "jose": "^6.2.3"
+  }
 }

--- a/scripts/draft-store-notes.ts
+++ b/scripts/draft-store-notes.ts
@@ -1,0 +1,100 @@
+// Draft the App Store "What's New" for the release the release-please PR is
+// about to cut, from that release's CHANGELOG section. Runs on the release PR
+// (workflow: store-notes.yml); the human edits the committed file in the PR,
+// and appstore.yml refuses to submit a version whose file is missing.
+//
+// The draft is exactly that — a draft. It never overwrites a human edit: the
+// file is only (re)written while its last committed author is the workflow
+// bot (or it doesn't exist yet). Delete the file in the PR to force a fresh
+// draft.
+//
+// Usage: ANTHROPIC_API_KEY=... bun scripts/draft-store-notes.ts
+
+import Anthropic from "@anthropic-ai/sdk";
+import { execFileSync } from "child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const NOTES_DIR = "apps/desktop/store-notes";
+const BOT_EMAIL = "github-actions[bot]@users.noreply.github.com";
+
+const version: string = JSON.parse(
+  readFileSync(".release-please-manifest.json", "utf8")
+)["."];
+if (!version) throw new Error("no version in .release-please-manifest.json");
+
+const notesPath = join(NOTES_DIR, `${version}.md`);
+
+// Never clobber a human's edit.
+if (existsSync(notesPath)) {
+  const lastAuthor = execFileSync(
+    "git",
+    ["log", "-1", "--format=%ae", "--", notesPath],
+    { encoding: "utf8" }
+  ).trim();
+  if (lastAuthor && lastAuthor !== BOT_EMAIL) {
+    console.log(`${notesPath} was last edited by ${lastAuthor}; leaving it alone.`);
+    process.exit(0);
+  }
+}
+
+// The version's CHANGELOG section: from its `## [x.y.z]` heading to the next
+// `## [` heading (or EOF).
+const changelog = readFileSync("CHANGELOG.md", "utf8");
+const escaped = version.replace(/\./g, "\\.");
+const section = changelog.match(
+  new RegExp(`^## \\[${escaped}\\][\\s\\S]*?(?=^## \\[|$(?![\\s\\S]))`, "m")
+)?.[0];
+if (!section) {
+  console.log(`CHANGELOG.md has no section for ${version} yet; nothing to draft.`);
+  process.exit(0);
+}
+
+// The most recent shipped notes file anchors the voice.
+const previous = existsSync(NOTES_DIR)
+  ? readdirSync(NOTES_DIR)
+      .filter((f) => f.endsWith(".md") && f !== `${version}.md`)
+      .sort((a, b) =>
+        b.localeCompare(a, undefined, { numeric: true, sensitivity: "base" })
+      )[0]
+  : undefined;
+const example = previous
+  ? readFileSync(join(NOTES_DIR, previous), "utf8").trim()
+  : undefined;
+
+const client = new Anthropic();
+const response = await client.messages.create({
+  model: "claude-opus-4-8",
+  max_tokens: 1024,
+  thinking: { type: "adaptive" },
+  system: [
+    "You write the App Store \"What's New\" text for lux, a DMX lighting controller used by lighting technicians and hobbyists.",
+    "Rules:",
+    "- Plain, factual sentences. No hype, no exclamation marks, no marketing adjectives, no emoji.",
+    "- Describe only what a user sees or does differently. Skip internal changes: refactors, CI, dependency bumps, backend plumbing, developer tooling.",
+    "- Short paragraphs separated by blank lines, most important change first. No headings, no bullet markers, no links, no PR numbers, no version numbers.",
+    "- If nothing in the changelog is user-visible, output exactly: Maintenance and stability improvements.",
+    "- Output the notes text only — nothing else.",
+    ...(example ? ["", "The previous release's notes, as a voice reference:", "", example] : []),
+  ].join("\n"),
+  messages: [
+    {
+      role: "user",
+      content: `Changelog for the release:\n\n${section}`,
+    },
+  ],
+});
+
+if (response.stop_reason !== "end_turn") {
+  throw new Error(`unexpected stop_reason: ${response.stop_reason}`);
+}
+const text = response.content
+  .filter((b): b is Anthropic.TextBlock => b.type === "text")
+  .map((b) => b.text)
+  .join("")
+  .trim();
+if (!text) throw new Error("empty draft");
+
+mkdirSync(NOTES_DIR, { recursive: true });
+writeFileSync(notesPath, text + "\n");
+console.log(`drafted ${notesPath} (${text.length} chars)`);

--- a/scripts/draft-store-notes.ts
+++ b/scripts/draft-store-notes.ts
@@ -21,7 +21,9 @@ const BOT_EMAIL = "github-actions[bot]@users.noreply.github.com";
 const version: string = JSON.parse(
   readFileSync(".release-please-manifest.json", "utf8")
 )["."];
-if (!version) throw new Error("no version in .release-please-manifest.json");
+if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+  throw new Error(`bad version in .release-please-manifest.json: ${version}`);
+}
 
 const notesPath = join(NOTES_DIR, `${version}.md`);
 
@@ -41,7 +43,9 @@ if (existsSync(notesPath)) {
 // The version's CHANGELOG section: from its `## [x.y.z]` heading to the next
 // `## [` heading (or EOF).
 const changelog = readFileSync("CHANGELOG.md", "utf8");
-const escaped = version.replace(/\./g, "\\.");
+// Canonical regex escape (the version is already shape-validated above, but
+// CodeQL rightly wants the escape complete rather than dot-only).
+const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const section = changelog.match(
   new RegExp(`^## \\[${escaped}\\][\\s\\S]*?(?=^## \\[|$(?![\\s\\S]))`, "m")
 )?.[0];


### PR DESCRIPTION
## What

When release-please opens or updates the release PR, a new `store-notes` workflow drafts the App Store "What's New" from that release's CHANGELOG section — one Claude Messages API call — and commits it to the PR branch as `apps/desktop/store-notes/<version>.md`.

The draft is a first pass, not the copy: it never overwrites a human edit (a file whose last committed author isn't the workflow bot is left alone; delete the file in the PR to force a redraft), so reviewing the notes is an ordinary PR file edit. The upcoming `appstore.yml` submission workflow will refuse to submit a version whose notes file is missing, making the human pass structural.

The 1.1.0 notes (as submitted to both stores) are seeded as the voice reference the drafter includes in its prompt.

## Security shape

- The Anthropic API key lives only in Secrets Manager (`lux/anthropic-api-key`, created out-of-band like the other `lux/*` secrets).
- A new `lux-store-notes` OIDC role grants `GetSecretValue` on exactly that secret, with trust scoped to `pull_request` workflows in this repo (fork PRs never receive OIDC). It is deliberately **not** an extension of `lux-release-signing`, whose main-ref-only trust exists to keep the updater signing key unreachable from PR contexts.
- The key is masked before entering the job environment; a `GITHUB_TOKEN` push to the PR branch cannot retrigger workflows, so no drafting loop.

## Setup required before merge

The secret must exist for the terraform plan to pass:

```sh
aws secretsmanager create-secret --name lux/anthropic-api-key \
  --description "Anthropic API key for store-notes drafting (CI only)" \
  --secret-string "<key>"
```

## Verification

- `terraform validate` passes; the script builds under bun; `bun install` lockfile updated with `@anthropic-ai/sdk` + `jose` (latest stable) as root dev dependencies.
- The drafting path exercises live on the next release PR; the no-changelog and human-edited guard paths are early-exit and log clearly.