### PR TITLE
fix(ui): collapse the view links into a nav dropdown

### DIFF
--- a/apps/desktop/src/components/view-menu.tsx
+++ b/apps/desktop/src/components/view-menu.tsx
@@ -1,0 +1,55 @@
+import { Link, useLocation } from "@tanstack/react-router";
+import {
+  Check,
+  ChevronsUpDown,
+  Lightbulb,
+  SlidersVertical,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+const VIEWS = [
+  { to: "/", label: "Fixtures", icon: Lightbulb },
+  { to: "/universe", label: "Universe", icon: SlidersVertical },
+] as const;
+
+/**
+ * The nav's view picker: which control surface is showing — Fixtures (the
+ * patched cards) or Universe (the raw 512-fader desk). One dropdown instead of
+ * two nav links keeps the bar breathing at phone widths.
+ */
+export default function ViewMenu() {
+  const pathname = useLocation({ select: (location) => location.pathname });
+  const active =
+    VIEWS.find((view) =>
+      view.to === "/" ? pathname === "/" : pathname.startsWith(view.to)
+    ) ?? VIEWS[0];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1.5">
+          <active.icon className="size-3.5" />
+          <span>{active.label}</span>
+          <ChevronsUpDown className="size-3.5 text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {VIEWS.map((view) => (
+          <DropdownMenuItem key={view.to} asChild>
+            <Link to={view.to} className="flex w-full items-center gap-2">
+              <view.icon className="size-4 text-muted-foreground" />
+              {view.label}
+              {view.to === active.to && <Check className="ml-auto size-4" />}
+            </Link>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -1,7 +1,8 @@
-import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
+import { createRootRoute, Outlet } from "@tanstack/react-router";
 import { Toaster } from "@/components/ui/sonner";
 import { Updater } from "@/components/updater";
 import SetupSwitcher from "@/components/setup-switcher";
+import ViewMenu from "@/components/view-menu";
 import AccountMenu from "@/components/account-menu";
 import SettingsMenu from "@/components/settings-menu";
 import SyncIndicator from "@/components/sync-indicator";
@@ -12,9 +13,6 @@ export const Route = createRootRoute({
   component: RootLayout,
 });
 
-const navLink =
-  "text-sm font-medium text-muted-foreground transition-colors hover:text-foreground [&.active]:text-foreground";
-
 function RootLayout() {
   useSyncOnFocus();
   return (
@@ -23,12 +21,7 @@ function RootLayout() {
         <nav className="flex shrink-0 items-center gap-4 border-b border-border/60 px-5 py-3">
           <SetupSwitcher />
           <div className="h-5 w-px bg-border/60" />
-          <Link to="/" activeOptions={{ exact: true }} className={navLink}>
-            Fixtures
-          </Link>
-          <Link to="/universe" className={navLink}>
-            Universe
-          </Link>
+          <ViewMenu />
           <div className="ml-auto flex items-center gap-3">
             <RemoteIndicator />
             <SyncIndicator />


### PR DESCRIPTION
## Summary

The top bar was crowding out at phone widths: setup switcher, two view links, and the right-side cluster. The Fixtures / Universe links become one **View dropdown** in the setup switcher's trigger idiom — active view's icon + name on the trigger, both views (with icons and an active check) in the menu.

## Test plan

- [x] `bun run build` + `bun run lint`
- [ ] PR gate
- [ ] On device: nav fits with the sign-in button visible; switching views from the menu works on both