### PR TITLE
fix(ui): presets on both views, default preset removed

### DIFF
--- a/apps/desktop/src/components/button-row.tsx
+++ b/apps/desktop/src/components/button-row.tsx
@@ -14,40 +14,20 @@ export function setBuffer(buffer: number[]) {
     .catch((e) => toast.error(String(e)));
 }
 
-// A full 512-channel frame at one level overrides the whole universe; a 6-byte
-// fixture write (Default) only overlays the leading RGBAW slots.
+// A full 512-channel frame at one level overrides the whole universe.
 const universe = (level: number) => Array(512).fill(level);
 
+// The two built-in presets. User-defined presets (saved scenes) are the
+// planned next residents of this row.
 const buttons = [
   {
     children: "⚫️ Blackout",
     onClick: () => setBuffer(universe(0)),
   },
   {
-    children: "✅ Default",
-    onClick: () => setBuffer([121, 255, 255, 0, 0, 42]),
-  },
-  {
     children: "💡 Full Bright",
     onClick: () => setBuffer(universe(255)),
   },
-  // Planned feature
-  // { children: "🌈 RGB Chase",
-  //   onClick: () => invoke("rgb_chase")
-  // },
-  // Debug functions
-  // {
-  //   children: "🔄 Sync",
-  //   onClick: () => invoke("sync_state"),
-  // },
-  // {
-  //   children: "🤘 Get state from Turso",
-  //   onClick: async () => await getInitialState(),
-  // },
-  // {
-  //   children: "🚮 Delete all Channels",
-  //   onClick: () => invoke("delete_channels"),
-  // },
 ];
 
 function ControlButton({
@@ -62,21 +42,16 @@ function ControlButton({
     onClick();
   };
   return (
-    <Button
-      key={children}
-      onClick={handleClick}
-      className=""
-      variant="link"
-      size="sm"
-    >
+    <Button key={children} onClick={handleClick} variant="link" size="sm">
       {children}
     </Button>
   );
 }
 
+/** The preset row, shown on both control surfaces (fixtures + universe). */
 function ButtonRow() {
   return (
-    <div className="grid-cols-1 sm:grid-cols-3 py-8 grid">
+    <div className="flex shrink-0 justify-center gap-2 py-2">
       {buttons.map(ControlButton)}
     </div>
   );

--- a/apps/desktop/src/routes/index.tsx
+++ b/apps/desktop/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
+import ButtonRow from "@/components/button-row";
 import FixturesView from "@/components/fixtures/fixtures-view";
 
 export const Route = createFileRoute("/")({
@@ -6,5 +7,10 @@ export const Route = createFileRoute("/")({
 });
 
 function Home() {
-  return <FixturesView />;
+  return (
+    <div className="flex min-h-0 w-full flex-1 flex-col items-center">
+      <ButtonRow />
+      <FixturesView />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

- The preset row renders on both control surfaces (fixtures + universe) instead of universe-only.
- Built-ins slim to **Blackout** and **Full Bright**; the old ✅ Default was a hardcoded fixture color (`[121,255,255,0,0,42]`) with no claim to being anyone's default.
- The row stays a data-driven list and drops its dead commented experiments — user-defined presets (saved scenes) are its planned next residents.
- Row padding tightens (`py-8` → `py-2`), part one of the universe-height fix (part two, the layout itself, is a follow-up PR).

## Test plan

- [x] `bun run build` + `bun run lint`
- [ ] PR gate
- [ ] On device: Blackout / Full Bright present and working on both views