### PR TITLE
feat(remote): ctl wire contract and authorizer publish policy

### DIFF
--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -12,7 +12,9 @@
 //! field they rely on.
 //!
 //! [`nudge`] holds the other half of the spine: the tiny change-notification
-//! frame and the MQTT topic scheme the sync-api publishes it on.
+//! frame and the MQTT topic scheme the sync-api publishes it on. [`ctl`] is
+//! the remote-control channel riding the same connection: live buffer frames
+//! between a user's own devices, parsed (unlike nudges) and versioned.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -189,6 +191,136 @@ pub mod nudge {
     pub const AUTHORIZER_NAME: &str = "lux-sync-auth";
 }
 
+pub mod ctl {
+    //! The remote-control channel: live buffer writes between a user's own
+    //! devices, riding the same standing IoT connection as [`super::nudge`].
+    //!
+    //! Topic scheme, all under the per-user prefix the authorizer's policy
+    //! wildcards ([`user_prefix`]):
+    //!
+    //! - `…/setup/<setupId>/frame` — live control frames, QoS 0, not retained.
+    //! - `…/setup/<setupId>/state` — retained echo of the applier's last-applied
+    //!   full buffer (a [`Frame::Buffer`]), so every surface can reflect truth.
+    //! - `…/presence/<session>` — retained presence card; an **empty retained
+    //!   payload clears it** and is also the connection's Last Will. Presence is
+    //!   session-scoped, not setup-scoped, because a connection has exactly one
+    //!   will and the active setup changes without reconnecting — the card's
+    //!   `setupId` carries the binding.
+    //! - `…/setup/<setupId>/config` — reserved for render-node compiled setups.
+    //!
+    //! Unlike nudge frames (opaque by contract), ctl payloads are parsed —
+    //! listeners route by topic. Every payload carries `v` from day one: the
+    //! desktop updates within hours while iOS waits on App Store review, so
+    //! version skew between one user's own devices is the normal case, and
+    //! readers drop frames whose version they don't know. Shapes stay flat and
+    //! small on purpose — an embedded render node must be able to consume
+    //! `frame`/`config` with a fixed-size parser.
+
+    use serde::{Deserialize, Serialize};
+
+    /// Current ctl payload version, stamped by the constructors. Readers drop
+    /// payloads with any other version (log + ignore, never an error surface).
+    pub const VERSION: u32 = 1;
+
+    /// The per-user ctl namespace, no trailing slash: `lux/ctl/user/<sub>`.
+    /// The authorizer grants publish/subscribe/receive on `<prefix>/*`.
+    pub fn user_prefix(sub: &str) -> String {
+        format!("lux/ctl/user/{sub}")
+    }
+
+    /// The subscription filter covering a user's whole ctl space.
+    pub fn user_filter(sub: &str) -> String {
+        format!("{}/#", user_prefix(sub))
+    }
+
+    /// Live control frames for one setup (remote surface → applier).
+    pub fn frame_topic(sub: &str, setup_id: &str) -> String {
+        format!("{}/setup/{setup_id}/frame", user_prefix(sub))
+    }
+
+    /// Retained last-applied buffer echo for one setup (applier → surfaces).
+    pub fn state_topic(sub: &str, setup_id: &str) -> String {
+        format!("{}/setup/{setup_id}/state", user_prefix(sub))
+    }
+
+    /// Reserved: retained compiled setup for render nodes. No publisher yet;
+    /// named now so the scheme is carved once.
+    pub fn config_topic(sub: &str, setup_id: &str) -> String {
+        format!("{}/setup/{setup_id}/config", user_prefix(sub))
+    }
+
+    /// Retained presence card for one connection (`session` = the random
+    /// client-id suffix the connection already mints).
+    pub fn presence_topic(sub: &str, session: &str) -> String {
+        format!("{}/presence/{session}", user_prefix(sub))
+    }
+
+    /// One live control write. The two kinds mirror the command layer's two
+    /// buffer mutations, so concurrent editors compose instead of clobbering
+    /// each other with stale full snapshots: a fader drag touches one slot, a
+    /// color-pick overlays the leading slots, and cross-device races resolve
+    /// per-slot last-write-wins at the applier.
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(untagged)]
+    pub enum Frame {
+        /// `{"v":1,"buffer":[…]}` — overlay onto the leading slots, exactly
+        /// `LuxBuffer::set` semantics (higher slots untouched).
+        Buffer { v: u32, buffer: Vec<u8> },
+        /// `{"v":1,"ch":10,"val":200}` — one slot; `ch` is the 1-based DMX
+        /// slot number, matching `set_channel`.
+        Channel { v: u32, ch: u16, val: u8 },
+    }
+
+    impl Frame {
+        pub fn buffer(buffer: Vec<u8>) -> Self {
+            Frame::Buffer { v: VERSION, buffer }
+        }
+
+        pub fn channel(ch: u16, val: u8) -> Self {
+            Frame::Channel {
+                v: VERSION,
+                ch,
+                val,
+            }
+        }
+
+        /// The payload's wire version — gate on this before applying.
+        pub fn version(&self) -> u32 {
+            match self {
+                Frame::Buffer { v, .. } | Frame::Channel { v, .. } => *v,
+            }
+        }
+    }
+
+    /// Retained presence card: "this connection is live, applying `setup_id`".
+    /// Republished on active-setup change; cleared (empty retained payload) on
+    /// sign-out/shutdown and by the connection's Last Will on ungraceful drops.
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct PresenceCard {
+        pub v: u32,
+        /// The connection's session id (its client-id suffix) — matches the
+        /// topic segment, so a card is self-describing off-topic too.
+        pub session: String,
+        /// The setup this peer currently has active and applies frames for.
+        pub setup_id: String,
+        /// Human-readable device name, so surfaces (and receiver tooling) can
+        /// say *which* device is live.
+        pub name: String,
+    }
+
+    impl PresenceCard {
+        pub fn new(session: String, setup_id: String, name: String) -> Self {
+            Self {
+                v: VERSION,
+                session,
+                setup_id,
+                name,
+            }
+        }
+    }
+}
+
 // --- golden tests: the wire's own drift gate ---------------------------------
 //
 // Each test pins the exact JSON a type produces/accepts. If one of these fails,
@@ -362,5 +494,75 @@ mod tests {
         assert_eq!(nudge::settings_changed_frame(), r#"{"changed":"settings"}"#);
         assert_eq!(nudge::user_topic("abc-123"), "lux/sync/user/abc-123");
         assert_eq!(nudge::client_id_prefix("abc-123"), "lux-sync-abc-123-");
+    }
+
+    #[test]
+    fn ctl_topics() {
+        assert_eq!(ctl::user_prefix("abc-123"), "lux/ctl/user/abc-123");
+        assert_eq!(ctl::user_filter("abc-123"), "lux/ctl/user/abc-123/#");
+        assert_eq!(
+            ctl::frame_topic("abc-123", "s-1"),
+            "lux/ctl/user/abc-123/setup/s-1/frame"
+        );
+        assert_eq!(
+            ctl::state_topic("abc-123", "s-1"),
+            "lux/ctl/user/abc-123/setup/s-1/state"
+        );
+        assert_eq!(
+            ctl::config_topic("abc-123", "s-1"),
+            "lux/ctl/user/abc-123/setup/s-1/config"
+        );
+        assert_eq!(
+            ctl::presence_topic("abc-123", "0a1b2c3d"),
+            "lux/ctl/user/abc-123/presence/0a1b2c3d"
+        );
+    }
+
+    #[test]
+    fn ctl_frame_shapes() {
+        // Overlay frame: the color-picker path, LuxBuffer::set semantics.
+        let overlay = ctl::Frame::buffer(vec![121, 255, 0]);
+        assert_eq!(
+            serde_json::to_string(&overlay).unwrap(),
+            r#"{"v":1,"buffer":[121,255,0]}"#
+        );
+
+        // Channel frame: the fader path, 1-based DMX slot.
+        let channel = ctl::Frame::channel(10, 200);
+        assert_eq!(
+            serde_json::to_string(&channel).unwrap(),
+            r#"{"v":1,"ch":10,"val":200}"#
+        );
+
+        // Parsing picks the right kind from the fields alone (untagged).
+        let parsed: ctl::Frame = serde_json::from_str(r#"{"v":1,"buffer":[1,2]}"#).unwrap();
+        assert_eq!(parsed, ctl::Frame::buffer(vec![1, 2]));
+        let parsed: ctl::Frame = serde_json::from_str(r#"{"v":1,"ch":512,"val":0}"#).unwrap();
+        assert_eq!(parsed, ctl::Frame::channel(512, 0));
+        assert_eq!(parsed.version(), 1);
+
+        // A future shape that matches neither kind fails to parse — readers
+        // treat that exactly like an unknown version: log + drop.
+        assert!(serde_json::from_str::<ctl::Frame>(r#"{"v":2,"verb":"fade"}"#).is_err());
+
+        // A known kind with a newer version still parses; the version gate is
+        // the reader's job, so it must survive deserialization.
+        let future: ctl::Frame = serde_json::from_str(r#"{"v":9,"ch":1,"val":1}"#).unwrap();
+        assert_eq!(future.version(), 9);
+    }
+
+    #[test]
+    fn ctl_presence_card_shape() {
+        let card = ctl::PresenceCard::new("0a1b2c3d".into(), "s-1".into(), "Mac Mini".into());
+        assert_eq!(
+            serde_json::to_string(&card).unwrap(),
+            r#"{"v":1,"session":"0a1b2c3d","setupId":"s-1","name":"Mac Mini"}"#
+        );
+
+        let parsed: ctl::PresenceCard = serde_json::from_str(
+            r#"{"v":1,"session":"0a1b2c3d","setupId":"s-1","name":"Mac Mini"}"#,
+        )
+        .unwrap();
+        assert_eq!(parsed, card);
     }
 }

--- a/services/iot-authorizer/Cargo.toml
+++ b/services/iot-authorizer/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# AWS IoT custom authorizer for the change-nudge channel. The desktop connects
-# to IoT Core over MQTT-over-WebSocket carrying its Cognito ID token; IoT hands
-# the token to this Lambda, which verifies it (lux-auth) and returns an IoT
-# policy scoped to that user's own nudge topic and client-id prefix (lux-wire).
+# AWS IoT custom authorizer for the user channel (change nudges + remote
+# control). The app connects to IoT Core over MQTT-over-WebSocket carrying its
+# Cognito ID token; IoT hands the token to this Lambda, which verifies it
+# (lux-auth) and returns an IoT policy scoped to that user's own nudge topic,
+# remote-control (ctl) space, and client-id prefix (lux-wire).
 # Built and deployed with cargo-lambda, like the sibling services.
 
 [lints]

--- a/services/iot-authorizer/src/main.rs
+++ b/services/iot-authorizer/src/main.rs
@@ -5,9 +5,11 @@
 //! IoT invokes this Lambda on every connect with the Cognito ID token the app
 //! put in the `x-lux-token` handshake header (the authorizer's
 //! `token_key_name`); we verify it exactly as the sync-api does (`lux-auth`)
-//! and answer with an IoT policy scoped to the *verified* user's own topic and
-//! client-id prefix — the same token-derived tenant isolation as the DynamoDB
-//! partition key. A bad token gets `isAuthenticated: false`, never a policy.
+//! and answer with an IoT policy scoped to the *verified* user's own topics —
+//! the nudge subscription plus pub/sub over their remote-control (`ctl`)
+//! space — and client-id prefix: the same token-derived tenant isolation as
+//! the DynamoDB partition key. A bad token gets `isAuthenticated: false`,
+//! never a policy.
 //!
 //! The authorizer is registered with signing disabled: the desktop is a public
 //! client and can't hold a signing key, so the JWT check here is the gate —
@@ -109,9 +111,22 @@ fn authorize(verifier: &lux_auth::Verifier, event: LambdaEvent<Value>) -> Value 
         }
     };
 
+    allow(region, account, &sub)
+}
+
+/// The allow response for a verified user: connect under their own client-id
+/// prefix, the nudge subscription, and full pub/sub over their own
+/// remote-control space (`lux_wire::ctl`) — the ctl channel rides the same
+/// connection, and the topic scheme scopes every grant to the verified sub.
+/// (In the ctl resources, `*` is an IAM string wildcard, so the Subscribe
+/// grant matches the client's `…/#` filter; Subscribe takes `topicfilter`
+/// ARNs, Publish/Receive take `topic` ARNs. The Publish grant also covers the
+/// connection's Last Will on the presence topic.)
+fn allow(region: &str, account: &str, sub: &str) -> Value {
     let prefix = format!("arn:aws:iot:{region}:{account}");
-    let topic = lux_wire::nudge::user_topic(&sub);
-    let client_prefix = lux_wire::nudge::client_id_prefix(&sub);
+    let nudge_topic = lux_wire::nudge::user_topic(sub);
+    let client_prefix = lux_wire::nudge::client_id_prefix(sub);
+    let ctl_prefix = lux_wire::ctl::user_prefix(sub);
 
     json!({
         "isAuthenticated": true,
@@ -132,12 +147,23 @@ fn authorize(verifier: &lux_auth::Verifier, event: LambdaEvent<Value>) -> Value 
                 {
                     "Effect": "Allow",
                     "Action": "iot:Subscribe",
-                    "Resource": format!("{prefix}:topicfilter/{topic}"),
+                    "Resource": [
+                        format!("{prefix}:topicfilter/{nudge_topic}"),
+                        format!("{prefix}:topicfilter/{ctl_prefix}/*"),
+                    ],
                 },
                 {
                     "Effect": "Allow",
                     "Action": "iot:Receive",
-                    "Resource": format!("{prefix}:topic/{topic}"),
+                    "Resource": [
+                        format!("{prefix}:topic/{nudge_topic}"),
+                        format!("{prefix}:topic/{ctl_prefix}/*"),
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": "iot:Publish",
+                    "Resource": format!("{prefix}:topic/{ctl_prefix}/*"),
                 },
             ],
         }],
@@ -218,5 +244,50 @@ mod tests {
         let e = event(json!({ "protocolData": { "http": { "headers": {} } } }));
         assert_eq!(extract_token(&e), None);
         assert_eq!(extract_token(&event(json!({}))), None);
+    }
+
+    #[test]
+    fn allow_policy_grants_nudge_and_ctl_scoped_to_the_sub() {
+        let response = allow("us-west-1", "735853783919", "abc-123");
+        assert_eq!(response["isAuthenticated"], true);
+        assert_eq!(response["principalId"], "abc123"); // non-alphanumerics dropped
+
+        let statements = &response["policyDocuments"][0]["Statement"];
+        let arn = |suffix: &str| format!("arn:aws:iot:us-west-1:735853783919:{suffix}");
+
+        assert_eq!(statements[0]["Action"], "iot:Connect");
+        assert_eq!(
+            statements[0]["Resource"],
+            arn("client/lux-sync-abc-123-*").as_str()
+        );
+
+        assert_eq!(statements[1]["Action"], "iot:Subscribe");
+        assert_eq!(
+            statements[1]["Resource"],
+            json!([
+                arn("topicfilter/lux/sync/user/abc-123"),
+                arn("topicfilter/lux/ctl/user/abc-123/*"),
+            ])
+        );
+
+        assert_eq!(statements[2]["Action"], "iot:Receive");
+        assert_eq!(
+            statements[2]["Resource"],
+            json!([
+                arn("topic/lux/sync/user/abc-123"),
+                arn("topic/lux/ctl/user/abc-123/*"),
+            ])
+        );
+
+        // The one genuinely new capability: publish, ctl space only — nothing
+        // grants publish on the nudge topic or anyone else's prefix.
+        assert_eq!(statements[3]["Action"], "iot:Publish");
+        assert_eq!(
+            statements[3]["Resource"],
+            arn("topic/lux/ctl/user/abc-123/*").as_str()
+        );
+        // json indexing past the end yields Null — asserts there is no fifth
+        // statement without unwrapping.
+        assert_eq!(statements[4], Value::Null);
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of the remote-control channel: the shared wire contract and broker policy that let a signed-in device publish live control frames into its own user-scoped topic space. Additive and inert — no client publishes or subscribes to these topics yet, and existing nudge behavior is unchanged.

- `lux-wire`: new `ctl` module — topic scheme under `lux/ctl/user/<sub>/…` (per-setup `frame`/`state`, reserved `config`, session-scoped `presence`), versioned intent-scoped frames mirroring the two buffer mutations (full-buffer overlay + single 1-based channel write), and the retained presence card whose empty payload doubles as the connection's Last Will. Golden tests pin every topic string and payload shape.
- `lux-iot-authorizer`: the verified user's policy now also grants publish/subscribe/receive over their own ctl space alongside the existing nudge grants; policy construction is extracted into `allow()` with a unit test asserting every statement — including that publish is scoped to the ctl space only (never the nudge topic, never another user's prefix).

The authorizer change ships with the next release's `deploy-lambdas`; older clients are unaffected.

## Test plan

- [x] `cargo test -p lux-wire -p lux-iot-authorizer --locked` — 19 tests (new ctl goldens + the policy statement test)
- [x] `cargo clippy -p lux-wire -p lux-iot-authorizer --locked -- -D warnings` (CI's invocation, scoped)
- [ ] PR gate: full workspace suite