### PR TITLE
feat(remote): apply ctl frames on the user channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2012,7 +2012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2413,6 +2413,16 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3560,6 +3570,7 @@ dependencies = [
  "aws-smithy-http-client",
  "base64 0.22.1",
  "enttecopendmx",
+ "gethostname",
  "keyring",
  "keyring-core",
  "libftd2xx 0.33.1",
@@ -4170,7 +4181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5018,7 +5029,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5097,7 +5108,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6365,7 +6376,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7267,7 +7278,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -74,6 +74,7 @@ rumqttc = { version = "0.25", features = ["websocket"] }
 # features here (no cmake / aws-lc-sys C build).
 rustls = { workspace = true, features = ["logging", "std", "tls12"] }
 tauri-plugin-process = "2"
+gethostname = "1.1.0"
 
 # Desktop-only outputs and integrations with no iOS/Android equivalent: USB/FTDI
 # (Enttec Open DMX), the system tray, and the self-updater. Mobile drives output

--- a/apps/desktop/src-tauri/src/buffer.rs
+++ b/apps/desktop/src-tauri/src/buffer.rs
@@ -103,6 +103,9 @@ impl LuxBuffer {
     ) -> Result<LuxBuffer, String> {
         emit_buffer(snapshot.clone(), &app)?;
         schedule_persist(&app);
+        // Refresh the retained remote-control state echo (no-op when the user
+        // channel is down) — remote surfaces reflect local changes through it.
+        crate::nudge::schedule_state_echo(&app);
         render(&snapshot, &app)?;
         Ok(self.clone())
     }

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -536,6 +536,8 @@ fn activate(app: &AppHandle, setups: &LuxSetups) -> Result<(), String> {
     }
     .emit(app)
     .map_err(|e| format!("Failed to emit patch_set event: {e}"))?;
+    // Remote surfaces learn the new binding through the presence card.
+    crate::nudge::presence_changed(app);
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/nudge.rs
+++ b/apps/desktop/src-tauri/src/nudge.rs
@@ -1,67 +1,115 @@
-//! Change-nudge listener: one open MQTT-over-WebSocket connection to AWS IoT
-//! Core, so this device pulls immediately when another of the user's devices
-//! writes a setup — vegify's sync model (server-authoritative, nudged pull),
-//! with IoT Core standing in for vegify's standing server as the connection
-//! holder.
+//! The user channel: one open MQTT-over-WebSocket connection to AWS IoT Core
+//! per signed-in device, carrying two kinds of traffic routed by topic:
 //!
-//! The sync-api publishes a tiny frame to `lux/sync/user/<sub>` after each
-//! committed write (`lux_wire::nudge`). The frame is opaque by design and never
-//! parsed here: **any** frame means "pull now", and the pull
-//! ([`crate::cloud::schedule_sync`], already single-flight) stays the
-//! authoritative sync. Missed frames are healed by the existing safety nets —
-//! pull on sign-in/startup/focus plus the on-(re)connect pull below — so
-//! delivery is deliberately best-effort (QoS 0).
+//! - **Change nudges** (`lux/sync/user/<sub>`) — the sync-api publishes a tiny
+//!   frame after each committed write. The frame is opaque by design and never
+//!   parsed here: **any** frame means "pull now", and the pull
+//!   ([`crate::cloud::schedule_sync`], already single-flight) stays the
+//!   authoritative sync. Missed frames are healed by the existing safety nets —
+//!   pull on sign-in/startup/focus plus the on-(re)connect pull below — so
+//!   delivery is deliberately best-effort (QoS 0).
+//! - **Remote control** (`lux/ctl/user/<sub>/…`, `lux_wire::ctl`) — live
+//!   buffer frames published by the user's other surfaces. Frames addressed to
+//!   this device's *active* setup run through the same [`LuxBuffer`] paths as
+//!   local input (overlay/channel semantics preserved); everything else is
+//!   dropped. The connection also announces itself with a retained presence
+//!   card (cleared by the Last Will on ungraceful drops and explicitly on
+//!   sign-out) and keeps a retained state echo — the last-applied full buffer,
+//!   coalesced to ≤5 Hz — so remote surfaces can reflect truth, including
+//!   changes made locally at this device.
 //!
 //! Auth mirrors the sync-api's posture: the handshake carries the Cognito ID
 //! token in the `x-lux-token` header; the `lux-sync-auth` IoT custom authorizer
 //! verifies it and scopes the connection's policy to the *verified* user's own
-//! topic. The token is re-read (and on auth failures refreshed) on every
+//! topics. The token is re-read (and on auth failures refreshed) on every
 //! reconnect attempt, vegify-style, with capped exponential backoff (1s→30s).
 //!
 //! The IoT endpoint comes from [`crate::endpoints`] (the generated-and-embedded
 //! production config, `endpoints.local.json` for dev stacks) — missing means
-//! nudges are off and pull-based sync carries everything. The authorizer name
-//! is protocol, not environment (`lux_wire::nudge::AUTHORIZER_NAME`). Runs
+//! the channel is off and pull-based sync carries everything. The authorizer
+//! name is protocol, not environment (`lux_wire::nudge::AUTHORIZER_NAME`). Runs
 //! while signed in; [`stop`] on sign-out.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 use std::time::Duration;
 
 use base64::Engine;
 use rumqttc::{
-    AsyncClient, ConnectionError, Event, MqttOptions, Packet, QoS, TlsConfiguration, Transport,
+    AsyncClient, ConnectionError, Event, LastWill, MqttOptions, Packet, QoS, SubscribeFilter,
+    TlsConfiguration, Transport,
 };
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Manager, Runtime};
 use tokio::sync::watch;
 use uuid::Uuid;
 
 use crate::account::{webpki_pem_bundle, LuxAccount};
+use crate::buffer::LuxBuffer;
+use crate::lock::LockPolicy;
+use crate::setup::LuxSetups;
+
+/// Trailing-edge coalescing window for the retained state echo (≤5 Hz) — a
+/// remote surface needs truth, not every intermediate slider position.
+const ECHO_WINDOW: Duration = Duration::from_millis(200);
 
 fn nudge_endpoint() -> Option<String> {
     Some(crate::endpoints::effective().nudge_endpoint.clone()).filter(|e| !e.is_empty())
 }
 
-/// Tauri-managed listener lifecycle. The watch value is a generation counter:
-/// [`start`] bumps it and spawns a listener bound to the new generation, so a
-/// stale listener (previous sign-in, or a sign-out via [`stop`]) sees the bump
-/// and exits — at most one listener is ever live.
+/// Tauri-managed listener lifecycle. The `generation` watch value is a
+/// counter: [`start`] bumps it and spawns a listener bound to the new
+/// generation, so a stale listener (previous sign-in, or a sign-out via
+/// [`stop`]) sees the bump and exits — at most one listener is ever live.
+/// `presence` is bumped by [`presence_changed`] so the live connection
+/// republishes its card without reconnecting; `echo` is the live connection's
+/// publish handle for [`schedule_state_echo`].
 pub struct LuxNudge {
     generation: watch::Sender<u64>,
+    presence: watch::Sender<u64>,
+    echo: Mutex<Option<EchoHandle>>,
+    echo_pending: AtomicBool,
 }
 
 impl Default for LuxNudge {
     fn default() -> Self {
         Self {
             generation: watch::channel(0).0,
+            presence: watch::channel(0).0,
+            echo: Mutex::new(None),
+            echo_pending: AtomicBool::new(false),
         }
     }
 }
 
-/// Start (or restart) the nudge listener for the signed-in user. Called after
-/// sign-in and after a startup session restore; no-op when nudges aren't
+impl LuxNudge {
+    fn set_echo(&self, handle: EchoHandle) {
+        *self.echo.lock_or_recover() = Some(handle);
+    }
+
+    /// Clear the echo handle, but only if it still belongs to `session` — a
+    /// replacement connection may already have installed its own.
+    fn clear_echo(&self, session: &str) {
+        let mut echo = self.echo.lock_or_recover();
+        if echo.as_ref().is_some_and(|e| e.session == session) {
+            *echo = None;
+        }
+    }
+}
+
+/// The live connection's handle for publishing the retained state echo.
+#[derive(Clone)]
+struct EchoHandle {
+    client: AsyncClient,
+    sub: String,
+    session: String,
+}
+
+/// Start (or restart) the listener for the signed-in user. Called after
+/// sign-in and after a startup session restore; no-op when the channel isn't
 /// configured or nobody is signed in.
 pub fn start(app: &AppHandle) {
     let Some(endpoint) = nudge_endpoint() else {
-        log::info!("nudge endpoint not configured (endpoints file); realtime sync nudges disabled");
+        log::info!("nudge endpoint not configured (endpoints file); user channel disabled");
         return;
     };
     if !app.state::<LuxAccount>().signed_in() {
@@ -103,9 +151,15 @@ pub fn start(app: &AppHandle) {
                 );
                 return;
             };
-            refresh_first =
-                run_connection(&app, &endpoint, token, &sub, &mut generation, &mut backoff_secs)
-                    .await;
+            refresh_first = run_connection(
+                &app,
+                &endpoint,
+                token,
+                &sub,
+                &mut generation,
+                &mut backoff_secs,
+            )
+            .await;
             if *generation.borrow() != my_generation {
                 return;
             }
@@ -120,10 +174,56 @@ pub fn stop(app: &AppHandle) {
     app.state::<LuxNudge>().generation.send_modify(|g| *g += 1);
 }
 
-/// One connection lifetime: connect, subscribe, forward frames to the sync
-/// engine until the connection drops or the listener is superseded. Returns
-/// whether the failure looked auth-shaped (broker refused the connect), so the
-/// caller refreshes the token before retrying.
+/// Ask the live connection to republish its presence card — called when the
+/// active setup changes, so remote surfaces learn the new binding without a
+/// reconnect. No-op when no connection is up.
+pub fn presence_changed<R: Runtime>(app: &AppHandle<R>) {
+    app.state::<LuxNudge>().presence.send_modify(|g| *g += 1);
+}
+
+/// Schedule a retained state-echo publish of the current buffer to the active
+/// setup's `state` topic, trailing-edge coalesced to [`ECHO_WINDOW`]. Called
+/// from the buffer's commit path, so local input and remotely-applied frames
+/// both refresh the echo; fast no-op when no connection is live. The echo is
+/// retained-topic-only and never fed back into the buffer, so it cannot loop.
+pub fn schedule_state_echo<R: Runtime>(app: &AppHandle<R>) {
+    let state = app.state::<LuxNudge>();
+    if state.echo.lock_or_recover().is_none() {
+        return;
+    }
+    if state.echo_pending.swap(true, Ordering::SeqCst) {
+        return; // a publish is already queued and will pick this change up
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(ECHO_WINDOW).await;
+        let state = app.state::<LuxNudge>();
+        state.echo_pending.store(false, Ordering::SeqCst);
+        let Some(echo) = state.echo.lock_or_recover().clone() else {
+            return;
+        };
+        let buffer: Vec<u8> = app.state::<LuxBuffer>().buffer.lock_or_recover().clone();
+        let setup_id = app.state::<LuxSetups>().active_id().to_string();
+        let frame = lux_wire::ctl::Frame::buffer(buffer).with_src(&echo.session);
+        let Ok(payload) = serde_json::to_vec(&frame) else {
+            return;
+        };
+        let topic = lux_wire::ctl::state_topic(&echo.sub, &setup_id);
+        if let Err(e) = echo
+            .client
+            .publish(topic, QoS::AtMostOnce, true, payload)
+            .await
+        {
+            log::debug!("state echo publish failed (connection likely down): {e}");
+        }
+    });
+}
+
+/// One connection lifetime: connect, subscribe (nudge + ctl), announce
+/// presence, then route incoming traffic until the connection drops or the
+/// listener is superseded. Returns whether the failure looked auth-shaped
+/// (broker refused the connect), so the caller refreshes the token before
+/// retrying.
 async fn run_connection(
     app: &AppHandle,
     endpoint: &str,
@@ -134,17 +234,25 @@ async fn run_connection(
 ) -> bool {
     // Random per-session suffix: one user's devices must not share a client id
     // (IoT disconnects duplicates). The authorizer's policy allows the prefix.
-    let client_id = format!(
-        "{}{}",
-        lux_wire::nudge::client_id_prefix(sub),
-        &Uuid::new_v4().simple().to_string()[..8]
-    );
+    // The suffix doubles as the connection's ctl session id — it names the
+    // presence topic and stamps outgoing frames (`Frame::src`).
+    let session = Uuid::new_v4().simple().to_string()[..8].to_owned();
+    let client_id = format!("{}{}", lux_wire::nudge::client_id_prefix(sub), session);
+    let presence_topic = lux_wire::ctl::presence_topic(sub, &session);
     let url = format!(
         "wss://{endpoint}/mqtt?x-amz-customauthorizer-name={}",
         lux_wire::nudge::AUTHORIZER_NAME
     );
     let mut opts = MqttOptions::new(client_id, url, 443);
     opts.set_keep_alive(Duration::from_secs(30));
+    // Ungraceful drops clear our retained presence card (empty retained
+    // payload = delete); the graceful paths below publish the same goodbye.
+    opts.set_last_will(LastWill::new(
+        presence_topic.clone(),
+        Vec::<u8>::new(),
+        QoS::AtMostOnce,
+        true,
+    ));
     // Trust the bundled webpki roots, not the platform store (unreadable on
     // iOS — same lesson as the account layer's AWS SDK client).
     opts.set_transport(Transport::Wss(TlsConfiguration::Simple {
@@ -165,38 +273,198 @@ async fn run_connection(
 
     let (client, mut eventloop) = AsyncClient::new(opts, 10);
     if let Err(e) = client
-        .subscribe(lux_wire::nudge::user_topic(sub), QoS::AtMostOnce)
+        .subscribe_many([
+            SubscribeFilter::new(lux_wire::nudge::user_topic(sub), QoS::AtMostOnce),
+            SubscribeFilter::new(lux_wire::ctl::user_filter(sub), QoS::AtMostOnce),
+        ])
         .await
     {
         log::warn!("nudge: could not queue subscribe: {e}");
         return false;
     }
 
+    let state = app.state::<LuxNudge>();
+    let mut presence_rx = state.presence.subscribe();
+    presence_rx.borrow_and_update();
+
     loop {
         tokio::select! {
             _ = generation.changed() => {
+                // Graceful goodbye: clear the retained presence card so other
+                // surfaces grey out immediately (the Last Will only fires on
+                // ungraceful drops).
+                let _ = client
+                    .publish(presence_topic.clone(), QoS::AtMostOnce, true, Vec::<u8>::new())
+                    .await;
                 let _ = client.disconnect().await;
+                state.clear_echo(&session);
                 return false; // superseded — the outer loop exits
+            }
+            _ = presence_rx.changed() => {
+                publish_presence(&client, app, sub, &session).await;
             }
             event = eventloop.poll() => match event {
                 Ok(Event::Incoming(Packet::SubAck(_))) => {
-                    log::info!("nudge channel connected; listening for setup changes");
+                    log::info!("user channel connected; nudges + remote control live");
                     *backoff_secs = 1;
+                    state.set_echo(EchoHandle {
+                        client: client.clone(),
+                        sub: sub.to_owned(),
+                        session: session.clone(),
+                    });
+                    publish_presence(&client, app, sub, &session).await;
+                    // Refresh the retained truth for whoever is watching.
+                    schedule_state_echo(app);
                     // On-(re)connect pull: cover anything nudged while offline.
                     crate::cloud::schedule_sync(app);
                 }
-                Ok(Event::Incoming(Packet::Publish(_))) => {
-                    // Opaque frame — never parsed; any frame means "pull now".
-                    log::debug!("nudge received; scheduling sync");
-                    crate::cloud::schedule_sync(app);
+                Ok(Event::Incoming(Packet::Publish(publish))) => {
+                    match route(&publish.topic, sub) {
+                        Route::Nudge => {
+                            // Opaque frame — never parsed; any frame means "pull now".
+                            log::debug!("nudge received; scheduling sync");
+                            crate::cloud::schedule_sync(app);
+                        }
+                        Route::Frame { setup_id } => {
+                            apply_frame(app, &publish.payload, setup_id, &session);
+                        }
+                        Route::Passive => {}
+                        Route::Unknown => {
+                            log::debug!("ignoring publish on unexpected topic {}", publish.topic);
+                        }
+                    }
                 }
                 Ok(_) => {}
                 Err(e) => {
                     log::info!("nudge connection error (will reconnect): {e}");
+                    state.clear_echo(&session);
                     return matches!(e, ConnectionError::ConnectionRefused(_));
                 }
             }
         }
+    }
+}
+
+/// Publish (or refresh) this connection's retained presence card.
+async fn publish_presence(client: &AsyncClient, app: &AppHandle, sub: &str, session: &str) {
+    let setup_id = app.state::<LuxSetups>().active_id().to_string();
+    let card = lux_wire::ctl::PresenceCard::new(session.to_owned(), setup_id, device_name());
+    let Ok(payload) = serde_json::to_vec(&card) else {
+        return;
+    };
+    let topic = lux_wire::ctl::presence_topic(sub, session);
+    if let Err(e) = client.publish(topic, QoS::AtMostOnce, true, payload).await {
+        log::debug!("presence publish failed: {e}");
+    }
+}
+
+/// This device's human-readable name for presence cards.
+fn device_name() -> String {
+    gethostname::gethostname().to_string_lossy().into_owned()
+}
+
+/// Parse a ctl frame and, if the gate lets it through, run it down the same
+/// buffer paths local input uses — so a remote write behaves exactly like a
+/// local one (overlay semantics, BufferSet emission, persistence, render).
+fn apply_frame(app: &AppHandle, payload: &[u8], frame_setup: &str, own_session: &str) {
+    let frame: lux_wire::ctl::Frame = match serde_json::from_slice(payload) {
+        Ok(frame) => frame,
+        Err(e) => {
+            log::warn!("ignoring unreadable ctl frame: {e}");
+            return;
+        }
+    };
+    let active = app.state::<LuxSetups>().active_id().to_string();
+    let Some(apply) = gate(frame, frame_setup, &active, own_session) else {
+        return;
+    };
+    let mut buffer = app.state::<LuxBuffer>().inner().clone();
+    let result = match apply {
+        RemoteApply::Overlay(bytes) => buffer.set(bytes, app.clone()).map(|_| ()),
+        RemoteApply::Channel { ch, val } => buffer
+            .set_channel(usize::from(ch), val, app.clone())
+            .map(|_| ()),
+    };
+    if let Err(e) = result {
+        log::warn!("ctl frame apply failed: {e}");
+    }
+}
+
+/// Where an incoming publish on the user channel goes.
+#[derive(Debug, PartialEq, Eq)]
+enum Route<'t> {
+    /// The opaque nudge topic — schedule a pull.
+    Nudge,
+    /// A live ctl frame addressed to one setup.
+    Frame { setup_id: &'t str },
+    /// Retained ctl traffic (presence cards, state echoes, reserved config) —
+    /// published by peers including this device; nothing for the listener to
+    /// do with it today.
+    Passive,
+    /// Not a topic this listener expects under the granted policy.
+    Unknown,
+}
+
+/// Classify an incoming topic. Plain function over plain types on purpose —
+/// the routing decision must stay testable (and extractable) without Tauri.
+fn route<'t>(topic: &'t str, sub: &str) -> Route<'t> {
+    if topic == lux_wire::nudge::user_topic(sub) {
+        return Route::Nudge;
+    }
+    let prefix = lux_wire::ctl::user_prefix(sub);
+    let Some(rest) = topic
+        .strip_prefix(prefix.as_str())
+        .and_then(|rest| rest.strip_prefix('/'))
+    else {
+        return Route::Unknown;
+    };
+    if let Some(setup_rest) = rest.strip_prefix("setup/") {
+        return match setup_rest.split_once('/') {
+            Some((setup_id, "frame")) => Route::Frame { setup_id },
+            Some((_, "state" | "config")) => Route::Passive,
+            _ => Route::Unknown,
+        };
+    }
+    if rest.strip_prefix("presence/").is_some() {
+        return Route::Passive;
+    }
+    Route::Unknown
+}
+
+/// One applicable buffer mutation extracted from a gated ctl frame.
+#[derive(Debug, PartialEq, Eq)]
+enum RemoteApply {
+    Overlay(Vec<u8>),
+    Channel { ch: u16, val: u8 },
+}
+
+/// Whether this peer applies `frame`: the version must be known, the frame
+/// must not be this connection's own publish echoed back (`src` == our
+/// session), and only frames addressed to the active setup apply. Plain
+/// function on purpose (see [`route`]).
+fn gate(
+    frame: lux_wire::ctl::Frame,
+    frame_setup: &str,
+    active_setup: &str,
+    own_session: &str,
+) -> Option<RemoteApply> {
+    if frame.version() != lux_wire::ctl::VERSION {
+        log::debug!(
+            "dropping ctl frame with unknown version {}",
+            frame.version()
+        );
+        return None;
+    }
+    if frame.src() == Some(own_session) {
+        return None; // our own frame, already applied locally
+    }
+    if frame_setup != active_setup {
+        log::debug!("dropping ctl frame for inactive setup {frame_setup}");
+        return None;
+    }
+    match frame {
+        lux_wire::ctl::Frame::Buffer { buffer, .. } => Some(RemoteApply::Overlay(buffer)),
+        lux_wire::ctl::Frame::Channel { ch, val, .. } => Some(RemoteApply::Channel { ch, val }),
     }
 }
 
@@ -216,6 +484,7 @@ fn jwt_sub(token: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lux_wire::ctl::Frame;
 
     #[test]
     fn jwt_sub_reads_the_payload_claim() {
@@ -229,5 +498,74 @@ mod tests {
     fn jwt_sub_rejects_garbage() {
         assert_eq!(jwt_sub("not-a-jwt"), None);
         assert_eq!(jwt_sub("a.b.c"), None);
+    }
+
+    #[test]
+    fn route_classifies_the_user_channel() {
+        let sub = "abc-123";
+        assert_eq!(route("lux/sync/user/abc-123", sub), Route::Nudge);
+        assert_eq!(
+            route("lux/ctl/user/abc-123/setup/s-1/frame", sub),
+            Route::Frame { setup_id: "s-1" }
+        );
+        assert_eq!(
+            route("lux/ctl/user/abc-123/setup/s-1/state", sub),
+            Route::Passive
+        );
+        assert_eq!(
+            route("lux/ctl/user/abc-123/setup/s-1/config", sub),
+            Route::Passive
+        );
+        assert_eq!(
+            route("lux/ctl/user/abc-123/presence/0a1b2c3d", sub),
+            Route::Passive
+        );
+
+        // Not ours / not a shape we know.
+        assert_eq!(route("lux/sync/user/other", sub), Route::Unknown);
+        assert_eq!(
+            route("lux/ctl/user/other/setup/s-1/frame", sub),
+            Route::Unknown
+        );
+        assert_eq!(
+            route("lux/ctl/user/abc-123/setup/s-1/verbs", sub),
+            Route::Unknown
+        );
+        assert_eq!(route("lux/ctl/user/abc-123/setup/s-1", sub), Route::Unknown);
+        assert_eq!(route("lux/ctl/user/abc-123", sub), Route::Unknown);
+        assert_eq!(route("lux/1/buffer/set", sub), Route::Unknown);
+    }
+
+    #[test]
+    fn gate_applies_only_known_versions_for_the_active_setup() {
+        let overlay = Frame::buffer(vec![1, 2, 3]);
+        assert_eq!(
+            gate(overlay, "s-1", "s-1", "me00"),
+            Some(RemoteApply::Overlay(vec![1, 2, 3]))
+        );
+        let channel = Frame::channel(10, 200);
+        assert_eq!(
+            gate(channel, "s-1", "s-1", "me00"),
+            Some(RemoteApply::Channel { ch: 10, val: 200 })
+        );
+
+        // Inactive setup → dropped.
+        assert_eq!(gate(Frame::channel(1, 1), "s-2", "s-1", "me00"), None);
+
+        // Unknown version → dropped (parse it as the reader would).
+        let future: Frame = serde_json::from_str(r#"{"v":9,"ch":1,"val":1}"#).expect("parses");
+        assert_eq!(gate(future, "s-1", "s-1", "me00"), None);
+    }
+
+    #[test]
+    fn gate_drops_our_own_frames_but_applies_other_sessions() {
+        let own = Frame::channel(1, 255).with_src("me00");
+        assert_eq!(gate(own, "s-1", "s-1", "me00"), None);
+
+        let theirs = Frame::channel(1, 255).with_src("them");
+        assert!(gate(theirs, "s-1", "s-1", "me00").is_some());
+
+        // Unstamped (e.g. CLI-published) frames apply.
+        assert!(gate(Frame::channel(1, 255), "s-1", "s-1", "me00").is_some());
     }
 }

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -260,20 +260,41 @@ pub mod ctl {
     /// each other with stale full snapshots: a fader drag touches one slot, a
     /// color-pick overlays the leading slots, and cross-device races resolve
     /// per-slot last-write-wins at the applier.
+    ///
+    /// `src` is the publishing connection's session id. Every peer subscribes
+    /// its whole ctl space, so a publisher receives its own frames back —
+    /// appliers drop frames whose `src` matches their own session instead of
+    /// re-applying them. Optional on the wire so hand-published frames (CLI
+    /// testing) stay valid; absent means "not mine, apply it".
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(untagged)]
     pub enum Frame {
         /// `{"v":1,"buffer":[…]}` — overlay onto the leading slots, exactly
         /// `LuxBuffer::set` semantics (higher slots untouched).
-        Buffer { v: u32, buffer: Vec<u8> },
+        Buffer {
+            v: u32,
+            buffer: Vec<u8>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            src: Option<String>,
+        },
         /// `{"v":1,"ch":10,"val":200}` — one slot; `ch` is the 1-based DMX
         /// slot number, matching `set_channel`.
-        Channel { v: u32, ch: u16, val: u8 },
+        Channel {
+            v: u32,
+            ch: u16,
+            val: u8,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            src: Option<String>,
+        },
     }
 
     impl Frame {
         pub fn buffer(buffer: Vec<u8>) -> Self {
-            Frame::Buffer { v: VERSION, buffer }
+            Frame::Buffer {
+                v: VERSION,
+                buffer,
+                src: None,
+            }
         }
 
         pub fn channel(ch: u16, val: u8) -> Self {
@@ -281,13 +302,31 @@ pub mod ctl {
                 v: VERSION,
                 ch,
                 val,
+                src: None,
             }
+        }
+
+        /// Stamp the publishing connection's session id (see the enum docs).
+        pub fn with_src(mut self, session: &str) -> Self {
+            match &mut self {
+                Frame::Buffer { src, .. } | Frame::Channel { src, .. } => {
+                    *src = Some(session.to_owned());
+                }
+            }
+            self
         }
 
         /// The payload's wire version — gate on this before applying.
         pub fn version(&self) -> u32 {
             match self {
                 Frame::Buffer { v, .. } | Frame::Channel { v, .. } => *v,
+            }
+        }
+
+        /// The publishing connection's session id, if stamped.
+        pub fn src(&self) -> Option<&str> {
+            match self {
+                Frame::Buffer { src, .. } | Frame::Channel { src, .. } => src.as_deref(),
             }
         }
     }
@@ -540,6 +579,22 @@ mod tests {
         let parsed: ctl::Frame = serde_json::from_str(r#"{"v":1,"ch":512,"val":0}"#).unwrap();
         assert_eq!(parsed, ctl::Frame::channel(512, 0));
         assert_eq!(parsed.version(), 1);
+
+        // `src` (the publisher's session id) rides both kinds and is omitted
+        // when absent — the unstamped pins above are also the CLI-publish shape.
+        assert_eq!(
+            serde_json::to_string(&ctl::Frame::channel(10, 200).with_src("0a1b2c3d")).unwrap(),
+            r#"{"v":1,"ch":10,"val":200,"src":"0a1b2c3d"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ctl::Frame::buffer(vec![1]).with_src("0a1b2c3d")).unwrap(),
+            r#"{"v":1,"buffer":[1],"src":"0a1b2c3d"}"#
+        );
+        let stamped: ctl::Frame =
+            serde_json::from_str(r#"{"v":1,"ch":1,"val":9,"src":"0a1b2c3d"}"#).unwrap();
+        assert_eq!(stamped.src(), Some("0a1b2c3d"));
+        let unstamped: ctl::Frame = serde_json::from_str(r#"{"v":1,"ch":1,"val":9}"#).unwrap();
+        assert_eq!(unstamped.src(), None);
 
         // A future shape that matches neither kind fails to parse — readers
         // treat that exactly like an unknown version: log + drop.


### PR DESCRIPTION
## Summary

Phase 2 of the remote-control channel: the peer listener/applier. The nudge listener becomes the full user channel — one MQTT-over-WSS connection per signed-in device now carries both traffic kinds, routed by topic:

- **Subscribe both, route by topic**: the opaque nudge topic keeps its exact contract (any frame → coalesced pull); `lux/ctl/user/<sub>/…` payloads are parsed. Routing and frame gating are plain functions over plain types with their own unit tests — no Tauri in the decision core.
- **Apply gating**: a ctl frame applies only when its version is known, it isn't this connection's own publish echoed back (`src` == own session — frames gain an optional `src` field on the wire for exactly this), and it addresses the *active* setup. Applying runs the same `LuxBuffer` paths as local input, so overlay semantics, `BufferSet` emission, persistence, and render behavior are identical to a local write — and a remotely-applied frame can never re-publish (publish will live at the command layer in the next phase; apply lives at the buffer layer).
- **Presence lifecycle**: each connection publishes a retained presence card (`session`, active `setupId`, device name via `gethostname`); the Last Will clears it on ungraceful drops, sign-out clears it explicitly before disconnecting, and an active-setup switch republishes it without reconnecting (hooked at `cmd::activate`, covering both manual switches and delete-reassignment).
- **State echo**: the buffer commit path now refreshes a retained echo of the full applied buffer on the active setup's `state` topic, trailing-edge coalesced to 5 Hz — so remote surfaces reflect truth including changes made locally at this device. No-op while signed out or disconnected; the echo is retained-topic-only and never fed back into the buffer.

Signed-out behavior is untouched: no connection, no publishes, all new paths no-op.

## Test plan

- [x] `cargo test -p lux -p lux-wire --locked` — routing/gating suite, updated wire goldens, bindings drift guard (IPC surface unchanged)
- [x] `cargo clippy -p lux -p lux-wire --locked -- -D warnings`
- [ ] PR gate: full workspace suite
- [ ] Runtime (dev stack, before the Phase 3 UI ships): `aws iot-data publish` a channel frame → light changes; verify the empty-payload retained Last Will deletes the presence card, and that retained cards arrive on wildcard subscribes