### PR TITLE
feat(node): headless lux-node for an always-on Linux box

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -1,0 +1,45 @@
+# Builds the lux-node static musl binary and stages it as an artifact —
+# dispatch it, download lux-node-x86_64-linux, and follow apps/node/README.md.
+# Same toolchain the Lambda deploys use; nothing here touches AWS or signs
+# anything, so it is safe to run from any ref.
+name: node-build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install musl-gcc
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: "."
+          cache-targets: "false"
+
+      - name: Build (static musl)
+        run: cargo build --release --target x86_64-unknown-linux-musl -p lux-node
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lux-node-x86_64-linux
+          path: target/x86_64-unknown-linux-musl/release/lux-node
+          if-no-files-found: error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
 dependencies = [
  "android_log-sys",
- "env_filter",
+ "env_filter 0.1.4",
  "log",
 ]
 
@@ -108,6 +108,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1312,6 +1362,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,6 +1671,37 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1986,6 +2073,29 @@ checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter 2.0.0",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -3151,6 +3261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,6 +3293,31 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3647,6 +3788,28 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lux-node"
+version = "0.1.0"
+dependencies = [
+ "aws-cognito-srp",
+ "aws-config",
+ "aws-sdk-cognitoidentityprovider",
+ "aws-smithy-http-client",
+ "env_logger",
+ "gethostname",
+ "log",
+ "lux-engine",
+ "lux-wire",
+ "rpassword",
+ "rumqttc",
+ "rustls 0.23.41",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -4148,6 +4311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4521,6 +4690,21 @@ dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -4956,6 +5140,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4973,6 +5168,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6992,6 +7197,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3575,8 +3575,8 @@ dependencies = [
  "keyring-core",
  "libftd2xx 0.33.1",
  "log",
+ "lux-engine",
  "lux-wire",
- "pem",
  "reqwest",
  "rumqttc",
  "rustls 0.23.41",
@@ -3595,7 +3595,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
- "webpki-root-certs",
 ]
 
 [[package]]
@@ -3620,6 +3619,19 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lux-engine"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "lux-wire",
+ "pem",
+ "serde_json",
+ "uuid",
+ "webpki-root-certs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "apps/desktop/src-tauri",
+    "apps/node",
     "crates/lux-auth",
     "crates/lux-engine",
     "crates/lux-wire",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "apps/desktop/src-tauri",
     "crates/lux-auth",
+    "crates/lux-engine",
     "crates/lux-wire",
     "services/bot",
     "services/iot-authorizer",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -34,8 +34,6 @@ aws-cognito-srp = "0.2.5"
 # of the platform native store, which is unreadable on iOS. Crypto on ring to
 # match the app's process-default provider (no aws-lc-sys C build).
 aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
-webpki-root-certs = "1"
-pem = "3"
 keyring = "4"
 # keyring's backing crate, named directly on every platform: session entries are
 # built through keyring-core types (on iOS with an access-policy modifier, see
@@ -68,6 +66,7 @@ uuid = { version = "1.23.4", features = [
 reqwest.workspace = true
 # The desktop↔sync-api wire contract — the same crate the Lambda serializes
 # with, so the two sides cannot drift (see crates/lux-wire).
+lux-engine = { path = "../../../crates/lux-engine" }
 lux-wire = { path = "../../../crates/lux-wire" }
 # base64url payload decode of our own Cognito ID token (topic addressing only —
 # verification stays server-side in the IoT authorizer / sync-api).

--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -14,7 +14,7 @@
 //! keeps the password on-device: only a zero-knowledge proof crosses the wire.
 
 use crate::lock::LockPolicy;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 
 use aws_cognito_srp::{SrpClient, User};
 use aws_config::BehaviorVersion;
@@ -300,24 +300,10 @@ pub fn restore_on_startup(app: &AppHandle) {
 
 // --- Cognito calls (unauthenticated; owned args so the future is 'static) -----
 
-/// The Mozilla CA set (webpki) as a single PEM bundle, built once.
-///
-/// The AWS SDK's default HTTP client trusts the platform *native* root store.
-/// iOS apps can't read the system CA store, so rustls parses zero roots and the
-/// SDK aborts (`debug_assert` in debug, empty trust store in release). Bundling
-/// the webpki roots makes TLS verification identical on every platform.
-pub(crate) fn webpki_pem_bundle() -> &'static [u8] {
-    static BUNDLE: OnceLock<Vec<u8>> = OnceLock::new();
-    BUNDLE.get_or_init(|| {
-        let mut pem = Vec::new();
-        for cert in webpki_root_certs::TLS_SERVER_ROOT_CERTS {
-            pem.extend_from_slice(
-                ::pem::encode(&::pem::Pem::new("CERTIFICATE", cert.as_ref().to_vec())).as_bytes(),
-            );
-        }
-        pem
-    })
-}
+// The AWS SDK's default HTTP client trusts the platform *native* root store,
+// unreadable on iOS — the bundled webpki roots (lux-engine) make TLS
+// verification identical on every platform.
+pub(crate) use lux_engine::tls::webpki_pem_bundle;
 
 async fn cognito_client(region: &str) -> Client {
     // Trust the bundled webpki roots rather than the platform native store

--- a/apps/desktop/src-tauri/src/devices/mod.rs
+++ b/apps/desktop/src-tauri/src/devices/mod.rs
@@ -11,7 +11,6 @@
 pub mod discovery;
 #[cfg(desktop)]
 pub mod enttec_open_dmx_usb;
-pub mod sacn;
 
 use crate::lock::LockPolicy;
 use std::net::Ipv4Addr;
@@ -23,11 +22,8 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 use tauri::{AppHandle, Manager, Runtime};
 
-/// A DMX output: take the fixture's channel bytes (lux uses 6: RGBAW + master)
-/// and push them to hardware.
-pub trait DmxSink: Send + Sync {
-    fn render(&self, channels: &[u8]) -> Result<(), String>;
-}
+pub use lux_engine::sacn;
+pub use lux_engine::DmxSink;
 
 /// The kind of transport behind a [`Device`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -238,7 +234,12 @@ fn build_sink(device: &Device) -> Arc<dyn DmxSink> {
         // No USB transport on mobile; a stray Enttec selection drops to silence.
         #[cfg(mobile)]
         Transport::Enttec => Arc::new(NullSink),
-        Transport::Sacn => match sacn::SacnSink::new(device.universe, sacn_interface_override()) {
+        Transport::Sacn => match sacn::SacnSink::new(
+            device.universe,
+            sacn_interface_override(),
+            sacn::DEFAULT_PRIORITY,
+            "lux",
+        ) {
             Ok(sink) => Arc::new(sink),
             Err(e) => {
                 log::error!("sACN init failed ({e}); output disabled until reselected");
@@ -277,7 +278,11 @@ pub fn switch_to_device<R: Runtime>(app: &AppHandle<R>, device: &Device) {
         app.state::<DmxOutput>().retarget_universe(universe);
     }
     persist_key(app, &device.key());
-    let buffer = app.state::<crate::buffer::LuxBuffer>().buffer.lock_or_recover().clone();
+    let buffer = app
+        .state::<crate::buffer::LuxBuffer>()
+        .buffer
+        .lock_or_recover()
+        .clone();
     if let Err(e) = app.state::<DmxOutput>().render(&buffer) {
         log::trace!("post-switch render failed: {e}");
     }
@@ -412,7 +417,11 @@ pub fn start_keepalive<R: Runtime>(app: &AppHandle<R>) {
                 continue;
             }
             // Copy out of the lock before the render so no guard is held across it.
-            let buffer = app.state::<crate::buffer::LuxBuffer>().buffer.lock_or_recover().clone();
+            let buffer = app
+                .state::<crate::buffer::LuxBuffer>()
+                .buffer
+                .lock_or_recover()
+                .clone();
             if let Err(e) = app.state::<DmxOutput>().render(&buffer) {
                 log::trace!("sACN keepalive render failed: {e}");
             }

--- a/apps/desktop/src-tauri/src/nudge.rs
+++ b/apps/desktop/src-tauri/src/nudge.rs
@@ -35,7 +35,6 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use base64::Engine;
 use rumqttc::{
     AsyncClient, ConnectionError, Event, LastWill, MqttOptions, Packet, QoS, TlsConfiguration,
     Transport,
@@ -44,7 +43,11 @@ use tauri::{AppHandle, Manager, Runtime};
 use tokio::sync::watch;
 use uuid::Uuid;
 
-use crate::account::{webpki_pem_bundle, LuxAccount};
+use lux_engine::auth::jwt_sub;
+use lux_engine::ctl::{gate, route, RemoteApply, Route};
+use lux_engine::tls::webpki_pem_bundle;
+
+use crate::account::LuxAccount;
 use crate::buffer::LuxBuffer;
 use crate::lock::LockPolicy;
 use crate::setup::LuxSetups;
@@ -699,157 +702,10 @@ fn apply_frame(app: &AppHandle, payload: &[u8], frame_setup: &str, own_session: 
     }
 }
 
-/// Where an incoming publish on the user channel goes.
-#[derive(Debug, PartialEq, Eq)]
-enum Route<'t> {
-    /// The opaque nudge topic — schedule a pull.
-    Nudge,
-    /// A live ctl frame addressed to one setup.
-    Frame { setup_id: &'t str },
-    /// An applier's retained state echo for one setup — reflected into the UI,
-    /// never applied (see [`crate::buffer::reflect_remote_state`]).
-    State { setup_id: &'t str },
-    /// A peer's retained presence card (empty payload = the peer is gone).
-    Presence { session: &'t str },
-    /// Reserved render-node config traffic; nothing consumes it yet.
-    Config,
-    /// Not a topic this listener expects under the granted policy.
-    Unknown,
-}
-
-/// Classify an incoming topic. Plain function over plain types on purpose —
-/// the routing decision must stay testable (and extractable) without Tauri.
-fn route<'t>(topic: &'t str, sub: &str) -> Route<'t> {
-    if topic == lux_wire::nudge::user_topic(sub) {
-        return Route::Nudge;
-    }
-    let prefix = lux_wire::ctl::user_prefix(sub);
-    let Some(rest) = topic
-        .strip_prefix(prefix.as_str())
-        .and_then(|rest| rest.strip_prefix('/'))
-    else {
-        return Route::Unknown;
-    };
-    if let Some(setup_rest) = rest.strip_prefix("setup/") {
-        return match setup_rest.split_once('/') {
-            Some((setup_id, "frame")) => Route::Frame { setup_id },
-            Some((setup_id, "state")) => Route::State { setup_id },
-            Some((_, "config")) => Route::Config,
-            _ => Route::Unknown,
-        };
-    }
-    if let Some(session) = rest.strip_prefix("presence/") {
-        return Route::Presence { session };
-    }
-    Route::Unknown
-}
-
-/// One applicable buffer mutation extracted from a gated ctl frame.
-#[derive(Debug, PartialEq, Eq)]
-enum RemoteApply {
-    Overlay(Vec<u8>),
-    Channel { ch: u16, val: u8 },
-}
-
-/// Whether this peer applies `frame`: the version must be known, the frame
-/// must not be this connection's own publish echoed back (`src` == our
-/// session), and only frames addressed to the active setup apply. Plain
-/// function on purpose (see [`route`]).
-fn gate(
-    frame: lux_wire::ctl::Frame,
-    frame_setup: &str,
-    active_setup: &str,
-    own_session: &str,
-) -> Option<RemoteApply> {
-    if frame.version() != lux_wire::ctl::VERSION {
-        log::debug!(
-            "dropping ctl frame with unknown version {}",
-            frame.version()
-        );
-        return None;
-    }
-    if frame.src() == Some(own_session) {
-        return None; // our own frame, already applied locally
-    }
-    if frame_setup != active_setup {
-        log::debug!("dropping ctl frame for inactive setup {frame_setup}");
-        return None;
-    }
-    match frame {
-        lux_wire::ctl::Frame::Buffer { buffer, .. } => Some(RemoteApply::Overlay(buffer)),
-        lux_wire::ctl::Frame::Channel { ch, val, .. } => Some(RemoteApply::Channel { ch, val }),
-    }
-}
-
-/// The `sub` claim from our own ID token's payload. Unverified base64 decode on
-/// purpose: this only *addresses* the topic we ask for — the IoT authorizer
-/// independently verifies the token and scopes the granted policy to the sub it
-/// verified, so a wrong value here can only produce a denied subscribe.
-fn jwt_sub(token: &str) -> Option<String> {
-    let payload = token.split('.').nth(1)?;
-    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(payload)
-        .ok()?;
-    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-    Some(claims.get("sub")?.as_str()?.to_owned())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use lux_wire::ctl::Frame;
-
-    #[test]
-    fn jwt_sub_reads_the_payload_claim() {
-        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .encode(r#"{"sub":"abc-123","token_use":"id"}"#);
-        let token = format!("eyJhbGciOiJSUzI1NiJ9.{payload}.sig");
-        assert_eq!(jwt_sub(&token).as_deref(), Some("abc-123"));
-    }
-
-    #[test]
-    fn jwt_sub_rejects_garbage() {
-        assert_eq!(jwt_sub("not-a-jwt"), None);
-        assert_eq!(jwt_sub("a.b.c"), None);
-    }
-
-    #[test]
-    fn route_classifies_the_user_channel() {
-        let sub = "abc-123";
-        assert_eq!(route("lux/sync/user/abc-123", sub), Route::Nudge);
-        assert_eq!(
-            route("lux/ctl/user/abc-123/setup/s-1/frame", sub),
-            Route::Frame { setup_id: "s-1" }
-        );
-        assert_eq!(
-            route("lux/ctl/user/abc-123/setup/s-1/state", sub),
-            Route::State { setup_id: "s-1" }
-        );
-        assert_eq!(
-            route("lux/ctl/user/abc-123/setup/s-1/config", sub),
-            Route::Config
-        );
-        assert_eq!(
-            route("lux/ctl/user/abc-123/presence/0a1b2c3d", sub),
-            Route::Presence {
-                session: "0a1b2c3d"
-            }
-        );
-
-        // Not ours / not a shape we know.
-        assert_eq!(route("lux/sync/user/other", sub), Route::Unknown);
-        assert_eq!(
-            route("lux/ctl/user/other/setup/s-1/frame", sub),
-            Route::Unknown
-        );
-        assert_eq!(
-            route("lux/ctl/user/abc-123/setup/s-1/verbs", sub),
-            Route::Unknown
-        );
-        assert_eq!(route("lux/ctl/user/abc-123/setup/s-1", sub), Route::Unknown);
-        assert_eq!(route("lux/ctl/user/abc-123", sub), Route::Unknown);
-        assert_eq!(route("lux/1/buffer/set", sub), Route::Unknown);
-    }
 
     #[test]
     fn outbox_coalesces_channels_to_latest_value() {
@@ -896,27 +752,6 @@ mod tests {
     }
 
     #[test]
-    fn gate_applies_only_known_versions_for_the_active_setup() {
-        let overlay = Frame::buffer(vec![1, 2, 3]);
-        assert_eq!(
-            gate(overlay, "s-1", "s-1", "me00"),
-            Some(RemoteApply::Overlay(vec![1, 2, 3]))
-        );
-        let channel = Frame::channel(10, 200);
-        assert_eq!(
-            gate(channel, "s-1", "s-1", "me00"),
-            Some(RemoteApply::Channel { ch: 10, val: 200 })
-        );
-
-        // Inactive setup → dropped.
-        assert_eq!(gate(Frame::channel(1, 1), "s-2", "s-1", "me00"), None);
-
-        // Unknown version → dropped (parse it as the reader would).
-        let future: Frame = serde_json::from_str(r#"{"v":9,"ch":1,"val":1}"#).expect("parses");
-        assert_eq!(gate(future, "s-1", "s-1", "me00"), None);
-    }
-
-    #[test]
     fn reflect_holdoff_gates_recent_local_input() {
         let state = LuxNudge::default();
         assert!(!state.within_reflect_holdoff()); // no input yet — echoes reflect
@@ -926,17 +761,5 @@ mod tests {
 
         *state.local_input_at.lock_or_recover() = Some(Instant::now() - REFLECT_HOLDOFF * 2);
         assert!(!state.within_reflect_holdoff()); // input long past — reflect again
-    }
-
-    #[test]
-    fn gate_drops_our_own_frames_but_applies_other_sessions() {
-        let own = Frame::channel(1, 255).with_src("me00");
-        assert_eq!(gate(own, "s-1", "s-1", "me00"), None);
-
-        let theirs = Frame::channel(1, 255).with_src("them");
-        assert!(gate(theirs, "s-1", "s-1", "me00").is_some());
-
-        // Unstamped (e.g. CLI-published) frames apply.
-        assert!(gate(Frame::channel(1, 255), "s-1", "s-1", "me00").is_some());
     }
 }

--- a/apps/node/Cargo.toml
+++ b/apps/node/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "lux-node"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# Headless lux for an always-on Linux box: holds the user-channel MQTT
+# connection, applies remote-control frames addressed to one configured setup,
+# and renders them to sACN — no Tauri, no webview, no GTK/glib in the binary.
+# Signs in with the same Cognito account as the apps (`lux-node login`) and
+# rides the same JWT-authorized channel as any other signed-in device.
+# Install/runbook: apps/node/README.md.
+
+[lints]
+workspace = true
+
+[dependencies]
+lux-engine = { path = "../../crates/lux-engine" }
+lux-wire = { path = "../../crates/lux-wire" }
+aws-config.workspace = true
+aws-sdk-cognitoidentityprovider = "1"
+aws-cognito-srp = "0.2.5"
+aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
+gethostname = "1.1.0"
+log = "^0.4.33"
+env_logger = "0.11"
+rpassword = "7"
+rumqttc = { version = "0.25", features = ["websocket"] }
+# rumqttc pulls rustls with no baked-in crypto provider; main() installs ring
+# as the process default (same as the Lambda services).
+rustls = { workspace = true }
+serde = { workspace = true }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+uuid = { version = "1.23.4", features = ["v4"] }

--- a/apps/node/README.md
+++ b/apps/node/README.md
@@ -1,0 +1,51 @@
+# lux-node
+
+Headless lux for an always-on Linux box: it signs into your lux account, holds the same realtime channel as the apps, applies remote-control frames addressed to one setup, and renders them to sACN. No display, no GTK — a single static binary and a systemd unit. Your phone anywhere drives the lights at home while this runs.
+
+It transmits at E1.31 priority 90 (surfaces send 100), so touching a fader on any device on the LAN overrides the node until you let go.
+
+## Get the binary
+
+Run the **node-build** workflow (Actions → node-build → Run workflow) and download the `lux-node-x86_64-linux` artifact, or build from a checkout:
+
+```bash
+cargo build --release --target x86_64-unknown-linux-musl -p lux-node
+```
+
+## Install (Ubuntu)
+
+```bash
+sudo install -m 755 lux-node /usr/local/bin/lux-node
+sudo useradd --system --home /var/lib/lux-node --shell /usr/sbin/nologin lux-node || true
+sudo mkdir -p /etc/lux-node
+sudo tee /etc/lux-node/config.json > /dev/null <<'EOF'
+{ "setupId": "<your setup uuid>", "universe": 1 }
+EOF
+sudo install -m 644 lux-node.service /etc/systemd/system/lux-node.service
+
+# Sign in once as the service user (stores the refresh token, 0600):
+sudo mkdir -p /var/lib/lux-node && sudo chown lux-node /var/lib/lux-node
+sudo -u lux-node XDG_CONFIG_HOME=/var/lib/lux-node lux-node login you@example.com
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now lux-node
+journalctl -u lux-node -f
+```
+
+`setupId` is the id of the setup this node applies — visible in the app's sync record, or ask any signed-in device. Optional config keys: `"interface"` (IPv4 of the NIC to egress multicast from, for multi-homed hosts) and `"priority"` (default 90).
+
+## An always-on box should stay on
+
+```bash
+sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target
+```
+
+On an Intel Mac mini, also enable auto power-on after a power failure (the setpci register varies by generation — verify for the model before poking):
+
+```bash
+sudo setpci -s 0:1f.0 0xa4.b=0
+```
+
+## What it does on the wire
+
+Outbound-only WSS to AWS IoT Core through the same JWT authorizer as the apps — no ports opened at the house. It subscribes your ctl space, applies `frame`s for its setup, seeds its buffer from the retained `state` echo on connect (restart persistence via the broker), re-renders every second (sACN receivers drop quiet sources), announces a retained presence card (cleared by its Last Will), and publishes its own state echo so every surface shows the rig's truth.

--- a/apps/node/lux-node.service
+++ b/apps/node/lux-node.service
@@ -1,0 +1,25 @@
+# lux-node — headless lux DMX renderer.
+# Install: apps/node/README.md. Config: /etc/lux-node/config.json; the stored
+# session lives in the service's state dir (/var/lib/lux-node).
+
+[Unit]
+Description=lux-node — headless lux DMX renderer
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=lux-node
+ExecStart=/usr/local/bin/lux-node run --config /etc/lux-node/config.json
+Restart=always
+RestartSec=5
+Environment=RUST_LOG=info
+# The refresh-token session file lives under the state dir, not a home dir.
+StateDirectory=lux-node
+Environment=XDG_CONFIG_HOME=/var/lib/lux-node
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/node/src/auth.rs
+++ b/apps/node/src/auth.rs
@@ -1,0 +1,131 @@
+//! Cognito auth for the node: the same embedded-SRP sign-in and silent
+//! refresh the apps use (mirrored from the desktop's account layer — the
+//! desktop crate links Tauri, so the node can't import it; unify into
+//! lux-engine when the desktop's account layer is next touched).
+
+use aws_cognito_srp::{SrpClient, User};
+use aws_config::BehaviorVersion;
+use aws_sdk_cognitoidentityprovider::config::Region;
+use aws_sdk_cognitoidentityprovider::error::{ProvideErrorMetadata, SdkError};
+use aws_sdk_cognitoidentityprovider::types::{AuthFlowType, ChallengeNameType};
+use aws_sdk_cognitoidentityprovider::Client;
+use aws_smithy_http_client::tls::{self, rustls_provider::CryptoMode};
+use lux_engine::tls::webpki_pem_bundle;
+
+use crate::config::Endpoints;
+
+pub struct Tokens {
+    pub id: String,
+    pub refresh: Option<String>,
+}
+
+async fn cognito_client(region: &str) -> Client {
+    // Trust the bundled webpki roots rather than the platform native store —
+    // a headless box may not even have ca-certificates installed. Crypto on
+    // ring, matching the process-default provider main() installs.
+    let tls_ctx = tls::TlsContext::builder()
+        .with_trust_store(tls::TrustStore::empty().with_pem_certificate(webpki_pem_bundle()))
+        .build()
+        .expect("build TLS context");
+    let http_client = aws_smithy_http_client::Builder::new()
+        .tls_provider(tls::Provider::Rustls(CryptoMode::Ring))
+        .tls_context(tls_ctx)
+        .build_https();
+    let cfg = aws_config::defaults(BehaviorVersion::latest())
+        .http_client(http_client)
+        .no_credentials()
+        .region(Region::new(region.to_owned()))
+        .load()
+        .await;
+    Client::new(&cfg)
+}
+
+pub async fn sign_in(env: &Endpoints, email: &str, password: &str) -> Result<Tokens, String> {
+    let client = cognito_client(&env.cognito_region).await;
+
+    // SRP step 1: send SRP_A, get the PASSWORD_VERIFIER challenge.
+    let srp = SrpClient::new(
+        User::new(&env.cognito_user_pool_id, email, password),
+        &env.cognito_app_client_id,
+        None,
+    );
+    let auth = srp.get_auth_parameters();
+    let init = client
+        .initiate_auth()
+        .auth_flow(AuthFlowType::UserSrpAuth)
+        .client_id(&env.cognito_app_client_id)
+        .auth_parameters("USERNAME", auth.username.clone())
+        .auth_parameters("SRP_A", auth.a.clone())
+        .send()
+        .await
+        .map_err(sdk_err)?;
+
+    let params = init
+        .challenge_parameters()
+        .ok_or("no challenge parameters in InitiateAuth response")?;
+    let get = |k: &str| {
+        params
+            .get(k)
+            .cloned()
+            .ok_or_else(|| format!("challenge missing {k}"))
+    };
+    let (salt, secret_block, srp_b, user_id) = (
+        get("SALT")?,
+        get("SECRET_BLOCK")?,
+        get("SRP_B")?,
+        get("USER_ID_FOR_SRP")?,
+    );
+
+    // SRP step 2: prove knowledge of the password and exchange for tokens.
+    let proof = srp
+        .verify(&secret_block, &user_id, &salt, &srp_b)
+        .map_err(|e| format!("SRP verification failed: {e}"))?;
+    let resp = client
+        .respond_to_auth_challenge()
+        .challenge_name(ChallengeNameType::PasswordVerifier)
+        .client_id(&env.cognito_app_client_id)
+        .challenge_responses("USERNAME", user_id)
+        .challenge_responses(
+            "PASSWORD_CLAIM_SECRET_BLOCK",
+            proof.password_claim_secret_block,
+        )
+        .challenge_responses("PASSWORD_CLAIM_SIGNATURE", proof.password_claim_signature)
+        .challenge_responses("TIMESTAMP", proof.timestamp)
+        .send()
+        .await
+        .map_err(sdk_err)?;
+
+    tokens_from(resp.authentication_result())
+}
+
+pub async fn refresh(env: &Endpoints, refresh_token: &str) -> Result<Tokens, String> {
+    let client = cognito_client(&env.cognito_region).await;
+    let out = client
+        .initiate_auth()
+        .auth_flow(AuthFlowType::RefreshTokenAuth)
+        .client_id(&env.cognito_app_client_id)
+        .auth_parameters("REFRESH_TOKEN", refresh_token)
+        .send()
+        .await
+        .map_err(sdk_err)?;
+    tokens_from(out.authentication_result())
+}
+
+fn tokens_from(
+    result: Option<&aws_sdk_cognitoidentityprovider::types::AuthenticationResultType>,
+) -> Result<Tokens, String> {
+    let r = result.ok_or("no authentication result")?;
+    Ok(Tokens {
+        id: r.id_token().ok_or("no id token")?.to_owned(),
+        refresh: r.refresh_token().map(str::to_owned),
+    })
+}
+
+/// Best-effort message from a Cognito SDK error — the modeled service message
+/// (e.g. "Incorrect username or password.") when present, else the raw error.
+fn sdk_err<E: ProvideErrorMetadata, R>(e: SdkError<E, R>) -> String {
+    if let Some(msg) = e.as_service_error().and_then(|se| se.message()) {
+        return msg.to_owned();
+    }
+    e.to_string()
+}

--- a/apps/node/src/config.rs
+++ b/apps/node/src/config.rs
@@ -1,0 +1,143 @@
+//! Node configuration: the embedded production endpoints (same generated file
+//! the apps embed — environment values are data, never code), the node's own
+//! small config file, and the stored session.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// The generated production endpoints, embedded at compile time from the same
+/// file the desktop embeds (single source of truth; CI drift-gates it against
+/// applied Terraform state). Never hand-edit the JSON.
+const ENDPOINTS_JSON: &str = include_str!("../../desktop/src-tauri/endpoints.prod.json");
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Endpoints {
+    pub cognito_region: String,
+    pub cognito_user_pool_id: String,
+    pub cognito_app_client_id: String,
+    pub nudge_endpoint: String,
+}
+
+pub fn endpoints() -> Result<Endpoints, String> {
+    serde_json::from_str(ENDPOINTS_JSON).map_err(|e| format!("embedded endpoints unreadable: {e}"))
+}
+
+/// `lux-node.json`: which setup this node applies, and how it transmits.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeConfig {
+    /// The setup whose ctl frames this node applies (the UUID from the app's
+    /// setups; the phone/desktop shows it in the sync record).
+    pub setup_id: String,
+    /// sACN universe to transmit on.
+    pub universe: u16,
+    /// Optional local NIC IPv4 to egress multicast from (multi-homed hosts).
+    #[serde(default)]
+    pub interface: Option<String>,
+    /// E1.31 per-packet priority. Defaults below the surfaces' 100 so a human
+    /// hand on a fader anywhere on the LAN overrides the node.
+    #[serde(default = "default_priority")]
+    pub priority: u8,
+}
+
+fn default_priority() -> u8 {
+    90
+}
+
+pub fn load_node_config(path: &Path) -> Result<NodeConfig, String> {
+    let json = fs::read_to_string(path)
+        .map_err(|e| format!("could not read node config {}: {e}", path.display()))?;
+    serde_json::from_str(&json).map_err(|e| format!("bad node config {}: {e}", path.display()))
+}
+
+/// The stored session: enough to restore on boot. Written 0600 — the refresh
+/// token is the credential (a headless box has no OS keychain to lean on).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredSession {
+    pub email: String,
+    pub refresh_token: String,
+}
+
+/// `$XDG_CONFIG_HOME/lux-node` (or `~/.config/lux-node`).
+pub fn config_dir() -> Result<PathBuf, String> {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        if !xdg.is_empty() {
+            return Ok(PathBuf::from(xdg).join("lux-node"));
+        }
+    }
+    std::env::var("HOME")
+        .map(|home| PathBuf::from(home).join(".config").join("lux-node"))
+        .map_err(|_| "neither XDG_CONFIG_HOME nor HOME is set".to_owned())
+}
+
+pub fn session_path() -> Result<PathBuf, String> {
+    Ok(config_dir()?.join("session.json"))
+}
+
+pub fn default_config_path() -> Result<PathBuf, String> {
+    Ok(config_dir()?.join("config.json"))
+}
+
+pub fn load_session() -> Result<StoredSession, String> {
+    let path = session_path()?;
+    let json = fs::read_to_string(&path).map_err(|e| {
+        format!(
+            "no stored session at {} ({e}); run `lux-node login <email>` first",
+            path.display()
+        )
+    })?;
+    serde_json::from_str(&json).map_err(|e| format!("stored session unreadable: {e}"))
+}
+
+pub fn save_session(session: &StoredSession) -> Result<(), String> {
+    let path = session_path()?;
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;
+    }
+    let json = serde_json::to_string_pretty(session).map_err(|e| e.to_string())?;
+    write_private(&path, json.as_bytes())
+}
+
+#[cfg(unix)]
+fn write_private(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| format!("could not open {}: {e}", path.display()))?;
+    file.write_all(bytes)
+        .map_err(|e| format!("could not write {}: {e}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn write_private(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    fs::write(path, bytes).map_err(|e| format!("could not write {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_endpoints_parse() {
+        let e = endpoints().expect("endpoints parse");
+        assert!(!e.cognito_region.is_empty());
+        assert!(!e.nudge_endpoint.is_empty());
+    }
+
+    #[test]
+    fn node_config_defaults_priority_below_surfaces() {
+        let cfg: NodeConfig =
+            serde_json::from_str(r#"{"setupId":"s-1","universe":1}"#).expect("parses");
+        assert_eq!(cfg.priority, 90);
+        assert!(cfg.interface.is_none());
+    }
+}

--- a/apps/node/src/main.rs
+++ b/apps/node/src/main.rs
@@ -1,0 +1,101 @@
+//! lux-node — headless lux for an always-on Linux box.
+//!
+//!   lux-node login <email>     sign in once; stores the refresh token (0600)
+//!   lux-node run [--config P]  hold the user channel and drive the rig
+//!
+//! Config file (default ~/.config/lux-node/config.json):
+//!   { "setupId": "<uuid>", "universe": 1, "interface": null, "priority": 90 }
+
+mod auth;
+mod config;
+mod node;
+
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+
+use lux_engine::sacn::SacnSink;
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    // rumqttc's rustls has no baked-in crypto provider; install ring as the
+    // process default before any TLS happens (same as the Lambda services).
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    if let Err(e) = dispatch() {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn dispatch() -> Result<(), String> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        Some("login") => {
+            let email = args
+                .get(1)
+                .ok_or("usage: lux-node login <email>")?
+                .to_owned();
+            login(email)
+        }
+        Some("run") | None => run(config_path(&args)?),
+        Some(other) => Err(format!(
+            "unknown command {other}; usage: lux-node login <email> | lux-node run [--config <path>]"
+        )),
+    }
+}
+
+fn config_path(args: &[String]) -> Result<PathBuf, String> {
+    if let Some(i) = args.iter().position(|a| a == "--config") {
+        return args
+            .get(i + 1)
+            .map(PathBuf::from)
+            .ok_or("--config needs a path".to_owned());
+    }
+    config::default_config_path()
+}
+
+fn login(email: String) -> Result<(), String> {
+    let env = config::endpoints()?;
+    let password =
+        rpassword::prompt_password("password: ").map_err(|e| format!("password prompt: {e}"))?;
+    let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+    let tokens = runtime.block_on(auth::sign_in(&env, &email, &password))?;
+    let refresh = tokens
+        .refresh
+        .ok_or("Cognito returned no refresh token; cannot run headless")?;
+    config::save_session(&config::StoredSession {
+        email: email.clone(),
+        refresh_token: refresh,
+    })?;
+    println!("signed in as {email}; session stored. Next: lux-node run");
+    Ok(())
+}
+
+fn run(config_file: PathBuf) -> Result<(), String> {
+    let env = config::endpoints()?;
+    let cfg = config::load_node_config(&config_file)?;
+    let session = config::load_session()?;
+
+    let interface = match &cfg.interface {
+        Some(ip) => Some(
+            ip.parse::<Ipv4Addr>()
+                .map_err(|e| format!("bad interface {ip}: {e}"))?,
+        ),
+        None => None,
+    };
+    let name = format!(
+        "lux-node ({})",
+        gethostname::gethostname().to_string_lossy()
+    );
+    let sink = SacnSink::new(cfg.universe, interface, cfg.priority, &name)?;
+    log::info!(
+        "lux-node: setup {} -> sACN universe {} at priority {} ({})",
+        cfg.setup_id,
+        cfg.universe,
+        cfg.priority,
+        session.email
+    );
+
+    let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+    runtime.block_on(node::run(env, cfg, session, sink))
+}

--- a/apps/node/src/node.rs
+++ b/apps/node/src/node.rs
@@ -1,0 +1,266 @@
+//! The node's run loop: one user-channel connection, frames applied to a
+//! plain universe buffer, sACN out.
+//!
+//! Mirrors the desktop listener's connection shape (`nudge.rs`) minus Tauri:
+//! WSS to IoT Core through the `lux-sync-auth` custom authorizer with a fresh
+//! Cognito ID token per attempt, a retained presence card cleared by the Last
+//! Will, and capped exponential backoff. Differences fitting a render node:
+//! it subscribes only the ctl space (a node never syncs), it seeds its buffer
+//! from the retained state echo on connect (restart persistence via the
+//! broker), it re-renders every second (sACN receivers drop a source that
+//! goes quiet), and it publishes its own retained state echo after applying.
+
+use std::time::Duration;
+
+use lux_engine::ctl::{gate, route, RemoteApply, Route};
+use lux_engine::sacn::SacnSink;
+use lux_engine::tls::webpki_pem_bundle;
+use lux_engine::universe::Universe;
+use lux_engine::DmxSink;
+use rumqttc::{
+    AsyncClient, ConnectionError, Event, LastWill, MqttOptions, Packet, QoS, TlsConfiguration,
+    Transport,
+};
+use uuid::Uuid;
+
+use crate::auth;
+use crate::config::{Endpoints, NodeConfig, StoredSession};
+
+/// sACN keepalive: receivers time a source out after ~2.5s of silence.
+const KEEPALIVE: Duration = Duration::from_secs(1);
+/// Trailing-edge coalescing for the retained state echo (≤5 Hz).
+const ECHO_WINDOW: Duration = Duration::from_millis(200);
+
+pub async fn run(
+    env: Endpoints,
+    cfg: NodeConfig,
+    session: StoredSession,
+    sink: SacnSink,
+) -> Result<(), String> {
+    let mut universe = Universe::default();
+    let mut refresh_token = session.refresh_token;
+    let mut backoff_secs = 1u64;
+
+    loop {
+        // Fresh ID token every attempt; Cognito may rotate the refresh token.
+        let tokens = match auth::refresh(&env, &refresh_token).await {
+            Ok(tokens) => tokens,
+            Err(e) => {
+                log::warn!("token refresh failed ({e}); retrying in {backoff_secs}s");
+                tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                backoff_secs = (backoff_secs * 2).min(30);
+                continue;
+            }
+        };
+        if let Some(rotated) = &tokens.refresh {
+            refresh_token = rotated.clone();
+        }
+        let Some(sub) = lux_engine::auth::jwt_sub(&tokens.id) else {
+            return Err("could not read sub from the id token".into());
+        };
+
+        run_connection(
+            &env,
+            &cfg,
+            &sink,
+            &mut universe,
+            &sub,
+            tokens.id,
+            &mut backoff_secs,
+        )
+        .await;
+        tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+        backoff_secs = (backoff_secs * 2).min(30);
+    }
+}
+
+#[allow(clippy::too_many_arguments)] // one call site; a struct would be noise
+async fn run_connection(
+    env: &Endpoints,
+    cfg: &NodeConfig,
+    sink: &SacnSink,
+    universe: &mut Universe,
+    sub: &str,
+    token: String,
+    backoff_secs: &mut u64,
+) {
+    // Random per-session suffix: shares the peers' client-id prefix (the
+    // authorizer allows it) and stamps our own frames/echoes.
+    let session = Uuid::new_v4().simple().to_string()[..8].to_owned();
+    let client_id = format!("{}{}", lux_wire::nudge::client_id_prefix(sub), session);
+    let presence_topic = lux_wire::ctl::presence_topic(sub, &session);
+    let state_topic = lux_wire::ctl::state_topic(sub, &cfg.setup_id);
+    let url = format!(
+        "wss://{}/mqtt?x-amz-customauthorizer-name={}",
+        env.nudge_endpoint,
+        lux_wire::nudge::AUTHORIZER_NAME
+    );
+    let mut opts = MqttOptions::new(client_id, url, 443);
+    opts.set_keep_alive(Duration::from_secs(30));
+    opts.set_last_will(LastWill::new(
+        presence_topic.clone(),
+        Vec::<u8>::new(),
+        QoS::AtMostOnce,
+        true,
+    ));
+    opts.set_transport(Transport::Wss(TlsConfiguration::Simple {
+        ca: webpki_pem_bundle().to_vec(),
+        alpn: None,
+        client_auth: None,
+    }));
+    let header_token = token;
+    opts.set_request_modifier(move |mut request| {
+        let value = header_token.clone();
+        async move {
+            if let Ok(v) = value.parse() {
+                request.headers_mut().insert(lux_wire::nudge::TOKEN_KEY, v);
+            }
+            request
+        }
+    });
+
+    let (client, mut eventloop) = AsyncClient::new(opts, 10);
+    if let Err(e) = client
+        .subscribe(lux_wire::ctl::user_filter(sub), QoS::AtMostOnce)
+        .await
+    {
+        log::warn!("could not queue the ctl subscribe: {e}");
+        return;
+    }
+
+    let mut keepalive = tokio::time::interval(KEEPALIVE);
+    let mut echo_tick = tokio::time::interval(ECHO_WINDOW);
+    let mut echo_dirty = false;
+
+    loop {
+        tokio::select! {
+            _ = keepalive.tick() => {
+                // Continuous transmission: receivers hold our look only while
+                // we keep sending it.
+                if let Err(e) = sink.render(universe.slots()) {
+                    log::warn!("sACN render failed: {e}");
+                }
+            }
+            _ = echo_tick.tick() => {
+                if echo_dirty {
+                    echo_dirty = false;
+                    publish_state(&client, &state_topic, universe, &session).await;
+                }
+            }
+            event = eventloop.poll() => match event {
+                Ok(Event::Incoming(Packet::SubAck(_))) => {
+                    log::info!("user channel connected; applying setup {}", cfg.setup_id);
+                    *backoff_secs = 1;
+                    publish_presence(&client, &presence_topic, cfg, &session).await;
+                    // Announce our current truth for whoever is watching.
+                    publish_state(&client, &state_topic, universe, &session).await;
+                }
+                Ok(Event::Incoming(Packet::Publish(publish))) => {
+                    match route(&publish.topic, sub) {
+                        Route::Frame { setup_id } if setup_id == cfg.setup_id => {
+                            if apply_frame(&publish.payload, cfg, universe, &session) {
+                                if let Err(e) = sink.render(universe.slots()) {
+                                    log::warn!("sACN render failed: {e}");
+                                }
+                                echo_dirty = true;
+                            }
+                        }
+                        Route::State { setup_id }
+                            if setup_id == cfg.setup_id =>
+                        {
+                            // Another applier's retained truth (or a surface's
+                            // echo): seed/converge without re-echoing it.
+                            seed_from_state(&publish.payload, universe, &session, sink);
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::info!("connection error (will reconnect): {e}");
+                    if matches!(e, ConnectionError::ConnectionRefused(_)) {
+                        // Auth-shaped: the caller refreshes the token first.
+                    }
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Parse + gate + apply one ctl frame; returns whether the universe changed.
+fn apply_frame(payload: &[u8], cfg: &NodeConfig, universe: &mut Universe, session: &str) -> bool {
+    let frame: lux_wire::ctl::Frame = match serde_json::from_slice(payload) {
+        Ok(frame) => frame,
+        Err(e) => {
+            log::warn!("ignoring unreadable ctl frame: {e}");
+            return false;
+        }
+    };
+    match gate(frame, &cfg.setup_id, &cfg.setup_id, session) {
+        Some(RemoteApply::Overlay(bytes)) => {
+            universe.overlay(&bytes);
+            true
+        }
+        Some(RemoteApply::Channel { ch, val }) => match universe.set_slot(ch, val) {
+            Ok(()) => true,
+            Err(e) => {
+                log::warn!("ctl frame apply failed: {e}");
+                false
+            }
+        },
+        None => false,
+    }
+}
+
+/// Seed the universe from a retained state echo (someone else's truth).
+fn seed_from_state(payload: &[u8], universe: &mut Universe, session: &str, sink: &SacnSink) {
+    let Ok(frame) = serde_json::from_slice::<lux_wire::ctl::Frame>(payload) else {
+        return;
+    };
+    if frame.version() != lux_wire::ctl::VERSION || frame.src() == Some(session) {
+        return;
+    }
+    if let lux_wire::ctl::Frame::Buffer { buffer, .. } = frame {
+        universe.overlay(&buffer);
+        if let Err(e) = sink.render(universe.slots()) {
+            log::warn!("sACN render failed: {e}");
+        }
+        log::info!("seeded the universe from the retained state echo");
+    }
+}
+
+async fn publish_presence(
+    client: &AsyncClient,
+    topic: &str,
+    cfg: &NodeConfig,
+    session: &str,
+) -> () {
+    let name = format!(
+        "lux-node ({})",
+        gethostname::gethostname().to_string_lossy()
+    );
+    let card = lux_wire::ctl::PresenceCard::new(session.to_owned(), cfg.setup_id.clone(), name);
+    let Ok(payload) = serde_json::to_vec(&card) else {
+        return;
+    };
+    if let Err(e) = client
+        .publish(topic.to_owned(), QoS::AtMostOnce, true, payload)
+        .await
+    {
+        log::debug!("presence publish failed: {e}");
+    }
+}
+
+async fn publish_state(client: &AsyncClient, topic: &str, universe: &Universe, session: &str) {
+    let frame = lux_wire::ctl::Frame::buffer(universe.slots().to_vec()).with_src(session);
+    let Ok(payload) = serde_json::to_vec(&frame) else {
+        return;
+    };
+    if let Err(e) = client
+        .publish(topic.to_owned(), QoS::AtMostOnce, true, payload)
+        .await
+    {
+        log::debug!("state echo publish failed: {e}");
+    }
+}

--- a/crates/lux-engine/Cargo.toml
+++ b/crates/lux-engine/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "lux-engine"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# The Tauri-free DMX core shared by the desktop app and the headless node:
+# the DmxSink trait + sACN/E1.31 sender, universe overlay semantics, the
+# remote-control routing/gating decisions, and the TLS/JWT glue every
+# connection needs. Nothing in here may depend on Tauri — this crate is what
+# lets lux run on a headless Linux box.
+
+[lints]
+workspace = true
+
+[dependencies]
+lux-wire = { path = "../lux-wire" }
+serde_json.workspace = true
+log = "^0.4.33"
+uuid = { version = "1.23.4", features = ["v4"] }
+base64 = "0.22"
+webpki-root-certs = "1"
+pem = "3"

--- a/crates/lux-engine/src/auth.rs
+++ b/crates/lux-engine/src/auth.rs
@@ -1,0 +1,36 @@
+//! Token glue for the user channel.
+
+use base64::Engine;
+
+/// The `sub` claim from our own ID token's payload. Unverified base64 decode
+/// on purpose: this only *addresses* the topics we ask for — the IoT
+/// authorizer independently verifies the token and scopes the granted policy
+/// to the sub it verified, so a wrong value here can only produce a denied
+/// subscribe.
+pub fn jwt_sub(token: &str) -> Option<String> {
+    let payload = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    Some(claims.get("sub")?.as_str()?.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jwt_sub_reads_the_payload_claim() {
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"sub":"abc-123","token_use":"id"}"#);
+        let token = format!("eyJhbGciOiJSUzI1NiJ9.{payload}.sig");
+        assert_eq!(jwt_sub(&token).as_deref(), Some("abc-123"));
+    }
+
+    #[test]
+    fn jwt_sub_rejects_garbage() {
+        assert_eq!(jwt_sub("not-a-jwt"), None);
+        assert_eq!(jwt_sub("a.b.c"), None);
+    }
+}

--- a/crates/lux-engine/src/ctl.rs
+++ b/crates/lux-engine/src/ctl.rs
@@ -1,0 +1,160 @@
+//! Remote-control decisions for the user channel: where an incoming publish
+//! goes, and whether a ctl frame should be applied. Plain functions over
+//! plain types on purpose — the desktop's Tauri listener and the headless
+//! node share them unchanged.
+
+/// Where an incoming publish on the user channel goes.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Route<'t> {
+    /// The opaque nudge topic — schedule a pull (peers only; the node ignores it).
+    Nudge,
+    /// A live ctl frame addressed to one setup.
+    Frame { setup_id: &'t str },
+    /// An applier's retained state echo for one setup — reflected, never applied.
+    State { setup_id: &'t str },
+    /// A peer's retained presence card (empty payload = the peer is gone).
+    Presence { session: &'t str },
+    /// Reserved render-node config traffic.
+    Config,
+    /// Not a topic this listener expects under the granted policy.
+    Unknown,
+}
+
+/// Classify an incoming topic for the user identified by `sub`.
+pub fn route<'t>(topic: &'t str, sub: &str) -> Route<'t> {
+    if topic == lux_wire::nudge::user_topic(sub) {
+        return Route::Nudge;
+    }
+    let prefix = lux_wire::ctl::user_prefix(sub);
+    let Some(rest) = topic
+        .strip_prefix(prefix.as_str())
+        .and_then(|rest| rest.strip_prefix('/'))
+    else {
+        return Route::Unknown;
+    };
+    if let Some(setup_rest) = rest.strip_prefix("setup/") {
+        return match setup_rest.split_once('/') {
+            Some((setup_id, "frame")) => Route::Frame { setup_id },
+            Some((setup_id, "state")) => Route::State { setup_id },
+            Some((_, "config")) => Route::Config,
+            _ => Route::Unknown,
+        };
+    }
+    if let Some(session) = rest.strip_prefix("presence/") {
+        return Route::Presence { session };
+    }
+    Route::Unknown
+}
+
+/// One applicable buffer mutation extracted from a gated ctl frame.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RemoteApply {
+    Overlay(Vec<u8>),
+    Channel { ch: u16, val: u8 },
+}
+
+/// Whether this peer applies `frame`: the version must be known, the frame
+/// must not be this connection's own publish echoed back (`src` == our
+/// session), and only frames addressed to the active setup apply.
+pub fn gate(
+    frame: lux_wire::ctl::Frame,
+    frame_setup: &str,
+    active_setup: &str,
+    own_session: &str,
+) -> Option<RemoteApply> {
+    if frame.version() != lux_wire::ctl::VERSION {
+        log::debug!(
+            "dropping ctl frame with unknown version {}",
+            frame.version()
+        );
+        return None;
+    }
+    if frame.src() == Some(own_session) {
+        return None; // our own frame, already applied locally
+    }
+    if frame_setup != active_setup {
+        log::debug!("dropping ctl frame for inactive setup {frame_setup}");
+        return None;
+    }
+    match frame {
+        lux_wire::ctl::Frame::Buffer { buffer, .. } => Some(RemoteApply::Overlay(buffer)),
+        lux_wire::ctl::Frame::Channel { ch, val, .. } => Some(RemoteApply::Channel { ch, val }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lux_wire::ctl::Frame;
+
+    #[test]
+    fn route_classifies_the_user_channel() {
+        let sub = "abc-123";
+        assert_eq!(route("lux/sync/user/abc-123", sub), Route::Nudge);
+        assert_eq!(
+            route("lux/ctl/user/abc-123/setup/s-1/frame", sub),
+            Route::Frame { setup_id: "s-1" }
+        );
+        assert_eq!(
+            route("lux/ctl/user/abc-123/setup/s-1/state", sub),
+            Route::State { setup_id: "s-1" }
+        );
+        assert_eq!(
+            route("lux/ctl/user/abc-123/setup/s-1/config", sub),
+            Route::Config
+        );
+        assert_eq!(
+            route("lux/ctl/user/abc-123/presence/0a1b2c3d", sub),
+            Route::Presence {
+                session: "0a1b2c3d"
+            }
+        );
+
+        // Not ours / not a shape we know.
+        assert_eq!(route("lux/sync/user/other", sub), Route::Unknown);
+        assert_eq!(
+            route("lux/ctl/user/other/setup/s-1/frame", sub),
+            Route::Unknown
+        );
+        assert_eq!(
+            route("lux/ctl/user/abc-123/setup/s-1/verbs", sub),
+            Route::Unknown
+        );
+        assert_eq!(route("lux/ctl/user/abc-123/setup/s-1", sub), Route::Unknown);
+        assert_eq!(route("lux/ctl/user/abc-123", sub), Route::Unknown);
+        assert_eq!(route("lux/1/buffer/set", sub), Route::Unknown);
+    }
+
+    #[test]
+    fn gate_applies_only_known_versions_for_the_active_setup() {
+        let overlay = Frame::buffer(vec![1, 2, 3]);
+        assert_eq!(
+            gate(overlay, "s-1", "s-1", "me00"),
+            Some(RemoteApply::Overlay(vec![1, 2, 3]))
+        );
+        let channel = Frame::channel(10, 200);
+        assert_eq!(
+            gate(channel, "s-1", "s-1", "me00"),
+            Some(RemoteApply::Channel { ch: 10, val: 200 })
+        );
+
+        // Inactive setup → dropped.
+        assert_eq!(gate(Frame::channel(1, 1), "s-2", "s-1", "me00"), None);
+
+        // Unknown version → dropped (parse it as the reader would).
+        let future: Frame = serde_json::from_str(r#"{"v":9,"ch":1,"val":1}"#).expect("parses");
+        assert_eq!(gate(future, "s-1", "s-1", "me00"), None);
+    }
+
+    #[test]
+    fn gate_drops_our_own_frames_but_applies_other_sessions() {
+        let own = Frame::channel(1, 255).with_src("me00");
+        assert_eq!(gate(own, "s-1", "s-1", "me00"), None);
+
+        let theirs = Frame::channel(1, 255).with_src("them");
+        assert!(gate(theirs, "s-1", "s-1", "me00").is_some());
+
+        // Unstamped (e.g. CLI-published) frames apply.
+        assert!(gate(Frame::channel(1, 255), "s-1", "s-1", "me00").is_some());
+    }
+}

--- a/crates/lux-engine/src/lib.rs
+++ b/crates/lux-engine/src/lib.rs
@@ -1,0 +1,21 @@
+//! The Tauri-free DMX core shared by the desktop app and the headless node.
+//!
+//! Everything here is plain functions and plain types: the [`DmxSink`] trait
+//! and its sACN/E1.31 sender ([`sacn`]), the universe overlay semantics
+//! ([`universe`]), the remote-control routing and gating decisions ([`ctl`]),
+//! and the TLS/JWT glue every user-channel connection needs ([`tls`],
+//! [`auth`]). The desktop app wraps these in Tauri state and event plumbing;
+//! `lux-node` wraps them in a systemd-friendly binary. Nothing in this crate
+//! may depend on Tauri — that boundary is what lets lux run headless on a
+//! Linux box with no GTK/glib in the binary.
+
+pub mod auth;
+pub mod ctl;
+pub mod sacn;
+pub mod tls;
+pub mod universe;
+
+/// A DMX output: take channel bytes (slot 1 first) and push them to hardware.
+pub trait DmxSink: Send + Sync {
+    fn render(&self, channels: &[u8]) -> Result<(), String>;
+}

--- a/crates/lux-engine/src/sacn.rs
+++ b/crates/lux-engine/src/sacn.rs
@@ -10,17 +10,26 @@
 //! Multicast means we never need the node's IP address — the eDMX1 Pro (which
 //! defaults to DHCP) subscribes to the multicast group for its configured
 //! universe, so this is genuinely zero-config beyond matching the universe.
+//!
+//! Senders identify themselves with a per-process CID, a human-readable
+//! source name, and a priority (E1.31: higher priority wins outright at the
+//! receiver; equal priorities fall to the receiver's merge policy). Live
+//! surfaces transmit at the default 100; the headless node transmits slightly
+//! lower so a human hand on a fader anywhere on the LAN overrides it.
 
 use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
 use std::sync::atomic::{AtomicU8, Ordering};
 
-use super::DmxSink;
+use crate::DmxSink;
 
 /// E1.31 listens on UDP 5568 (ACN-defined).
 const SACN_PORT: u16 = 5568;
 /// Total packet length for a full 512-slot universe:
 /// root layer (38) + framing layer (77) + DMP layer (523).
 const PACKET_LEN: usize = 638;
+
+/// The E1.31 default per-packet priority; live control surfaces send this.
+pub const DEFAULT_PRIORITY: u8 = 100;
 
 /// An sACN/E1.31 multicast sender bound to a single DMX universe.
 pub struct SacnSink {
@@ -29,6 +38,10 @@ pub struct SacnSink {
     universe: u16,
     /// Sender component identifier — stable for the life of the process.
     cid: [u8; 16],
+    /// E1.31 per-packet priority (0..=200; see the module docs).
+    priority: u8,
+    /// Source name, shown by receiver tooling (64 bytes on the wire).
+    source_name: String,
     /// Per-packet sequence number; receivers use it to spot lost/old packets.
     /// Wraps 255 -> 0 naturally via `AtomicU8`.
     sequence: AtomicU8,
@@ -39,9 +52,17 @@ impl SacnSink {
     /// local NIC's IPv4), bind to it so multicast egresses that interface —
     /// needed on multi-homed machines (e.g. Wi-Fi + Ethernet) where the node
     /// hangs off a specific NIC. Otherwise bind `0.0.0.0` and let the OS route.
-    pub fn new(universe: u16, interface: Option<Ipv4Addr>) -> Result<Self, String> {
+    pub fn new(
+        universe: u16,
+        interface: Option<Ipv4Addr>,
+        priority: u8,
+        source_name: &str,
+    ) -> Result<Self, String> {
         if universe == 0 || universe > 63999 {
             return Err(format!("sACN universe {universe} out of range (1..=63999)"));
+        }
+        if priority > 200 {
+            return Err(format!("sACN priority {priority} out of range (0..=200)"));
         }
         let bind_ip = interface.unwrap_or(Ipv4Addr::UNSPECIFIED);
         let socket = UdpSocket::bind((bind_ip, 0))
@@ -53,6 +74,8 @@ impl SacnSink {
             dest: SocketAddrV4::new(group, SACN_PORT),
             universe,
             cid: *uuid::Uuid::new_v4().as_bytes(),
+            priority,
+            source_name: source_name.to_owned(),
             sequence: AtomicU8::new(0),
         })
     }
@@ -61,7 +84,14 @@ impl SacnSink {
 impl DmxSink for SacnSink {
     fn render(&self, channels: &[u8]) -> Result<(), String> {
         let seq = self.sequence.fetch_add(1, Ordering::Relaxed);
-        let packet = build_packet(&self.cid, self.universe, channels, seq);
+        let packet = build_packet(
+            &self.cid,
+            self.universe,
+            self.priority,
+            &self.source_name,
+            channels,
+            seq,
+        );
         self.socket
             .send_to(&packet, self.dest)
             .map(|_| ())
@@ -72,7 +102,14 @@ impl DmxSink for SacnSink {
 /// Build one E1.31 data packet carrying `channels` at DMX slots 1.. of
 /// `universe`. Free function (not a method) so the byte layout is testable
 /// without binding a socket. Layout follows ANSI E1.31-2018 §4.1.
-fn build_packet(cid: &[u8; 16], universe: u16, channels: &[u8], sequence: u8) -> [u8; PACKET_LEN] {
+fn build_packet(
+    cid: &[u8; 16],
+    universe: u16,
+    priority: u8,
+    source_name: &str,
+    channels: &[u8],
+    sequence: u8,
+) -> [u8; PACKET_LEN] {
     let mut p = [0u8; PACKET_LEN];
 
     // ---- Root layer (ACN root, 38 bytes) ----
@@ -86,9 +123,11 @@ fn build_packet(cid: &[u8; 16], universe: u16, channels: &[u8], sequence: u8) ->
     // ---- Framing layer (77 bytes) ----
     p[38..40].copy_from_slice(&(0x7000u16 | (PACKET_LEN as u16 - 38)).to_be_bytes()); // flags+length
     p[40..44].copy_from_slice(&2u32.to_be_bytes()); // VECTOR_E131_DATA_PACKET
-    p[44..47].copy_from_slice(b"lux"); // source name (64 bytes, null-padded)
-    p[108] = 100; // priority (0..=200, 100 = default)
-                  // [109..111] synchronization address = 0 (unused)
+    let name = source_name.as_bytes();
+    let n = name.len().min(63); // 64-byte field, null-terminated
+    p[44..44 + n].copy_from_slice(&name[..n]);
+    p[108] = priority; // 0..=200, 100 = default
+                       // [109..111] synchronization address = 0 (unused)
     p[111] = sequence;
     // [112] options = 0 (not preview, not terminated)
     p[113..115].copy_from_slice(&universe.to_be_bytes());
@@ -115,7 +154,7 @@ mod tests {
     fn packet_layout_is_e131_conformant() {
         let cid = [0xABu8; 16];
         let channels = [10u8, 20, 30, 40, 50, 60];
-        let p = build_packet(&cid, 1, &channels, 7);
+        let p = build_packet(&cid, 1, 100, "lux", &channels, 7);
 
         assert_eq!(p.len(), 638);
         // Root layer
@@ -129,10 +168,11 @@ mod tests {
         assert_eq!(p[38..40], [0x72, 0x58]); // flags(0x7) + length 600
         assert_eq!(p[40..44], [0, 0, 0, 2]); // VECTOR_E131_DATA_PACKET
         assert_eq!(p[44..47], *b"lux"); // source name
+        assert_eq!(p[47], 0); // null padding after the name
         assert_eq!(p[108], 100); // priority
         assert_eq!(p[111], 7); // sequence
         assert_eq!(p[113..115], [0, 1]); // universe 1
-        // DMP layer
+                                         // DMP layer
         assert_eq!(p[115..117], [0x72, 0x0b]); // flags(0x7) + length 523
         assert_eq!(p[117], 0x02); // VECTOR_DMP_SET_PROPERTY
         assert_eq!(p[118], 0xa1); // address & data type
@@ -144,23 +184,40 @@ mod tests {
     }
 
     #[test]
+    fn priority_and_name_are_stamped() {
+        let p = build_packet(&[0u8; 16], 1, 90, "lux-node on mini", &[], 0);
+        assert_eq!(p[108], 90);
+        assert_eq!(&p[44..60], b"lux-node on mini");
+
+        // Over-long names truncate to the 63 bytes the null-terminated field holds.
+        let long = "x".repeat(100);
+        let p = build_packet(&[0u8; 16], 1, 90, &long, &[], 0);
+        assert_eq!(p[44..107], [b'x'; 63]);
+        assert_eq!(p[107], 0);
+    }
+
+    #[test]
     fn universe_maps_to_multicast_group() {
-        let sink = SacnSink::new(1, None).unwrap();
-        assert_eq!(sink.dest, SocketAddrV4::new(Ipv4Addr::new(239, 255, 0, 1), 5568));
+        let sink = SacnSink::new(1, None, DEFAULT_PRIORITY, "lux").unwrap();
+        assert_eq!(
+            sink.dest,
+            SocketAddrV4::new(Ipv4Addr::new(239, 255, 0, 1), 5568)
+        );
         // 300 = 0x012C -> 239.255.1.44
-        let sink = SacnSink::new(300, None).unwrap();
+        let sink = SacnSink::new(300, None, DEFAULT_PRIORITY, "lux").unwrap();
         assert_eq!(sink.dest.ip(), &Ipv4Addr::new(239, 255, 1, 44));
     }
 
     #[test]
-    fn rejects_out_of_range_universe() {
-        assert!(SacnSink::new(0, None).is_err());
-        assert!(SacnSink::new(64000, None).is_err());
+    fn rejects_out_of_range_universe_and_priority() {
+        assert!(SacnSink::new(0, None, DEFAULT_PRIORITY, "lux").is_err());
+        assert!(SacnSink::new(64000, None, DEFAULT_PRIORITY, "lux").is_err());
+        assert!(SacnSink::new(1, None, 201, "lux").is_err());
     }
 
     #[test]
     fn sequence_increments_and_wraps() {
-        let sink = SacnSink::new(1, None).unwrap();
+        let sink = SacnSink::new(1, None, DEFAULT_PRIORITY, "lux").unwrap();
         // fetch_add returns the prior value; first render uses 0, then 1, 2...
         assert_eq!(sink.sequence.fetch_add(1, Ordering::Relaxed), 0);
         assert_eq!(sink.sequence.fetch_add(1, Ordering::Relaxed), 1);

--- a/crates/lux-engine/src/tls.rs
+++ b/crates/lux-engine/src/tls.rs
@@ -1,0 +1,33 @@
+//! TLS trust glue shared by every outbound connection.
+
+use std::sync::OnceLock;
+
+/// The Mozilla CA set (webpki) as a single PEM bundle, built once.
+///
+/// Platform-native root stores are unreliable across lux's targets: iOS apps
+/// can't read the system CA store at all (rustls parses zero roots and the
+/// AWS SDK aborts), and a headless Linux box may not have ca-certificates
+/// installed. Bundling the webpki roots makes TLS verification identical on
+/// every platform.
+pub fn webpki_pem_bundle() -> &'static [u8] {
+    static BUNDLE: OnceLock<Vec<u8>> = OnceLock::new();
+    BUNDLE.get_or_init(|| {
+        let mut pem = Vec::new();
+        for cert in webpki_root_certs::TLS_SERVER_ROOT_CERTS {
+            pem.extend_from_slice(
+                pem::encode(&pem::Pem::new("CERTIFICATE", cert.as_ref().to_vec())).as_bytes(),
+            );
+        }
+        pem
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn bundle_is_nonempty_pem() {
+        let bundle = super::webpki_pem_bundle();
+        assert!(bundle.starts_with(b"-----BEGIN CERTIFICATE-----"));
+        assert!(bundle.len() > 10_000);
+    }
+}

--- a/crates/lux-engine/src/universe.rs
+++ b/crates/lux-engine/src/universe.rs
@@ -1,0 +1,79 @@
+//! The DMX universe buffer and its overlay semantics.
+//!
+//! One byte per slot, exactly [`UNIVERSE_SIZE`] slots. Writes *overlay*: an
+//! incoming frame touches only the slots it carries, leaving higher slots
+//! untouched — which is what lets a 6-byte RGBAW write (a color pick, a
+//! remote frame) coexist with raw faders on slots 7..=512. These are the same
+//! semantics as the desktop's `LuxBuffer`; the node uses this plain form.
+
+/// A full DMX512 universe is 512 one-byte slots.
+pub const UNIVERSE_SIZE: usize = 512;
+
+/// A plain universe buffer with overlay semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Universe {
+    slots: [u8; UNIVERSE_SIZE],
+}
+
+impl Default for Universe {
+    fn default() -> Self {
+        Self {
+            slots: [0; UNIVERSE_SIZE],
+        }
+    }
+}
+
+impl Universe {
+    /// Overlay `incoming` onto the leading slots; higher slots keep their
+    /// values. Oversized input is truncated at the universe boundary.
+    pub fn overlay(&mut self, incoming: &[u8]) {
+        let n = incoming.len().min(UNIVERSE_SIZE);
+        self.slots[..n].copy_from_slice(&incoming[..n]);
+    }
+
+    /// Set one slot; `slot` is the 1-based DMX slot number.
+    pub fn set_slot(&mut self, slot: u16, value: u8) -> Result<(), String> {
+        let index = usize::from(slot);
+        if !(1..=UNIVERSE_SIZE).contains(&index) {
+            return Err(format!(
+                "slot {slot} out of range (expected 1..={UNIVERSE_SIZE})"
+            ));
+        }
+        self.slots[index - 1] = value;
+        Ok(())
+    }
+
+    /// The current slot values, slot 1 first.
+    pub fn slots(&self) -> &[u8; UNIVERSE_SIZE] {
+        &self.slots
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overlay_touches_only_the_leading_slots() {
+        let mut u = Universe::default();
+        u.set_slot(10, 200).unwrap();
+        u.overlay(&[1, 2, 3]);
+        assert_eq!(&u.slots()[..3], &[1, 2, 3]);
+        assert_eq!(u.slots()[9], 200); // untouched by the overlay
+
+        // Oversized input truncates instead of panicking.
+        u.overlay(&[7u8; 600]);
+        assert!(u.slots().iter().all(|&v| v == 7));
+    }
+
+    #[test]
+    fn set_slot_is_one_based_and_bounded() {
+        let mut u = Universe::default();
+        u.set_slot(1, 9).unwrap();
+        u.set_slot(512, 9).unwrap();
+        assert_eq!(u.slots()[0], 9);
+        assert_eq!(u.slots()[511], 9);
+        assert!(u.set_slot(0, 9).is_err());
+        assert!(u.set_slot(513, 9).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

The first `lux-node`: phone anywhere → lights at home, with no desktop running. Two stacked commits:

**1. `crates/lux-engine`** — the Tauri-free core extracted from the desktop: the `DmxSink` trait + sACN/E1.31 sender (now parameterized with per-sender priority and source name; the desktop still announces as `lux` at the default 100), universe overlay semantics as a plain struct, the remote-control `route`/`gate` decisions, the webpki PEM bundle, and the id-token `sub` reader. The desktop consumes them through re-exports with behavior unchanged; the moved unit tests travel to the crate.

**2. `apps/node`** — the binary:
- `lux-node login <email>`: embedded SRP sign-in (mirrors the desktop's account layer — that crate links Tauri, so the node can't import it; noted for unification); refresh token stored 0600 under the service state dir.
- `lux-node run`: outbound-only WSS through the same `lux-sync-auth` JWT authorizer as every signed-in device — zero backend changes needed. Subscribes the ctl space, gates + applies frames for its configured setup, renders to sACN at **priority 90** (surfaces send 100, so a live hand on any LAN device overrides the node per E1.31), re-renders every second (receivers drop quiet sources), seeds its buffer from the retained state echo on connect (restart persistence via the broker), announces a retained presence card (Last Will clears it — the phone's indicator shows `lux-node (<host>)`), and publishes its own coalesced state echo.
- Ships `lux-node.service` (hardened systemd unit, `StateDirectory`, restart-always), an Ubuntu runbook (`apps/node/README.md`, including never-sleep and Intel-mini auto-power-on notes), and a dispatchable `node-build` workflow producing the static musl artifact with the Lambda deploys' proven toolchain.

## Test plan

- [x] `cargo test --workspace` (engine's 13 moved+new tests; node config tests incl. embedded-endpoints parse; desktop suite green post-extraction; bindings drift guard untouched)
- [x] `cargo clippy -p lux -p lux-engine -p lux-node -- -D warnings` on host; `-p lux -p lux-engine` on `aarch64-apple-ios-sim`
- [ ] PR gate
- [ ] First `node-build` dispatch produces the artifact (first musl compile of the node)
- [ ] On the box: install per README, `login`, `run` — presence appears on the phone, phone drives the rig with the desktop closed