### PR TITLE
fix(ci): finish superseded runs on release branches

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -49,7 +49,7 @@ on:
 permissions:
   contents: read
 
-# PRs supersede (a force-push cancels the stale run); pushes to main QUEUE
+# Ordinary PRs supersede (a force-push cancels the stale run); pushes to main QUEUE
 # instead — every main commit must end with a completed CI record, so
 # back-to-back merges can't cancel each other's runs (that burned 69642ae,
 # whose push CI was cancelled after 4s by the release merge landing behind
@@ -61,7 +61,12 @@ permissions:
 # own parent (GitHub kills the job at startup; broke the v0.12.2 run).
 concurrency:
   group: ${{ github.workflow }}-gate-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Cancel superseded runs on ordinary PRs (fast feedback), but let them
+  # finish on release-please branches: the bot lands stamp + draft pushes
+  # seconds apart there, and a cancelled run paints a permanent red ✗ on the
+  # superseded commit in the release PR's history. Finishing costs only
+  # duplicate public-runner minutes and keeps the history green.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--') }}
 
 jobs:
   deny:

--- a/.github/workflows/store-notes.yml
+++ b/.github/workflows/store-notes.yml
@@ -16,7 +16,10 @@ on:
 # conflict. Newest event wins; the superseded run is cancelled mid-flight.
 concurrency:
   group: store-notes-${{ github.head_ref }}
-  cancel-in-progress: true
+  # Serialize, don't cancel: the write-once drafter (scripts/
+  # draft-store-notes.ts) makes a queued follow-up run a green no-op, whereas
+  # a cancellation paints a red ✗ on the superseded commit in the release PR.
+  cancel-in-progress: false
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

Every release PR showed a red ✗ mid-history: the bot lands the stamp-sync and draft pushes seconds apart, each push cancelled the previous commit's in-flight `desktop` gate, and GitHub renders cancellations as failures. Nothing was failing — but a permanent red mark in every release's history reads as rot.

- `desktop`: `cancel-in-progress` now excludes `release-please--` branches — superseded runs finish (duplicate public-runner minutes, green history); ordinary PRs keep fast-cancel.
- `store-notes`: serializes instead of cancelling — with the write-once drafter (#170), a queued follow-up run is a green no-op, so cancellation buys nothing and paints red.

## Test plan

- [x] YAML-only; expression validated by actionlint in the PR gate
- [ ] Next release-branch rebuild: every commit in the PR timeline ends green (stamp commit's gate completes instead of ✗)