### PR TITLE
fix(account): key credential autofill off the username token

### DIFF
--- a/apps/desktop/src/components/account-menu.tsx
+++ b/apps/desktop/src/components/account-menu.tsx
@@ -217,7 +217,10 @@ export default function AccountMenu() {
             <Input
               id="account-email"
               type="email"
-              autoComplete="email"
+              // `username`, not `email`: credential autofill (iCloud Keychain,
+              // password managers) keys the saved login off the username +
+              // current-password pair; `email` is the contact-info token.
+              autoComplete="username"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required


### PR DESCRIPTION
## Summary

One-attribute fix completing the AutoFill work: the sign-in email field advertised `autoComplete="email"` (the contact-info token), but credential autofill — iCloud Keychain, password managers — pairs a saved login off the **`username`** + `current-password` tokens. The rest of the form was already right (`current-password`/`new-password` by mode, `one-time-code` on the confirm step), so this is the last field-level piece; the domain-association half shipped in #156.

## Test plan

- [x] `bun run build` + `bun run lint`
- [ ] PR gate
- [ ] With the AASA live and the new build installed: tapping the email field offers the saved lux.johncarmack.com credential