### PR TITLE
fix(ios): keep the stored session readable at locked launch

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -37,6 +37,12 @@ aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
 webpki-root-certs = "1"
 pem = "3"
 keyring = "4"
+# keyring's backing crate, named directly on every platform: session entries are
+# built through keyring-core types (on iOS with an access-policy modifier, see
+# account::keyring_entry), and account::init_keychain registers the
+# data-protection store with it at startup — keyring's own auto-registration
+# skips iOS. Cargo unifies this onto the same instance keyring uses.
+keyring-core = "1"
 log = "^0.4.33"
 serde_json.workspace = true
 serde.workspace = true
@@ -93,10 +99,6 @@ tauri-plugin-updater = "2"
 # feature — Cargo unifies it onto the same instance keyring uses.
 [target.'cfg(target_os = "ios")'.dependencies]
 apple-native-keyring-store = { version = "1", features = ["protected"] }
-# Naming keyring's backing crate directly lets us register the data-protection
-# store as the default at startup (see account::init_keychain) — keyring's own
-# auto-registration skips iOS.
-keyring-core = "1"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -269,8 +269,11 @@ pub fn restore_on_startup(app: &AppHandle) {
     let session = state.session.clone();
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        match do_refresh(cfg, stored.refresh_token).await {
+        match do_refresh(cfg, stored.refresh_token.clone()).await {
             Ok(tokens) => {
+                // Re-save so items written by older builds pick up the current
+                // keychain access policy (save recreates the item).
+                save_session(&stored);
                 {
                     let mut s = session.lock_or_recover();
                     s.id_token = Some(tokens.id);
@@ -498,16 +501,39 @@ pub fn init_keychain() {
 #[cfg(not(target_os = "ios"))]
 pub fn init_keychain() {}
 
-fn keyring_entry() -> Result<keyring::Entry, keyring::Error> {
-    keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER)
+/// The stored-session keychain entry. Off iOS this goes through `keyring`'s
+/// v1 wrapper on purpose — its first use lazily registers the platform
+/// credential store (macOS Keychain, Windows Credential Manager, Linux Secret
+/// Service) — and hands back the underlying core entry so every caller works
+/// with one type.
+#[cfg(not(target_os = "ios"))]
+fn keyring_entry() -> keyring_core::Result<keyring_core::Entry> {
+    keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER).map(|entry| entry.inner)
+}
+
+/// iOS: build the entry against the data-protection store registered in
+/// [`init_keychain`], relaxing the item to `after-first-unlock`. The store's
+/// default policy (`when-unlocked`) makes the refresh token unreadable
+/// whenever iOS launches the app while the phone is locked (prewarming), so
+/// the startup restore silently finds nothing and that long-lived process
+/// greets the user signed out. A launch-time credential wants exactly
+/// after-first-unlock accessibility.
+#[cfg(target_os = "ios")]
+fn keyring_entry() -> keyring_core::Result<keyring_core::Entry> {
+    let modifiers = std::collections::HashMap::from([("access-policy", "after-first-unlock")]);
+    keyring_core::Entry::new_with_modifiers(KEYRING_SERVICE, KEYRING_USER, &modifiers)
 }
 
 fn save_session(s: &StoredSession) {
     let result = (|| {
         let json = serde_json::to_string(s).map_err(|e| e.to_string())?;
-        keyring_entry()
-            .and_then(|e| e.set_password(&json))
-            .map_err(|e| e.to_string())
+        let entry = keyring_entry().map_err(|e| e.to_string())?;
+        // Recreate rather than update: updating an existing item keeps its
+        // original accessibility, and items written by older builds carry the
+        // when-unlocked default (see keyring_entry) — delete + set stamps the
+        // current policy on every save.
+        let _ = entry.delete_credential();
+        entry.set_password(&json).map_err(|e| e.to_string())
     })();
     if let Err(e) = result {
         log::warn!("could not save session to keychain: {e}");
@@ -515,8 +541,24 @@ fn save_session(s: &StoredSession) {
 }
 
 fn load_session() -> Option<StoredSession> {
-    let json = keyring_entry().ok()?.get_password().ok()?;
-    serde_json::from_str(&json).ok()
+    let entry = match keyring_entry() {
+        Ok(entry) => entry,
+        Err(e) => {
+            log::warn!("keychain unavailable ({e}); cannot restore a session");
+            return None;
+        }
+    };
+    match entry.get_password() {
+        Ok(json) => serde_json::from_str(&json)
+            .inspect_err(|e| log::warn!("stored session unreadable ({e}); ignoring it"))
+            .ok(),
+        // First run or signed out — the normal quiet path.
+        Err(keyring_core::Error::NoEntry) => None,
+        Err(e) => {
+            log::warn!("could not read the stored session ({e}); starting signed out");
+            None
+        }
+    }
 }
 
 fn clear_session() {


### PR DESCRIPTION
## Summary

iOS "forgets" the signed-in session even though the refresh token is persisted to the keychain. Two findings from a simulator investigation:

- **Historical**: sim logs from the June bring-up show successful sign-ins whose keychain save failed with `No default store has been set` — the pre-#112 era never persisted a session on iOS at all. #112 fixed registration and is in v1.1.0.
- **Live suspect on v1.1.0**: the protected store writes items with `when-unlocked` accessibility by default, but iOS prewarms app processes while the phone is locked. A prewarmed launch reads a locked keychain, finds nothing, and — because the load path swallowed every error — the long-lived process greets the user signed out with zero breadcrumbs.

Changes:

- iOS session entries are built with `access-policy: after-first-unlock` — Apple's intended accessibility for launch-time credentials (readable from first unlock after boot onward, prewarm included).
- `save_session` deletes + recreates the item instead of updating it: updates keep an item's original accessibility, so entries written by older builds would never migrate. A successful restore also re-saves, upgrading existing installs on their first good launch.
- `load_session` stops swallowing errors: a genuinely absent entry stays quiet; any other failure logs why the app is starting signed out, so a future regression names itself.
- `keyring-core` becomes an all-platform dependency (entries are built through its types everywhere; off iOS the `keyring` v1 wrapper still performs its lazy store registration and hands back the core entry).

Verified in the iPhone 16 Pro simulator: the store registers, the modifier parses, and the entry is created with `AccessPolicy: AfterFirstUnlock`; a fresh install's read path completes quietly (`NoEntry`).

## Test plan

- [x] `cargo test -p lux --locked`; `cargo clippy -p lux --locked -- -D warnings` on the host and `--target aarch64-apple-ios-sim`
- [x] Sim run: registration + policy + quiet no-session read confirmed in the app log
- [ ] PR gate: full workspace suite
- [ ] On device (next TestFlight build): sign in once, then confirm the session survives relaunches — including first launch of a day (the prewarm case); if it ever forgets again, the log now says why