### PR TITLE
fix(ui): fit the universe desk to the viewport

### DIFF
--- a/apps/desktop/src/components/control-grid/grid.tsx
+++ b/apps/desktop/src/components/control-grid/grid.tsx
@@ -46,7 +46,7 @@ export default function ControlGrid() {
 
   if (!data.length || settings === null) {
     return (
-      <div className="mt-4 w-full max-w-xl rounded-md border py-10 text-center text-muted-foreground">
+      <div className="mx-auto mt-4 w-full max-w-xl rounded-md border py-10 text-center text-muted-foreground">
         {/* Blank while queries settle; "No channels" only once we know. */}
         {settings === null ? " " : "No channels"}
       </div>
@@ -82,9 +82,12 @@ function Desk({ data, vertical }: { data: Channels; vertical: boolean }) {
     <div
       ref={parentRef}
       className={cn(
-        "mt-4 h-[68vh] w-full overflow-auto rounded-md border",
+        // Fill whatever the route hands us (it fits the desk to the viewport)
+        // instead of a hardcoded viewport fraction that overflowed under the
+        // presets row.
+        "h-full w-full overflow-auto rounded-md border",
         // Horizontal rows read badly at full width; columns want all of it.
-        !vertical && "max-w-xl"
+        !vertical && "mx-auto max-w-xl"
       )}
     >
       <div

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -29,14 +29,16 @@ function RootLayout() {
             <AccountMenu />
           </div>
         </nav>
-        <div className="flex flex-1 flex-col items-center overflow-y-auto">
+        {/* Routes own their scrolling: the fixtures list scrolls as a page,
+            the universe desk fits the viewport and scrolls internally — a
+            shared scroller can't serve both. min-h-0 lets flex children
+            actually shrink to fit. */}
+        <div className="flex min-h-0 flex-1 flex-col">
           <Outlet />
-          {/* mt-auto: sits at the viewport bottom until the content is tall
-              enough to scroll, then trails it. */}
-          <footer className="mt-auto pb-3 pt-8 text-xs text-muted-foreground/70">
-            lux v{__APP_VERSION__}
-          </footer>
         </div>
+        <footer className="shrink-0 pb-2 pt-1 text-center text-xs text-muted-foreground/70">
+          lux v{__APP_VERSION__}
+        </footer>
       </div>
       <Toaster closeButton />
       <Updater />

--- a/apps/desktop/src/routes/index.tsx
+++ b/apps/desktop/src/routes/index.tsx
@@ -8,9 +8,13 @@ export const Route = createFileRoute("/")({
 
 function Home() {
   return (
-    <div className="flex min-h-0 w-full flex-1 flex-col items-center">
-      <ButtonRow />
-      <FixturesView />
+    // This view scrolls as a page (many fixtures); min-h-full keeps the
+    // vertical console able to fill the viewport when content is short.
+    <div className="h-full w-full overflow-y-auto">
+      <div className="flex min-h-full w-full flex-col items-center">
+        <ButtonRow />
+        <FixturesView />
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/routes/universe.tsx
+++ b/apps/desktop/src/routes/universe.tsx
@@ -8,9 +8,13 @@ export const Route = createFileRoute("/universe")({
 
 function Universe() {
   return (
-    <div className="flex w-full max-w-3xl flex-col items-center">
+    // This view fits the viewport — the desk scrolls internally, the page
+    // never does. The presets row takes its height; the desk absorbs the rest.
+    <div className="mx-auto flex h-full w-full max-w-3xl flex-col px-4">
       <ButtonRow />
-      <ControlGrid />
+      <div className="mb-3 min-h-0 w-full flex-1">
+        <ControlGrid />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The universe page scrolled because the desk hardcoded `h-[68vh]` inside a shared page scroller — with the presets row above it, the total always overflowed the viewport. Scroll ownership moves into the routes, since the two views genuinely want different models:

- **Universe** fits the viewport: presets row on top, the desk absorbs the remaining height (`flex-1 min-h-0`) and scrolls internally along its fader axis. No page scroll at any window size.
- **Fixtures** keeps scrolling as a page (many fixtures), with `min-h-full` preserving the vertical console's fill behavior when content is short.
- The version footer moves out of the scroll content to a fixed line under the route container, so an exactly-fitting view isn't pushed into overflow by it.

## Test plan

- [x] `bun run build` + `bun run lint`
- [ ] PR gate
- [ ] On device: universe shows presets + full-height faders with zero page scroll in both orientations; fixtures view still scrolls normally