### PR TITLE
build(store-notes): push drafts with the release App token

### DIFF
--- a/.github/workflows/store-notes.yml
+++ b/.github/workflows/store-notes.yml
@@ -25,8 +25,50 @@ jobs:
       contents: write # push the drafted file to the release PR branch
       id-token: write # AWS OIDC, to read the Anthropic API key
     steps:
+      # Credentials + the release App token come first: the draft commit below
+      # must be pushed with the App token, not GITHUB_TOKEN — a GITHUB_TOKEN
+      # push starts no workflow runs, which left the release branch tip
+      # ungated (and the PR "awaiting approval"). The App-token push triggers
+      # the PR gate normally; the retriggered copy of THIS workflow finds
+      # nothing new to commit and exits, so there is no push loop. Same
+      # pattern (and the same App) as release.yml, gated on the same variable.
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+        with:
+          role-to-assume: arn:aws:iam::735853783919:role/lux-store-notes
+          aws-region: us-west-1
+
+      - name: Load release-bot App private key
+        id: app-key
+        if: ${{ vars.RELEASE_APP_CLIENT_ID != '' }}
+        # Multi-line PEM into $GITHUB_ENV via a heredoc; never echoed, so the
+        # key stays out of the logs. Fail-soft: the role's grant on this secret
+        # ships via terraform apply, so until that lands the step logs and the
+        # push falls back to GITHUB_TOKEN (today's behavior) instead of
+        # failing the draft.
+        run: |
+          if key=$(aws secretsmanager get-secret-value --secret-id lux/release-app-private-key --query SecretString --output text 2>/dev/null); then
+            {
+              echo "RELEASE_APP_PRIVATE_KEY<<__EOF__"
+              printf '%s\n' "$key"
+              echo "__EOF__"
+            } >> "$GITHUB_ENV"
+            echo "loaded=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "app key unreadable (role grant not applied yet?); pushing with GITHUB_TOKEN"
+          fi
+
+      - name: Mint push token (GitHub App)
+        id: app-token
+        if: ${{ vars.RELEASE_APP_CLIENT_ID != '' && steps.app-key.outputs.loaded == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ env.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
           # The real branch (not the merge ref) — the draft is pushed to it.
           ref: ${{ github.head_ref }}
           # Full history: the draft guard and the restore step attribute the
@@ -49,13 +91,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: bun scripts/restore-store-notes.ts
 
-      - name: Configure AWS credentials (OIDC)
-        if: steps.restore.outputs.restored != 'true'
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
-        with:
-          role-to-assume: arn:aws:iam::735853783919:role/lux-store-notes
-          aws-region: us-west-1
-
       - name: Load Anthropic API key
         if: steps.restore.outputs.restored != 'true'
         run: |
@@ -68,7 +103,8 @@ jobs:
         run: bun scripts/draft-store-notes.ts
 
       - name: Commit the draft (if new)
-        # A GITHUB_TOKEN push never retriggers workflows, so no loop.
+        # Pushed with the App token from the checkout above, so the PR gate
+        # runs on the branch tip; the retriggered store-notes run no-ops.
         env:
           BRANCH: ${{ github.head_ref }}
           RESTORED: ${{ steps.restore.outputs.restored }}

--- a/infra/store-notes.tf
+++ b/infra/store-notes.tf
@@ -12,13 +12,10 @@ data "aws_secretsmanager_secret" "anthropic_api_key" {
   name = "lux/anthropic-api-key"
 }
 
-# The release GitHub App's private key (also read by the release workflow's
-# main-pinned role). store-notes pushes its draft commit to the release PR
-# branch with an App token: a default-GITHUB_TOKEN push starts no workflow
-# runs, which left the branch tip ungated and the PR stuck "awaiting approval".
-data "aws_secretsmanager_secret" "release_app_private_key" {
-  name = "lux/release-app-private-key"
-}
+# store-notes pushes its draft commit to the release PR branch with an App
+# token: a default-GITHUB_TOKEN push starts no workflow runs, which left the
+# branch tip ungated and the PR stuck "awaiting approval". The App's private
+# key is the data source release-signing.tf already declares.
 
 resource "aws_iam_role" "store_notes" {
   name = "lux-store-notes"

--- a/infra/store-notes.tf
+++ b/infra/store-notes.tf
@@ -12,6 +12,14 @@ data "aws_secretsmanager_secret" "anthropic_api_key" {
   name = "lux/anthropic-api-key"
 }
 
+# The release GitHub App's private key (also read by the release workflow's
+# main-pinned role). store-notes pushes its draft commit to the release PR
+# branch with an App token: a default-GITHUB_TOKEN push starts no workflow
+# runs, which left the branch tip ungated and the PR stuck "awaiting approval".
+data "aws_secretsmanager_secret" "release_app_private_key" {
+  name = "lux/release-app-private-key"
+}
+
 resource "aws_iam_role" "store_notes" {
   name = "lux-store-notes"
   assume_role_policy = jsonencode({
@@ -48,9 +56,12 @@ resource "aws_iam_role_policy" "read_anthropic_api_key" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect   = "Allow"
-      Action   = "secretsmanager:GetSecretValue"
-      Resource = [data.aws_secretsmanager_secret.anthropic_api_key.arn]
+      Effect = "Allow"
+      Action = "secretsmanager:GetSecretValue"
+      Resource = [
+        data.aws_secretsmanager_secret.anthropic_api_key.arn,
+        data.aws_secretsmanager_secret.release_app_private_key.arn,
+      ]
     }]
   })
 }


### PR DESCRIPTION
## Summary

The `github-actions[bot]` draft commit on release PRs is pushed with the default `GITHUB_TOKEN`, and GitHub deliberately starts no workflow runs for such pushes — so the release branch tip ends up ungated and the PR sits "2 workflows awaiting approval" (as on #162). Same class of problem #84 fixed for release-please itself; same fix:

- store-notes now assumes its OIDC role up front, reads the release App's private key, mints an App token, and checks out with it — the draft push then triggers the PR gate on the branch tip normally. The retriggered store-notes run finds nothing to commit and exits, so there is no push loop. The commit *author* stays `github-actions[bot]`, keeping the restore step's author-attribution guard untouched.
- `infra/store-notes.tf`: the `lux-store-notes` role gains `GetSecretValue` on `lux/release-app-private-key` (the release workflow's main-pinned role can't be assumed from PR context, so the grant lands on the role that already runs there).
- **Fail-soft until the grant applies**: the key load tolerates AccessDenied and falls back to today's `GITHUB_TOKEN` behavior, so nothing breaks between this merge and the next `terraform apply` (the next release, or a manual apply).

For the currently open release PR: approve its stuck workflows manually once; PRs after the grant is applied gate cleanly.

## Test plan

- [x] Terraform plan gate on this PR shows the data source + policy statement addition, nothing else
- [ ] PR gate
- [ ] Next release PR after the grant: draft commit lands and the `desktop` gate runs on the tip without an approval prompt