### PR TITLE
build(store-notes): survive release-please branch rebuilds

### DIFF
--- a/.github/workflows/store-notes.yml
+++ b/.github/workflows/store-notes.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: read # the restore step reads prior branch tips from run history
       contents: write # push the drafted file to the release PR branch
       id-token: write # AWS OIDC, to read the Anthropic API key
     steps:
@@ -28,29 +29,50 @@ jobs:
         with:
           # The real branch (not the merge ref) — the draft is pushed to it.
           ref: ${{ github.head_ref }}
+          # Full history: the draft guard and the restore step attribute the
+          # notes file by commit author, which a depth-1 clone cannot see, and
+          # the push retry below rebases.
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # release-please rebuilds the release branch from main on every push to
+      # main, discarding the drafted file and any human edit to it. Recover
+      # the newest human-authored copy from prior branch tips (via run
+      # history) before deciding whether to draft.
+      - name: Restore a human-edited draft (release rebases discard it)
+        id: restore
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bun scripts/restore-store-notes.ts
+
       - name: Configure AWS credentials (OIDC)
+        if: steps.restore.outputs.restored != 'true'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           role-to-assume: arn:aws:iam::735853783919:role/lux-store-notes
           aws-region: us-west-1
 
       - name: Load Anthropic API key
+        if: steps.restore.outputs.restored != 'true'
         run: |
           key=$(aws secretsmanager get-secret-value --secret-id lux/anthropic-api-key --query SecretString --output text)
           echo "::add-mask::$key"
           echo "ANTHROPIC_API_KEY=$key" >> "$GITHUB_ENV"
 
       - name: Draft store notes
+        if: steps.restore.outputs.restored != 'true'
         run: bun scripts/draft-store-notes.ts
 
       - name: Commit the draft (if new)
         # A GITHUB_TOKEN push never retriggers workflows, so no loop.
+        env:
+          BRANCH: ${{ github.head_ref }}
+          RESTORED: ${{ steps.restore.outputs.restored }}
+          RESTORE_AUTHOR: ${{ steps.restore.outputs.author }}
         run: |
           if git diff --quiet && [ -z "$(git status --porcelain apps/desktop/store-notes)" ]; then
             echo "nothing to commit"
@@ -59,5 +81,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add apps/desktop/store-notes
-          git commit -m "chore: draft App Store notes"
-          git push origin "HEAD:${{ github.head_ref }}"
+          if [ "$RESTORED" = "true" ]; then
+            # Keep the human author so the never-overwrite guard holds.
+            git commit --author "$RESTORE_AUTHOR" -m "chore: restore edited App Store notes"
+          else
+            git commit -m "chore: draft App Store notes"
+          fi
+          # The release workflow's Cargo.lock sync pushes to this branch too —
+          # rebase and retry instead of failing on a non-fast-forward.
+          for _ in 1 2 3; do
+            git push origin "HEAD:$BRANCH" && exit 0
+            git pull --rebase origin "$BRANCH"
+          done
+          exit 1

--- a/infra/store-notes.tf
+++ b/infra/store-notes.tf
@@ -28,6 +28,15 @@ resource "aws_iam_role" "store_notes" {
           # blast radius of this role is exactly one spend-limited API key.
           "token.actions.githubusercontent.com:sub" = "repo:johncarmack1984/lux:pull_request"
         }
+        StringLike = {
+          # Only the store-notes workflow file may assume the role — any other
+          # workflow running in pull_request context (present or future) is
+          # refused. Residual trust: someone with push access could still ship
+          # a modified store-notes.yml on a branch, so push access remains the
+          # real boundary; this stops every path that doesn't rewrite the one
+          # audited file.
+          "token.actions.githubusercontent.com:job_workflow_ref" = "johncarmack1984/lux/.github/workflows/store-notes.yml@*"
+        }
       }
     }]
   })

--- a/scripts/draft-store-notes.ts
+++ b/scripts/draft-store-notes.ts
@@ -6,7 +6,10 @@
 // The draft is exactly that — a draft. It never overwrites a human edit: the
 // file is only (re)written while its last committed author is the workflow
 // bot (or it doesn't exist yet). Delete the file in the PR to force a fresh
-// draft.
+// draft. The authorship check reads git history, so the workflow checks out
+// with full depth; scripts/restore-store-notes.ts runs first and resurrects a
+// human edit that a release-please branch rebuild discarded (the workflow
+// skips drafting entirely when it restores one).
 //
 // Usage: ANTHROPIC_API_KEY=... bun scripts/draft-store-notes.ts
 

--- a/scripts/restore-store-notes.ts
+++ b/scripts/restore-store-notes.ts
@@ -1,0 +1,153 @@
+// Restore a human-edited App Store notes file after release-please rebuilds
+// the release branch.
+//
+// release-please regenerates its release branch from main on every push to
+// main, force-pushing a single generated commit — every foreign commit on the
+// branch (the drafted notes file, and any human edit to it) is discarded each
+// time main moves. The draft workflow re-drafts afterwards, but a redraft is
+// fresh model output: without this step, a human's edited copy would be
+// silently replaced and the release would ship the wrong notes.
+//
+// The discarded branch tips remain fetchable by SHA, and every prior workflow
+// run on the branch recorded its tip as `head_sha` — the run history doubles
+// as an archive of the branch's states. This script walks it, newest first,
+// and restores the most recent human-authored copy of the notes file into the
+// working tree (the workflow commits it, preserving the human author, which
+// is also what keeps the draft script's never-overwrite guard holding on
+// later runs). Decision rules:
+//
+//   - current HEAD authored by a human → do nothing. A person shaped the
+//     branch state on purpose: an edit is kept by the draft guard, a deletion
+//     is the documented "redraft, please" gesture.
+//   - walking prior tips: file present, last touched by a human → restore
+//     that copy and stop.
+//   - file present but bot-authored → stop with nothing to restore; the
+//     freshest human intent was to leave a bot draft in place.
+//   - tip is a human commit that deleted the file → stop; don't resurrect a
+//     deliberate deletion.
+//   - anything else (pre-draft states) → keep walking.
+//
+// A failure here must never block drafting: any error degrades to
+// restored=false with a warning, which is exactly the no-restore status quo.
+//
+// Usage (from store-notes.yml, before the draft step; needs actions: read):
+//   GITHUB_TOKEN=... bun scripts/restore-store-notes.ts
+// Outputs (GITHUB_OUTPUT): restored=true|false, author="Name <email>".
+
+import { execFileSync } from "child_process";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+
+const NOTES_DIR = "apps/desktop/store-notes";
+const BOT_AUTHOR = /\[bot\]@users\.noreply\.github\.com$/i;
+
+const repo = process.env.GITHUB_REPOSITORY;
+const branch = process.env.GITHUB_HEAD_REF;
+const token = process.env.GITHUB_TOKEN;
+const api = process.env.GITHUB_API_URL ?? "https://api.github.com";
+
+function output(kv: Record<string, string>) {
+  const out = process.env.GITHUB_OUTPUT;
+  if (!out) return;
+  for (const [k, v] of Object.entries(kv)) {
+    appendFileSync(out, `${k}=${v.replace(/\r?\n/g, " ")}\n`);
+  }
+}
+
+async function gh<T>(path: string): Promise<T | null> {
+  const r = await fetch(`${api}${path}`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+  if (r.status === 404) return null;
+  if (!r.ok) throw new Error(`GET ${path} -> ${r.status}`);
+  return (await r.json()) as T;
+}
+
+async function restore(): Promise<boolean> {
+  if (!repo || !branch || !token) {
+    throw new Error("missing GITHUB_REPOSITORY/GITHUB_HEAD_REF/GITHUB_TOKEN");
+  }
+
+  const version: string = JSON.parse(
+    readFileSync(".release-please-manifest.json", "utf8")
+  )["."];
+  if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(`bad version in .release-please-manifest.json: ${version}`);
+  }
+  const notesPath = `${NOTES_DIR}/${version}.md`;
+
+  // A human-authored HEAD is a deliberate branch state — leave it alone.
+  const headAuthor = execFileSync("git", ["log", "-1", "--format=%ae"], {
+    encoding: "utf8",
+  }).trim();
+  if (!BOT_AUTHOR.test(headAuthor)) {
+    console.log(`HEAD is human-authored (${headAuthor}); nothing to restore.`);
+    return false;
+  }
+
+  // Prior branch tips, newest first, from the run history (any workflow).
+  const runs = await gh<{
+    workflow_runs: { head_sha: string; created_at: string }[];
+  }>(
+    `/repos/${repo}/actions/runs?event=pull_request&branch=${encodeURIComponent(branch)}&per_page=100`
+  );
+  const seen = new Set<string>();
+  const tips = (runs?.workflow_runs ?? [])
+    .sort((a, b) => b.created_at.localeCompare(a.created_at))
+    .map((r) => r.head_sha)
+    .filter((sha) => !seen.has(sha) && (seen.add(sha), true))
+    .slice(0, 30);
+
+  for (const sha of tips) {
+    const file = await gh<{ content?: string }>(
+      `/repos/${repo}/contents/${notesPath}?ref=${sha}`
+    );
+    if (file?.content) {
+      // Who last touched the file as of this tip?
+      const commits = await gh<
+        { commit: { author: { name: string; email: string } } }[]
+      >(
+        `/repos/${repo}/commits?path=${encodeURIComponent(notesPath)}&sha=${sha}&per_page=1`
+      );
+      const author = commits?.[0]?.commit?.author;
+      if (!author) continue;
+      if (BOT_AUTHOR.test(author.email)) {
+        console.log(
+          `newest surviving copy (${sha.slice(0, 7)}) is bot-authored; nothing to restore.`
+        );
+        return false;
+      }
+      mkdirSync(NOTES_DIR, { recursive: true });
+      writeFileSync(notesPath, Buffer.from(file.content, "base64"));
+      output({ author: `${author.name} <${author.email}>` });
+      console.log(`restored ${notesPath} from ${sha.slice(0, 7)} (${author.email})`);
+      return true;
+    }
+    // Missing at this tip: a human deletion commit is the documented
+    // "redraft, please" gesture — don't walk past it.
+    const commit = await gh<{
+      commit: { author: { email: string } };
+      files?: { filename: string; status: string }[];
+    }>(`/repos/${repo}/commits/${sha}`);
+    const deleted = commit?.files?.some(
+      (f) => f.filename === notesPath && f.status === "removed"
+    );
+    if (deleted && commit && !BOT_AUTHOR.test(commit.commit.author.email)) {
+      console.log(`deliberately deleted at ${sha.slice(0, 7)}; leaving it deleted.`);
+      return false;
+    }
+  }
+  console.log("no prior human-authored copy found.");
+  return false;
+}
+
+try {
+  output({ restored: String(await restore()) });
+} catch (err) {
+  // Degrade to the no-restore status quo rather than failing the job.
+  console.log(`::warning::store-notes restore skipped: ${err}`);
+  output({ restored: "false" });
+}


### PR DESCRIPTION
release-please rebuilds its release branch from main on every push to main, force-pushing a single generated commit. Foreign commits on the branch are discarded each time — including the store-notes draft and, worse, a maintainer's hand-edit of it. The workflow would then re-draft from scratch, silently replacing the edited copy: the release would ship model output that was believed to be human-reviewed.

Fix: before drafting, walk the branch's prior tips — workflow run history retains every head SHA, and the commits stay fetchable after the force-push — and restore the newest human-authored copy of the notes file, committed with its original author so the draft script's never-overwrite guard continues to hold. When a restore lands, the drafting steps are skipped entirely: no model call, no AWS role assumption.

Decision rules (documented in `scripts/restore-store-notes.ts`):
- a human-authored branch HEAD is a deliberate state: an edit is kept by the draft guard, a deletion is the documented "redraft" gesture — no restore
- newest prior tip where the file exists and is human-authored → restore it and stop
- newest prior tip where the file exists but is bot-authored → nothing to restore
- a human deletion commit stops the walk — deliberate deletions stay deleted
- any restore failure degrades to the pre-restore status quo (draft as usual) rather than failing the job

Hardening in the same pass:
- `fetch-depth: 0`: the authorship guard reads `git log`, which a depth-1 checkout cannot see — it would misread a human edit as unattributed and overwrite it whenever any other push landed on top
- the draft push rebases and retries: release.yml's Cargo.lock sync pushes to the same branch
- infra: the `lux-store-notes` role trust adds a `job_workflow_ref` condition, so only `.github/workflows/store-notes.yml` — not any pull_request-context workflow in the repo — can assume the role

The restore walk was exercised against this repo's real release-branch run history (correctly returns no-restore for branches that never carried the file).