### PR TITLE
fix(store-notes): never redraft an existing file

### DIFF
--- a/scripts/draft-store-notes.ts
+++ b/scripts/draft-store-notes.ts
@@ -3,23 +3,21 @@
 // (workflow: store-notes.yml); the human edits the committed file in the PR,
 // and appstore.yml refuses to submit a version whose file is missing.
 //
-// The draft is exactly that — a draft. It never overwrites a human edit: the
-// file is only (re)written while its last committed author is the workflow
-// bot (or it doesn't exist yet). Delete the file in the PR to force a fresh
-// draft. The authorship check reads git history, so the workflow checks out
-// with full depth; scripts/restore-store-notes.ts runs first and resurrects a
-// human edit that a release-please branch rebuild discarded (the workflow
-// skips drafting entirely when it restores one).
+// The draft is exactly that — a draft, written once: the file is only created
+// when it doesn't exist. Existing files are never rewritten (human edits are
+// sacred; regenerating a bot draft would produce different text and re-push —
+// see the guard below). Delete the file in the PR to force a fresh draft.
+// scripts/restore-store-notes.ts runs first and resurrects a human edit that
+// a release-please branch rebuild discarded (the workflow skips drafting
+// entirely when it restores one).
 //
 // Usage: ANTHROPIC_API_KEY=... bun scripts/draft-store-notes.ts
 
 import Anthropic from "@anthropic-ai/sdk";
-import { execFileSync } from "child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "fs";
 import { join } from "path";
 
 const NOTES_DIR = "apps/desktop/store-notes";
-const BOT_EMAIL = "github-actions[bot]@users.noreply.github.com";
 
 const version: string = JSON.parse(
   readFileSync(".release-please-manifest.json", "utf8")
@@ -30,17 +28,17 @@ if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
 
 const notesPath = join(NOTES_DIR, `${version}.md`);
 
-// Never clobber a human's edit.
+// Never redraft an existing file, whoever wrote it. Human edits are sacred,
+// and regenerating a bot draft through the model produces *different* text
+// (the model is nondeterministic) — which would commit, push, retrigger this
+// workflow, and loop, now that draft pushes start workflow runs (App-token
+// pushes; see store-notes.yml). A stale bot draft never survives anyway:
+// release-please rebuilds the branch from main on every change, discarding
+// the file, and the next run drafts fresh from the new CHANGELOG. Delete the
+// file in the PR to force a redraft explicitly.
 if (existsSync(notesPath)) {
-  const lastAuthor = execFileSync(
-    "git",
-    ["log", "-1", "--format=%ae", "--", notesPath],
-    { encoding: "utf8" }
-  ).trim();
-  if (lastAuthor && lastAuthor !== BOT_EMAIL) {
-    console.log(`${notesPath} was last edited by ${lastAuthor}; leaving it alone.`);
-    process.exit(0);
-  }
+  console.log(`${notesPath} already exists; leaving it alone.`);
+  process.exit(0);
 }
 
 // The version's CHANGELOG section: from its `## [x.y.z]` heading to the next


### PR DESCRIPTION
## Summary

Fixes the draft loop observed on #162 tonight: the drafter's policy was *redraft while the file is bot-authored* — safe in the `GITHUB_TOKEN` era, when a bot push could never start a workflow run. With drafts now pushed via the release App token (#166), each push retriggers the workflow, the retriggered run regenerated the draft through the model, got **nondeterministically different text**, committed, pushed, and looped (~7 cycles before the workflow was disabled).

The draft becomes write-once: the file is only created when absent.

- Human edits stay sacred (a strict superset of the old author check).
- A stale bot draft still can't survive: release-please rebuilds the branch from main on every change, discarding the file, and the next run drafts fresh from the new CHANGELOG.
- Deleting the file in the PR still forces an explicit redraft.
- The author check (and its `execFileSync`) leaves the drafter entirely; restore-store-notes.ts keeps its own authorship logic untouched.

The store-notes workflow is currently **disabled** (loop tourniquet) — re-enable after this merges; the resulting release-branch rebuild is the live proof: one draft, one App-token push, tip gated, no second cycle.

## Test plan

- [x] Script parses; no other consumers of the removed check
- [ ] PR gate
- [ ] After merge + workflow re-enable: the rebuild drafts exactly once and the retriggered run logs "already exists; leaving it alone"