### PR TITLE
build(deploy): route the IoT authorizer through a live alias

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,16 +432,24 @@ jobs:
 
       # provided.al2023 runs the zip's `bootstrap`; package each binary under
       # that name and wait until Lambda finishes swapping code before smoking.
+      # Every deploy publishes a numbered version (rollback provenance). The
+      # sync-api and bot serve traffic from $LATEST (their Function URLs are
+      # unqualified), so the code swap is their cutover; the authorizer serves
+      # through the `live` alias, so its new version takes no traffic until the
+      # flip step below — after its smoke has passed against that exact version.
       - name: Deploy
         run: |
           for fn in lux-sync-api lux-iot-authorizer lux-discord-bot; do
             staging=$(mktemp -d)
             cp "target/x86_64-unknown-linux-musl/release/$fn" "$staging/bootstrap"
             (cd "$staging" && zip -q9 function.zip bootstrap)
-            aws lambda update-function-code --function-name "$fn" \
-              --zip-file "fileb://$staging/function.zip" --query 'CodeSha256' --output text
+            version=$(aws lambda update-function-code --function-name "$fn" \
+              --zip-file "fileb://$staging/function.zip" --publish --query 'Version' --output text)
             aws lambda wait function-updated --function-name "$fn"
-            echo "deployed $fn"
+            echo "deployed $fn as version $version"
+            if [ "$fn" = "lux-iot-authorizer" ]; then
+              echo "AUTH_VERSION=$version" >> "$GITHUB_ENV"
+            fi
           done
 
       - name: sccache stats
@@ -458,16 +466,35 @@ jobs:
           cat /tmp/body; echo
           test "$code" = "401" && grep -q '"error"' /tmp/body
 
-      # Invoke the authorizer directly with a garbage token: a well-formed
-      # deny proves it cold-started (JWKS fetch) and rejects bad tokens.
-      - name: Smoke iot-authorizer
+      # Invoke the freshly published version directly (qualified) with a
+      # garbage token: a well-formed deny proves it cold-started (JWKS fetch)
+      # and rejects bad tokens — all before it takes any auth traffic.
+      - name: Smoke iot-authorizer (pre-flip, exact version)
         run: |
           aws lambda invoke --function-name lux-iot-authorizer \
+            --qualifier "$AUTH_VERSION" \
             --cli-binary-format raw-in-base64-out \
             --payload '{"token":"smoke-test-garbage","protocolData":{"http":{"headers":{}}}}' \
             /tmp/authorizer.json >/dev/null
           cat /tmp/authorizer.json; echo
           grep -q '"isAuthenticated":false' /tmp/authorizer.json
+
+      # The smoked version goes live by repointing the alias IoT invokes
+      # through. Roll back by pointing it at the previous version (echoed
+      # below and in the job summary).
+      - name: Flip authorizer alias
+        run: |
+          prev=$(aws lambda get-alias --function-name lux-iot-authorizer \
+            --name live --query FunctionVersion --output text)
+          aws lambda update-alias --function-name lux-iot-authorizer \
+            --name live --function-version "$AUTH_VERSION" \
+            --query 'AliasArn' --output text
+          {
+            echo "authorizer \`live\` alias: v$prev → v$AUTH_VERSION"
+            echo '```'
+            echo "rollback: aws lambda update-alias --function-name lux-iot-authorizer --name live --function-version $prev"
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       # The bot verifies Discord's ed25519 signature before anything else, so an
       # unsigned request answering 401 proves the new code is up and checking.

--- a/infra/nudge.tf
+++ b/infra/nudge.tf
@@ -67,11 +67,39 @@ resource "aws_lambda_function" "lux_iot_authorizer" {
   }
 }
 
-# IoT (not a user) invokes the authorizer.
+# Deploys publish a numbered version, smoke that exact version, then repoint
+# this alias — the authorizer registration below invokes through it, so a bad
+# build never takes auth traffic and rollback is one command:
+#   aws lambda update-alias --function-name lux-iot-authorizer \
+#     --name live --function-version <prev>
+# Terraform seeds the pointer ($LATEST = today's semantics) and then leaves it
+# to the deploy pipeline, same hands-off pattern as the placeholder code.
+resource "aws_lambda_alias" "lux_iot_authorizer_live" {
+  name             = "live"
+  function_name    = aws_lambda_function.lux_iot_authorizer.function_name
+  function_version = "$LATEST"
+  lifecycle {
+    ignore_changes = [function_version]
+  }
+}
+
+# IoT (not a user) invokes the authorizer. Two permissions during the alias
+# transition: the unqualified one predates the alias and stays so there is no
+# destroy/create window in which IoT can't invoke; the qualified one is what
+# the alias-routed registration actually uses.
 resource "aws_lambda_permission" "lux_iot_authorizer_invoke" {
   statement_id  = "AllowIoTCustomAuthorizer"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.lux_iot_authorizer.function_name
+  principal     = "iot.amazonaws.com"
+  source_arn    = aws_iot_authorizer.lux_sync.arn
+}
+
+resource "aws_lambda_permission" "lux_iot_authorizer_invoke_alias" {
+  statement_id  = "AllowIoTCustomAuthorizerAlias"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lux_iot_authorizer.function_name
+  qualifier     = aws_lambda_alias.lux_iot_authorizer_live.name
   principal     = "iot.amazonaws.com"
   source_arn    = aws_iot_authorizer.lux_sync.arn
 }
@@ -86,7 +114,7 @@ resource "aws_lambda_permission" "lux_iot_authorizer_invoke" {
 # lux_wire::nudge::TOKEN_KEY (the app's handshake header).
 resource "aws_iot_authorizer" "lux_sync" {
   name                    = "lux-sync-auth"
-  authorizer_function_arn = aws_lambda_function.lux_iot_authorizer.arn
+  authorizer_function_arn = aws_lambda_alias.lux_iot_authorizer_live.arn
   signing_disabled        = true
   status                  = "ACTIVE"
   token_key_name          = "x-lux-token"

--- a/infra/terraform-ci.tf
+++ b/infra/terraform-ci.tf
@@ -340,14 +340,21 @@ resource "aws_iam_role_policy" "lambda_deploy" {
         Action = [
           "lambda:GetFunction", "lambda:GetFunctionConfiguration",
           "lambda:UpdateFunctionCode", "lambda:GetFunctionUrlConfig",
+          # Every deploy publishes a numbered version (rollback provenance).
+          "lambda:PublishVersion",
         ]
         Resource = local.lux_lambda_functions
       },
       {
-        Sid      = "SmokeInvokeAuthorizer"
-        Effect   = "Allow"
-        Action   = "lambda:InvokeFunction"
-        Resource = "arn:aws:lambda:*:${local.aws_account_id}:function:lux-iot-authorizer"
+        # The pre-flip smoke invokes the freshly published version directly
+        # (qualified ARN), and the flip repoints the `live` alias to it.
+        Sid    = "SmokeAndFlipAuthorizer"
+        Effect = "Allow"
+        Action = ["lambda:InvokeFunction", "lambda:GetAlias", "lambda:UpdateAlias"]
+        Resource = [
+          "arn:aws:lambda:*:${local.aws_account_id}:function:lux-iot-authorizer",
+          "arn:aws:lambda:*:${local.aws_account_id}:function:lux-iot-authorizer:*",
+        ]
       },
     ]
   })


### PR DESCRIPTION
## Summary

Phase 1 of the blue/green work — the free half, chosen because the authorizer is addressed by *name* from clients, so nothing client-visible changes:

- **Terraform**: a `live` alias on `lux-iot-authorizer` (seeded at `$LATEST`, `function_version` ignored thereafter — the deploy pipeline owns the pointer, same hands-off pattern as the placeholder code). The IoT authorizer registration invokes the alias ARN; a qualified invoke permission lands alongside the existing unqualified one so the transition has no window where IoT can't invoke. The deploy role gains `PublishVersion` (all three functions) and `GetAlias`/`UpdateAlias` + qualified invoke on the authorizer.
- **Pipeline**: every deploy publishes a numbered version (rollback provenance for all three). The authorizer's smoke now invokes the *freshly published version directly* — a true pre-cutover gate — and a new flip step repoints the alias only after the smoke passes, echoing the previous version and a ready-made rollback command into the job summary.
- **Ordering safety**: terraform-apply creates the alias and grants in the same release run, before deploy-lambdas; any smoke failure stops the job before the flip, leaving auth traffic on the previous version.

The sync-api and bot keep in-place cutover for now: their unqualified Function URLs serve `$LATEST`, and alias-qualified URLs are *different URLs* — that migration (new endpoints, embedded-config regen across a release boundary, a one-time Discord portal update) is deliberately deferred as phase 2.

## Test plan

- [x] Terraform plan gate on this PR (alias + permission + policy statements, no endpoint outputs touched — the endpoints drift gate is unaffected by design)
- [ ] PR gate
- [ ] Next release: deploy job summary shows `live` alias v$LATEST → vN with the rollback command; nudge/remote-control connects work after (alias-routed auth verified live)