### PR TITLE
feat(remote): publish local control to the user channel

### DIFF
--- a/apps/desktop/src-tauri/src/buffer.rs
+++ b/apps/desktop/src-tauri/src/buffer.rs
@@ -111,6 +111,24 @@ impl LuxBuffer {
     }
 }
 
+/// Overwrite the live buffer with an applier's echoed truth (a remote state
+/// echo, full-universe) and reflect it in the UI + persistence **without**
+/// rendering, publishing, or re-echoing. Remote state must never re-enter the
+/// output or publish paths — that asymmetry is what makes echo loops between
+/// devices impossible by construction.
+pub fn reflect_remote_state<R: Runtime>(app: &tauri::AppHandle<R>, incoming: &[u8]) {
+    let snapshot = {
+        let state = app.state::<LuxBuffer>();
+        let mut guard = state.buffer.lock_or_recover();
+        *guard = normalize(incoming);
+        guard.clone()
+    };
+    if let Err(e) = emit_buffer(snapshot, app) {
+        log::warn!("could not reflect remote state to the UI: {e}");
+    }
+    schedule_persist(app);
+}
+
 // --- persistence (app_config_dir/buffer.json) --------------------------------
 
 /// Restore the last-rendered universe from disk, so a restart brings the light

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -6,6 +6,7 @@ use crate::{
     channels::LuxChannels,
     devices::{self, DmxDeviceInfo, DmxOutput},
     fixture::{self, ChannelDef, Fixture, FixturePreset},
+    nudge::RemotePeer,
     settings::{SliderOrientation, UserSettings},
     setup::{self, LuxSetups, SetupSummary},
     sync::*,
@@ -112,6 +113,10 @@ pub trait CmdMethods {
     // window focus so remote edits land without waiting for a restart).
     fn sync_status(&self, app_handle: AppHandle) -> Result<crate::cloud::SyncState, String>;
     fn sync_now(&self, app_handle: AppHandle) -> Result<(), String>;
+    // Remote control — the user's other live devices, learned from presence
+    // cards on the user channel. Backend-driven, so the UI polls it (events
+    // don't reliably reach the webview on iOS).
+    fn list_remote_peers(&self, app_handle: AppHandle) -> Result<Vec<RemotePeer>, String>;
     // DMX output — the in-app device picker (the only output selector on mobile,
     // where there's no tray). Mirrors the desktop tray's device menu.
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String>;
@@ -156,7 +161,12 @@ impl CmdMethods for CmdEndpoint {
     fn set_buffer(&self, app_handle: AppHandle, buffer: Buffer) -> Result<LuxBuffer, String> {
         log::trace!("received buffer {:?}", buffer);
         let mut state = app_handle.state::<LuxBuffer>().inner().clone();
-        state.set(buffer, app_handle.clone())
+        let outgoing = buffer.clone();
+        let result = state.set(buffer, app_handle.clone())?;
+        // User input also drives the rig remotely. Publishing lives here at
+        // the command layer only — apply paths never publish (loop guard).
+        crate::nudge::publish_input_overlay(&app_handle, outgoing);
+        Ok(result)
     }
     fn update_channel_value(
         &self,
@@ -166,7 +176,12 @@ impl CmdMethods for CmdEndpoint {
     ) -> Result<LuxBuffer, String> {
         log::debug!("received channel {} to {}", channel_number, value);
         let mut state = app_handle.state::<LuxBuffer>().inner().clone();
-        state.set_channel(channel_number as usize, value, app_handle.clone())
+        let result = state.set_channel(channel_number as usize, value, app_handle.clone())?;
+        // set_channel validated the range, so the narrowing always fits.
+        if let Ok(ch) = u16::try_from(channel_number) {
+            crate::nudge::publish_input_channel(&app_handle, ch, value);
+        }
+        Ok(result)
     }
     fn insert_channel(
         &self,
@@ -409,6 +424,10 @@ impl CmdMethods for CmdEndpoint {
     fn sync_now(&self, app_handle: AppHandle) -> Result<(), String> {
         crate::cloud::schedule_sync(&app_handle);
         Ok(())
+    }
+
+    fn list_remote_peers(&self, app_handle: AppHandle) -> Result<Vec<RemotePeer>, String> {
+        Ok(app_handle.state::<crate::nudge::LuxNudge>().remote_peers())
     }
 
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String> {

--- a/apps/desktop/src-tauri/src/nudge.rs
+++ b/apps/desktop/src-tauri/src/nudge.rs
@@ -30,6 +30,7 @@
 //! name is protocol, not environment (`lux_wire::nudge::AUTHORIZER_NAME`). Runs
 //! while signed in; [`stop`] on sign-out.
 
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
@@ -52,6 +53,11 @@ use crate::setup::LuxSetups;
 /// remote surface needs truth, not every intermediate slider position.
 const ECHO_WINDOW: Duration = Duration::from_millis(200);
 
+/// Trailing-edge coalescing window for outgoing ctl frames (~25 Hz) — a fader
+/// drag calls the input commands far faster than the wire needs; the outbox
+/// keeps the latest value per touched slot and the flush publishes one batch.
+const PUBLISH_WINDOW: Duration = Duration::from_millis(40);
+
 fn nudge_endpoint() -> Option<String> {
     Some(crate::endpoints::effective().nudge_endpoint.clone()).filter(|e| !e.is_empty())
 }
@@ -68,6 +74,12 @@ pub struct LuxNudge {
     presence: watch::Sender<u64>,
     echo: Mutex<Option<EchoHandle>>,
     echo_pending: AtomicBool,
+    /// Presence cards from the user's *other* connections, keyed by session —
+    /// the UI polls these through `list_remote_peers`.
+    peers: Mutex<HashMap<String, lux_wire::ctl::PresenceCard>>,
+    /// Outgoing ctl writes accumulated between flushes (see [`PUBLISH_WINDOW`]).
+    outbox: Mutex<Outbox>,
+    publish_pending: AtomicBool,
 }
 
 impl Default for LuxNudge {
@@ -77,6 +89,9 @@ impl Default for LuxNudge {
             presence: watch::channel(0).0,
             echo: Mutex::new(None),
             echo_pending: AtomicBool::new(false),
+            peers: Mutex::new(HashMap::new()),
+            outbox: Mutex::new(Outbox::default()),
+            publish_pending: AtomicBool::new(false),
         }
     }
 }
@@ -93,6 +108,90 @@ impl LuxNudge {
         if echo.as_ref().is_some_and(|e| e.session == session) {
             *echo = None;
         }
+    }
+
+    fn upsert_peer(&self, session: &str, card: lux_wire::ctl::PresenceCard) {
+        self.peers
+            .lock_or_recover()
+            .insert(session.to_owned(), card);
+    }
+
+    fn remove_peer(&self, session: &str) {
+        self.peers.lock_or_recover().remove(session);
+    }
+
+    /// Forget every peer — the connection dropped, so the retained cards will
+    /// be redelivered (and re-learned) on the next subscribe.
+    fn clear_peers(&self) {
+        self.peers.lock_or_recover().clear();
+    }
+
+    /// The user's other live connections, stable-ordered for the UI poll.
+    pub fn remote_peers(&self) -> Vec<RemotePeer> {
+        let mut peers: Vec<RemotePeer> = self
+            .peers
+            .lock_or_recover()
+            .values()
+            .map(|card| RemotePeer {
+                session: card.session.clone(),
+                setup_id: card.setup_id.clone(),
+                name: card.name.clone(),
+            })
+            .collect();
+        peers.sort_by(|a, b| a.session.cmp(&b.session));
+        peers
+    }
+}
+
+/// One of the user's other signed-in devices, as the UI sees it (a thinned
+/// [`lux_wire::ctl::PresenceCard`]). A peer whose `setup_id` matches the
+/// active setup is an applier for it: touches here apply there.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct RemotePeer {
+    pub session: String,
+    pub setup_id: String,
+    pub name: String,
+}
+
+/// Outgoing ctl writes coalesced between flushes: latest value per touched
+/// slot, plus at most one merged overlay. Drain order (overlay first, then
+/// channels) matches local chronology — an overlay clears the pending channel
+/// writes it covers, and later channel writes land after it at the applier.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Outbox {
+    overlay: Option<Vec<u8>>,
+    channels: BTreeMap<u16, u8>,
+}
+
+impl Outbox {
+    fn push_overlay(&mut self, bytes: Vec<u8>) {
+        // The overlay supersedes any pending channel writes inside its range.
+        self.channels.retain(|ch, _| usize::from(*ch) > bytes.len());
+        match &mut self.overlay {
+            // A shorter overlay after a longer one only rewrites its prefix.
+            Some(pending) if pending.len() > bytes.len() => {
+                pending[..bytes.len()].copy_from_slice(&bytes);
+            }
+            slot => *slot = Some(bytes),
+        }
+    }
+
+    fn push_channel(&mut self, ch: u16, val: u8) {
+        self.channels.insert(ch, val);
+    }
+
+    /// Everything pending as publishable frames, in apply order, leaving the
+    /// outbox empty.
+    fn drain(&mut self) -> Vec<lux_wire::ctl::Frame> {
+        let mut frames = Vec::with_capacity(1 + self.channels.len());
+        if let Some(bytes) = self.overlay.take() {
+            frames.push(lux_wire::ctl::Frame::buffer(bytes));
+        }
+        for (ch, val) in std::mem::take(&mut self.channels) {
+            frames.push(lux_wire::ctl::Frame::channel(ch, val));
+        }
+        frames
     }
 }
 
@@ -219,6 +318,69 @@ pub fn schedule_state_echo<R: Runtime>(app: &AppHandle<R>) {
     });
 }
 
+/// Queue a locally-entered overlay write (the color-picker path) for remote
+/// publish. Called from the command layer only — never from an apply path —
+/// which is the structural loop guard: remotely-applied frames re-enter the
+/// buffer, not the outbox. Fast no-op when the user channel is down.
+pub fn publish_input_overlay<R: Runtime>(app: &AppHandle<R>, bytes: Vec<u8>) {
+    let state = app.state::<LuxNudge>();
+    if state.echo.lock_or_recover().is_none() {
+        return;
+    }
+    state.outbox.lock_or_recover().push_overlay(bytes);
+    schedule_publish(app);
+}
+
+/// Queue a locally-entered single-slot write (the fader path) for remote
+/// publish. Same command-layer-only contract as [`publish_input_overlay`].
+pub fn publish_input_channel<R: Runtime>(app: &AppHandle<R>, ch: u16, val: u8) {
+    let state = app.state::<LuxNudge>();
+    if state.echo.lock_or_recover().is_none() {
+        return;
+    }
+    state.outbox.lock_or_recover().push_channel(ch, val);
+    schedule_publish(app);
+}
+
+/// Trailing-edge flush of the outbox onto the wire: frames are addressed to
+/// the setup active at flush time, stamped with the connection's session id
+/// (so our own subscription echo is dropped by the gate), and published in
+/// apply order on the one connection, which preserves ordering end to end.
+fn schedule_publish<R: Runtime>(app: &AppHandle<R>) {
+    let state = app.state::<LuxNudge>();
+    if state.publish_pending.swap(true, Ordering::SeqCst) {
+        return; // a flush is already queued and will pick these writes up
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(PUBLISH_WINDOW).await;
+        let state = app.state::<LuxNudge>();
+        state.publish_pending.store(false, Ordering::SeqCst);
+        let Some(echo) = state.echo.lock_or_recover().clone() else {
+            // Connection died inside the window; drop the batch — the retained
+            // state echo re-synchronizes everyone once a connection returns.
+            state.outbox.lock_or_recover().drain();
+            return;
+        };
+        let frames = state.outbox.lock_or_recover().drain();
+        let setup_id = app.state::<LuxSetups>().active_id().to_string();
+        let topic = lux_wire::ctl::frame_topic(&echo.sub, &setup_id);
+        for frame in frames {
+            let Ok(payload) = serde_json::to_vec(&frame.with_src(&echo.session)) else {
+                continue;
+            };
+            if let Err(e) = echo
+                .client
+                .publish(topic.clone(), QoS::AtMostOnce, false, payload)
+                .await
+            {
+                log::debug!("ctl publish failed (connection likely down): {e}");
+                return;
+            }
+        }
+    });
+}
+
 /// One connection lifetime: connect, subscribe (nudge + ctl), announce
 /// presence, then route incoming traffic until the connection drops or the
 /// listener is superseded. Returns whether the failure looked auth-shaped
@@ -298,6 +460,7 @@ async fn run_connection(
                     .await;
                 let _ = client.disconnect().await;
                 state.clear_echo(&session);
+                state.clear_peers();
                 return false; // superseded — the outer loop exits
             }
             _ = presence_rx.changed() => {
@@ -328,7 +491,13 @@ async fn run_connection(
                         Route::Frame { setup_id } => {
                             apply_frame(app, &publish.payload, setup_id, &session);
                         }
-                        Route::Passive => {}
+                        Route::State { setup_id } => {
+                            reflect_state(app, &publish.payload, setup_id, &session);
+                        }
+                        Route::Presence { session: card_session } => {
+                            update_presence(app, &publish.payload, card_session, &session);
+                        }
+                        Route::Config => {}
                         Route::Unknown => {
                             log::debug!("ignoring publish on unexpected topic {}", publish.topic);
                         }
@@ -338,6 +507,7 @@ async fn run_connection(
                 Err(e) => {
                     log::info!("nudge connection error (will reconnect): {e}");
                     state.clear_echo(&session);
+                    state.clear_peers();
                     return matches!(e, ConnectionError::ConnectionRefused(_));
                 }
             }
@@ -361,6 +531,64 @@ async fn publish_presence(client: &AsyncClient, app: &AppHandle, sub: &str, sess
 /// This device's human-readable name for presence cards.
 fn device_name() -> String {
     gethostname::gethostname().to_string_lossy().into_owned()
+}
+
+/// Reflect an applier's state echo: overwrite the live buffer and update the
+/// UI/persistence **without rendering, publishing, or re-echoing** — remote
+/// state must never re-enter the output or publish paths, which is what makes
+/// two devices echoing at each other impossible by construction.
+fn reflect_state(app: &AppHandle, payload: &[u8], frame_setup: &str, own_session: &str) {
+    let frame: lux_wire::ctl::Frame = match serde_json::from_slice(payload) {
+        Ok(frame) => frame,
+        Err(e) => {
+            log::warn!("ignoring unreadable state echo: {e}");
+            return;
+        }
+    };
+    if frame.version() != lux_wire::ctl::VERSION {
+        log::debug!(
+            "dropping state echo with unknown version {}",
+            frame.version()
+        );
+        return;
+    }
+    if frame.src() == Some(own_session) {
+        return; // our own echo delivered back
+    }
+    if frame_setup != app.state::<LuxSetups>().active_id().to_string() {
+        return;
+    }
+    let lux_wire::ctl::Frame::Buffer { buffer, .. } = frame else {
+        log::debug!("state echo carried a non-buffer frame; ignoring");
+        return;
+    };
+    crate::buffer::reflect_remote_state(app, &buffer);
+}
+
+/// Track a peer's retained presence card (empty payload = the peer is gone).
+/// Our own card comes back through the wildcard subscription too — skipped, so
+/// the peers list is always "the user's *other* devices".
+fn update_presence(app: &AppHandle, payload: &[u8], card_session: &str, own_session: &str) {
+    if card_session == own_session {
+        return;
+    }
+    let state = app.state::<LuxNudge>();
+    if payload.is_empty() {
+        state.remove_peer(card_session);
+        return;
+    }
+    let card: lux_wire::ctl::PresenceCard = match serde_json::from_slice(payload) {
+        Ok(card) => card,
+        Err(e) => {
+            log::warn!("ignoring unreadable presence card: {e}");
+            return;
+        }
+    };
+    if card.v != lux_wire::ctl::VERSION {
+        log::debug!("dropping presence card with unknown version {}", card.v);
+        return;
+    }
+    state.upsert_peer(card_session, card);
 }
 
 /// Parse a ctl frame and, if the gate lets it through, run it down the same
@@ -397,10 +625,13 @@ enum Route<'t> {
     Nudge,
     /// A live ctl frame addressed to one setup.
     Frame { setup_id: &'t str },
-    /// Retained ctl traffic (presence cards, state echoes, reserved config) —
-    /// published by peers including this device; nothing for the listener to
-    /// do with it today.
-    Passive,
+    /// An applier's retained state echo for one setup — reflected into the UI,
+    /// never applied (see [`crate::buffer::reflect_remote_state`]).
+    State { setup_id: &'t str },
+    /// A peer's retained presence card (empty payload = the peer is gone).
+    Presence { session: &'t str },
+    /// Reserved render-node config traffic; nothing consumes it yet.
+    Config,
     /// Not a topic this listener expects under the granted policy.
     Unknown,
 }
@@ -421,12 +652,13 @@ fn route<'t>(topic: &'t str, sub: &str) -> Route<'t> {
     if let Some(setup_rest) = rest.strip_prefix("setup/") {
         return match setup_rest.split_once('/') {
             Some((setup_id, "frame")) => Route::Frame { setup_id },
-            Some((_, "state" | "config")) => Route::Passive,
+            Some((setup_id, "state")) => Route::State { setup_id },
+            Some((_, "config")) => Route::Config,
             _ => Route::Unknown,
         };
     }
-    if rest.strip_prefix("presence/").is_some() {
-        return Route::Passive;
+    if let Some(session) = rest.strip_prefix("presence/") {
+        return Route::Presence { session };
     }
     Route::Unknown
 }
@@ -510,15 +742,17 @@ mod tests {
         );
         assert_eq!(
             route("lux/ctl/user/abc-123/setup/s-1/state", sub),
-            Route::Passive
+            Route::State { setup_id: "s-1" }
         );
         assert_eq!(
             route("lux/ctl/user/abc-123/setup/s-1/config", sub),
-            Route::Passive
+            Route::Config
         );
         assert_eq!(
             route("lux/ctl/user/abc-123/presence/0a1b2c3d", sub),
-            Route::Passive
+            Route::Presence {
+                session: "0a1b2c3d"
+            }
         );
 
         // Not ours / not a shape we know.
@@ -534,6 +768,50 @@ mod tests {
         assert_eq!(route("lux/ctl/user/abc-123/setup/s-1", sub), Route::Unknown);
         assert_eq!(route("lux/ctl/user/abc-123", sub), Route::Unknown);
         assert_eq!(route("lux/1/buffer/set", sub), Route::Unknown);
+    }
+
+    #[test]
+    fn outbox_coalesces_channels_to_latest_value() {
+        let mut outbox = Outbox::default();
+        outbox.push_channel(10, 1);
+        outbox.push_channel(10, 2);
+        outbox.push_channel(3, 9);
+        assert_eq!(
+            outbox.drain(),
+            vec![Frame::channel(3, 9), Frame::channel(10, 2)]
+        );
+        assert_eq!(outbox.drain(), vec![]); // drained empty
+    }
+
+    #[test]
+    fn outbox_overlay_supersedes_covered_channels_and_drains_first() {
+        let mut outbox = Outbox::default();
+        outbox.push_channel(2, 7); // inside the overlay range — superseded
+        outbox.push_channel(100, 42); // outside — survives
+        outbox.push_overlay(vec![1, 2, 3, 4, 5, 6]);
+        outbox.push_channel(2, 8); // after the overlay — applies after it
+        assert_eq!(
+            outbox.drain(),
+            vec![
+                Frame::buffer(vec![1, 2, 3, 4, 5, 6]),
+                Frame::channel(2, 8),
+                Frame::channel(100, 42),
+            ]
+        );
+    }
+
+    #[test]
+    fn outbox_merges_a_shorter_overlay_onto_a_longer_pending_one() {
+        let mut outbox = Outbox::default();
+        outbox.push_overlay(vec![9, 9, 9, 9]);
+        outbox.push_overlay(vec![1, 2]);
+        assert_eq!(outbox.drain(), vec![Frame::buffer(vec![1, 2, 9, 9])]);
+
+        // A longer (or equal) overlay simply replaces the pending one.
+        let mut outbox = Outbox::default();
+        outbox.push_overlay(vec![1, 2]);
+        outbox.push_overlay(vec![5, 5, 5]);
+        assert_eq!(outbox.drain(), vec![Frame::buffer(vec![5, 5, 5])]);
     }
 
     #[test]

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -145,6 +145,11 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  list_remote_peers(): Promise<RemotePeer[]> {
+    return invoke("cmd.list_remote_peers");
+  },
+
+  /** @throws {string} */
   list_dmx_devices(): Promise<DmxDeviceInfo[]> {
     return invoke("cmd.list_dmx_devices");
   },
@@ -274,6 +279,17 @@ export type LuxChannels = {
 export type LuxLabelColor = "Red" | "Green" | "Blue" | "Amber" | "White" | "Brightness" | 
 /**  Raw universe channels (7..=512) with no fixed colour role. */
 "Generic";
+
+/**
+ *  One of the user's other signed-in devices, as the UI sees it (a thinned
+ *  [`lux_wire::ctl::PresenceCard`]). A peer whose `setup_id` matches the
+ *  active setup is an applier for it: touches here apply there.
+ */
+export type RemotePeer = {
+	session: string,
+	setupId: string,
+	name: string,
+};
 
 /**
  *  A lightweight setup descriptor for the switcher UI — no fixtures, so listing

--- a/apps/desktop/src/components/remote-indicator.tsx
+++ b/apps/desktop/src/components/remote-indicator.tsx
@@ -1,0 +1,40 @@
+import { useRef } from "react";
+import { Radio } from "lucide-react";
+import useAuth from "@/hooks/useAuth";
+import useRemotePeers from "@/hooks/useRemotePeers";
+import useSetups from "@/hooks/useSetups";
+
+/**
+ * Live-rig indicator for the nav, shown only when signed in and another of the
+ * user's devices has this setup active — meaning touches here apply there.
+ * Brief absences are held for 5s before the indicator disappears, so the user
+ * channel's hourly re-auth reconnect never visibly flickers it.
+ */
+export default function RemoteIndicator() {
+  const auth = useAuth();
+  const peers = useRemotePeers();
+  const setups = useSetups();
+  const lastLive = useRef<{ name: string; at: number } | null>(null);
+
+  if (!auth?.signedIn) return null;
+
+  const active = setups?.find((s) => s.active);
+  const live = active ? peers?.find((p) => p.setupId === active.id) : undefined;
+  if (live) lastLive.current = { name: live.name, at: Date.now() };
+  const held =
+    !live && lastLive.current && Date.now() - lastLive.current.at < 5000
+      ? lastLive.current
+      : null;
+  const shown = live?.name ?? held?.name;
+  if (!shown) return null;
+
+  return (
+    <span
+      title={`Live — control also applies at ${shown}`}
+      className="flex items-center gap-1.5 text-emerald-600 dark:text-emerald-500"
+    >
+      <Radio className="size-4" aria-label="Remote rig live" />
+      <span className="hidden text-xs font-medium sm:inline">{shown}</span>
+    </span>
+  );
+}

--- a/apps/desktop/src/hooks/useRemotePeers.ts
+++ b/apps/desktop/src/hooks/useRemotePeers.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { createTauRPCProxy, type RemotePeer } from "@/bindings";
+
+/** Query key for the user's other live devices on the user channel. */
+export const REMOTE_PEERS_QUERY_KEY = ["remotePeers"] as const;
+
+/**
+ * The user's other signed-in devices, learned from their retained presence
+ * cards on the user channel. `null` until the first read.
+ *
+ * Backend-driven (cards arrive over MQTT, not from UI mutations), so this
+ * polls like `useSyncStatus` — `list_remote_peers` is a cheap in-memory read,
+ * and events don't reliably reach the webview on iOS.
+ */
+export default function useRemotePeers(): RemotePeer[] | null {
+  const { data } = useQuery({
+    queryKey: REMOTE_PEERS_QUERY_KEY,
+    queryFn: () => createTauRPCProxy().cmd.list_remote_peers(),
+    refetchInterval: 2000,
+  });
+  return data ?? null;
+}

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import SetupSwitcher from "@/components/setup-switcher";
 import AccountMenu from "@/components/account-menu";
 import SettingsMenu from "@/components/settings-menu";
 import SyncIndicator from "@/components/sync-indicator";
+import RemoteIndicator from "@/components/remote-indicator";
 import useSyncOnFocus from "@/hooks/useSyncOnFocus";
 
 export const Route = createRootRoute({
@@ -29,6 +30,7 @@ function RootLayout() {
             Universe
           </Link>
           <div className="ml-auto flex items-center gap-3">
+            <RemoteIndicator />
             <SyncIndicator />
             <SettingsMenu />
             <AccountMenu />


### PR DESCRIPTION
## Summary

Phase 3 of the remote-control channel: the remote surface. With this, a signed-in device anywhere drives the rig at home end to end — local input publishes, the peer with the setup active applies, and truth flows back.

- **Command-layer publish + throttle**: `set_buffer` / `update_channel_value` queue their writes into a coalescing outbox — latest value per touched slot, overlays merged (a shorter overlay rewrites only its prefix; an overlay supersedes the pending channel writes it covers), drained in local-chronology order and flushed at ~25 Hz trailing-edge to the active setup's frame topic, stamped with the connection's session id. Publishing exists only at the command layer; apply paths never publish (the structural loop guard).
- **Presence surfacing**: incoming presence cards are tracked per session (own card excluded, cleared on disconnect) and exposed via a new polled `list_remote_peers` command — polling rather than an event because events don't reliably reach the webview on iOS. The nav gains a live-rig indicator shown when another of the user's devices has the active setup open, held ~5s through the channel's hourly re-auth reconnect so it never visibly flickers.
- **State reflection**: incoming state echoes for the active setup overwrite the live buffer, update the UI, and persist — but never render, publish, or re-echo (`buffer::reflect_remote_state`). That asymmetry makes cross-device echo loops impossible by construction, and a freshly opened app reflects the rig's retained truth immediately.
- Bindings regenerated (`RemotePeer` + `list_remote_peers`); drift guard green.

Signed-out behavior is unchanged: every new path fast-no-ops without a live user channel.

## Test plan

- [x] `cargo test -p lux --locked` — outbox coalescing/ordering suite, route/gate updates, bindings drift guard
- [x] `cargo clippy -p lux --locked -- -D warnings`
- [x] `bun run build` + `bun run lint`
- [ ] PR gate: full workspace suite
- [ ] Rig verification (two signed-in devices, one with hardware): remote color pick + fader drag apply at the rig; local desk changes appear on the remote surface; presence indicator truthful through quit, crash, and the hourly reconnect; retained-LWT clear and retained-on-wildcard delivery confirmed on AWS IoT