### PR TITLE
feat(ios): associated domains for password autofill

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -50,6 +50,13 @@ jobs:
             --exclude "*" --include "*.html" \
             --cache-control "no-cache" \
             --content-type "text/html; charset=utf-8"
+          # The AASA file is extensionless, so the sync's mime guess would call
+          # it octet-stream and cache it for a week — Apple's CDN wants
+          # application/json and prompt refresh on change.
+          aws s3 cp apps/site/dist/.well-known/apple-app-site-association \
+            "s3://lux-johncarmack-com/.well-known/apple-app-site-association" \
+            --cache-control "no-cache" \
+            --content-type "application/json"
 
       - name: Invalidate CloudFront
         run: |

--- a/apps/desktop/src-tauri/gen/apple/lux_iOS/lux_iOS.entitlements
+++ b/apps/desktop/src-tauri/gen/apple/lux_iOS/lux_iOS.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.developer.networking.multicast</key>
 	<true/>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:lux.johncarmack.com</string>
+	</array>
 </dict>
 </plist>

--- a/apps/site/public/.well-known/apple-app-site-association
+++ b/apps/site/public/.well-known/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+  "webcredentials": {
+    "apps": ["T3UN6N5K6Z.com.johncarmack.lux"]
+  }
+}


### PR DESCRIPTION
## Summary

Wires the two app-side legs of Associated Domains for `lux.johncarmack.com` so iOS Password AutoFill can offer the domain's saved credentials in the app's sign-in form:

- `lux_iOS.entitlements` claims `com.apple.developer.associated-domains` with `webcredentials:lux.johncarmack.com`.
- The site serves `/.well-known/apple-app-site-association` listing `T3UN6N5K6Z.com.johncarmack.lux` (Vite copies `public/.well-known` into `dist` verbatim — verified in a local build).
- `site.yml` uploads the AASA explicitly with `application/json` + `no-cache`: the file is extensionless, so the existing sync's mime guess would serve it as octet-stream with a week-long cache, and Apple's CDN wants JSON and prompt refresh.

Prerequisite ordering: the Associated Domains capability must be enabled on the App ID **before** the next iOS build is signed — an app claiming an entitlement its profile lacks fails signing. Capability first, then this; profiles regenerate automatically on the next ASC-API-signed build.

## Test plan

- [x] Site builds; `dist/.well-known/apple-app-site-association` present with the expected JSON
- [ ] PR gate (`site` job builds the site)
- [ ] After the next site deploy: `curl -i https://lux.johncarmack.com/.well-known/apple-app-site-association` returns 200 `application/json`
- [ ] First TestFlight build after the capability change installs and AutoFill offers the domain credential in the sign-in form (Apple's CDN can take up to ~24h to pick up a new AASA; a fresh app install re-evaluates the association)