### PR TITLE
fix(ui): 44px minimum touch width on vertical faders

### DIFF
--- a/apps/desktop/src/components/ui/slider.tsx
+++ b/apps/desktop/src/components/ui/slider.tsx
@@ -10,7 +10,12 @@ const Slider = React.forwardRef<
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
-      "relative flex touch-none select-none items-center data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+      // Vertical faders get a 44px-wide root (the Apple HIG touch minimum):
+      // Radix takes pointer events on the whole root and reads a vertical
+      // slider's value from Y only, so the width is pure hit area — a near
+      // miss grabs the fader instead of falling through to the card surface
+      // (whose click-to-collapse guard also excludes this root via touch-none).
+      "relative flex touch-none select-none items-center data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-11 data-[orientation=vertical]:flex-col",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary

Fat-fingering a vertical fader could toggle the fixture card's collapse: the slider root was `w-auto`, making the 8px track the entire touch target, and misses fell through to the card surface (whose click-to-collapse fires on surface clicks). The root is now `w-11` (44px — the Apple HIG minimum) for vertical orientation only:

- Radix binds pointer events on the root and derives a vertical slider's value from Y alone, so the added width is pure hit area — a near miss now grabs the fader.
- The card's surface-click guard already excludes the slider root (`.touch-none`), so the widened area is also a widened collapse-exclusion zone.
- Visually identical: the 8px track stays centered, and both vertical layouts (fixture strips, 56px; virtualized desk columns, 64px) host the 44px root without shifting. Verified in the iPhone 16 Pro simulator against the v1.2.0 build.

## Test plan

- [x] `bun run build` + `bun run lint`
- [x] Sim visual check: layout unchanged in the fixture card's vertical strip
- [ ] PR gate
- [ ] On device: grabbing beside a fader track drags it instead of collapsing the card