### PR TITLE
fix(ui): label universe channels from the active patch only

### DIFF
--- a/apps/desktop/src/components/control-grid/grid.tsx
+++ b/apps/desktop/src/components/control-grid/grid.tsx
@@ -1,8 +1,10 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import useLuxState from "@/hooks/useLuxState";
+import useFixtures from "@/hooks/useFixtures";
 import useSettings from "@/hooks/useSettings";
 import { cn } from "@/lib/utils";
+import { patchChannelMeta } from "@/lib/channel-map";
 import DeskRow from "./desk-row";
 import DeskColumn from "./desk-column";
 
@@ -14,8 +16,10 @@ type Channels = ReturnType<typeof useLuxState>;
 
 /**
  * The universe desk: every DMX512 channel as a fader, virtualized so 512 lanes
- * scroll smoothly while only the ~visible handful mount. Channels 1–6 are the
- * labelled RGBAW fixture (also driven by the color picker); 7–512 are raw.
+ * scroll smoothly while only the ~visible handful mount. Channels covered by
+ * the active setup's patch carry that fixture's role color and label; every
+ * other channel is a plain numbered fader — an empty setup is 512 plain
+ * sliders.
  *
  * The "slider orientation" user setting picks the layout: vertical faders in a
  * horizontally-scrolling desk (the default, like a lighting console), or
@@ -25,8 +29,20 @@ type Channels = ReturnType<typeof useLuxState>;
  * launch.
  */
 export default function ControlGrid() {
-  const data = useLuxState();
+  const channels = useLuxState();
+  const fixtures = useFixtures();
   const settings = useSettings();
+
+  // Patch-derived labels only: unpatched channels render blank + neutral.
+  const data = useMemo(() => {
+    const meta = patchChannelMeta(fixtures);
+    return channels.map((channel) => {
+      const patched = meta.get(channel.channelNumber);
+      return patched
+        ? { ...channel, label: patched.label, labelColor: patched.labelColor }
+        : { ...channel, label: "", labelColor: "Generic" as const };
+    });
+  }, [channels, fixtures]);
 
   if (!data.length || settings === null) {
     return (

--- a/apps/desktop/src/lib/channel-map.ts
+++ b/apps/desktop/src/lib/channel-map.ts
@@ -1,0 +1,22 @@
+import type { Fixture, LuxLabelColor } from "@/bindings";
+
+/**
+ * Per-channel display metadata derived from the active setup's patch: a
+ * channel carries a role color and label only when a patched fixture occupies
+ * it. Everything else is a plain numbered fader — an empty setup's universe is
+ * just 512 plain sliders.
+ */
+export function patchChannelMeta(
+  fixtures: Fixture[] | null
+): Map<number, { label: string; labelColor: LuxLabelColor }> {
+  const meta = new Map<number, { label: string; labelColor: LuxLabelColor }>();
+  for (const fixture of fixtures ?? []) {
+    fixture.channels.forEach((channel, i) => {
+      meta.set(fixture.address + i, {
+        label: channel.label,
+        labelColor: channel.role,
+      });
+    });
+  }
+  return meta;
+}


### PR DESCRIPTION
## Summary

The universe desk labelled channels 1–6 Red/Green/Blue/… from hardcoded startup metadata regardless of what's patched. Labels and role colors now derive from the **active setup's patch** (`patchChannelMeta`, address → role/label per fixture channel): a channel shows a label and role color only while a fixture occupies it, everything else is a plain numbered fader, and an empty setup's universe is just 512 plain sliders. Both desk layouts (rows and columns) inherit the change through the shared data path.

## Test plan

- [x] `bun run build` + `bun run lint`
- [ ] PR gate
- [ ] On device: empty setup → no labels anywhere; patch an RGBAW at 10 → labels appear at 10–15 only