### PR TITLE
build(store-notes): one drafter per branch

### DIFF
--- a/.github/workflows/store-notes.yml
+++ b/.github/workflows/store-notes.yml
@@ -10,6 +10,14 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# Back-to-back pushes to a release branch (release-please rebuild, then the
+# version-stamp sync seconds later) start overlapping drafters whose push
+# retries rebase into each other's identical draft commit and die on the
+# conflict. Newest event wins; the superseded run is cancelled mid-flight.
+concurrency:
+  group: store-notes-${{ github.head_ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## Summary

Tonight's rapid merges exposed a race: release-please rebuilds the release branch, the version-stamp sync pushes seconds later, and both events start store-notes drafters. Each drafts the same file; the slower one's push-retry loop `pull --rebase`s into the winner's identical draft commit and dies on the conflict (observed on #162: `error: could not apply … chore: draft App Store notes`).

A per-branch `concurrency` group with `cancel-in-progress` keeps one drafter alive: the newest event wins, the superseded run is cancelled mid-flight, and the survivor re-evaluates the branch state before committing — the existing "nothing to commit" guard makes that safe.

## Test plan

- [x] YAML change only; actionlint via the PR gate
- [ ] Next release-branch rebuild: exactly one store-notes run completes, no push-conflict failures