### PR TITLE
feat(node): self-installing binary + release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -956,3 +956,49 @@ jobs:
             -f description="Mac App Store build uploaded to TestFlight for $TAG" >/dev/null
           echo "recorded testflight-macos deployment $id ($TAG)"
 
+  # The node binary becomes a public release asset, so installing on a Linux
+  # box is a curl of releases/latest + `sudo ./lux-node install` — no Actions
+  # login to fetch an artifact. Runs after build-macos on purpose: the
+  # assetless-release resolver treats "release has assets" as "finished", so
+  # nothing may attach assets before the macOS publish does.
+  node-release:
+    needs: [release-please, build-macos]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write # upload the release asset
+    env:
+      TAG: ${{ needs.release-please.outputs.tag_name }}
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.TAG }}
+
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install musl-gcc
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: "."
+          cache-targets: "false"
+
+      - name: Build (static musl)
+        run: cargo build --release --target x86_64-unknown-linux-musl -p lux-node
+
+      - name: Upload as a release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cp target/x86_64-unknown-linux-musl/release/lux-node lux-node-x86_64-linux
+          gh release upload "$TAG" lux-node-x86_64-linux --clobber
+          echo "uploaded lux-node-x86_64-linux to $TAG"

--- a/apps/node/README.md
+++ b/apps/node/README.md
@@ -4,41 +4,19 @@ Headless lux for an always-on Linux box: it signs into your lux account, holds t
 
 It transmits at E1.31 priority 90 (surfaces send 100), so touching a fader on any device on the LAN overrides the node until you let go.
 
-## Get the binary
-
-Run the **node-build** workflow (Actions → node-build → Run workflow) and download the `lux-node-x86_64-linux` artifact, or build from a checkout:
+## Install
 
 ```bash
-cargo build --release --target x86_64-unknown-linux-musl -p lux-node
+curl -fsSL -o lux-node https://github.com/johncarmack1984/lux/releases/latest/download/lux-node-x86_64-linux
+chmod +x lux-node
+sudo ./lux-node install
 ```
 
-## Install (Ubuntu)
+`install` does everything and is safe to re-run (it upgrades the binary and fixes whatever is missing): copies itself to `/usr/local/bin`, creates the `lux-node` system user and dirs, writes the systemd unit, prompts for the setup id + universe (only when no config exists), signs in as the service identity, enables the service, and masks sleep/suspend — pass `--keep-sleep` to skip that last part. Watch it with `journalctl -u lux-node -f`.
 
-```bash
-sudo install -m 755 lux-node /usr/local/bin/lux-node
-sudo useradd --system --home /var/lib/lux-node --shell /usr/sbin/nologin lux-node || true
-sudo mkdir -p /etc/lux-node
-sudo tee /etc/lux-node/config.json > /dev/null <<'EOF'
-{ "setupId": "<your setup uuid>", "universe": 1 }
-EOF
-sudo install -m 644 lux-node.service /etc/systemd/system/lux-node.service
+The setup id is the id of the setup this node applies — visible in the app's sync record, or ask any signed-in device. Optional keys in `/etc/lux-node/config.json`: `"interface"` (IPv4 of the NIC to egress multicast from, for multi-homed hosts) and `"priority"` (default 90).
 
-# Sign in once as the service user (stores the refresh token, 0600):
-sudo mkdir -p /var/lib/lux-node && sudo chown lux-node /var/lib/lux-node
-sudo -u lux-node XDG_CONFIG_HOME=/var/lib/lux-node lux-node login you@example.com
-
-sudo systemctl daemon-reload
-sudo systemctl enable --now lux-node
-journalctl -u lux-node -f
-```
-
-`setupId` is the id of the setup this node applies — visible in the app's sync record, or ask any signed-in device. Optional config keys: `"interface"` (IPv4 of the NIC to egress multicast from, for multi-homed hosts) and `"priority"` (default 90).
-
-## An always-on box should stay on
-
-```bash
-sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target
-```
+(No release with the asset yet, or hacking on a checkout? The **node-build** workflow's `lux-node-x86_64-linux` artifact and `cargo build --release --target x86_64-unknown-linux-musl -p lux-node` produce the same binary.)
 
 On an Intel Mac mini, also enable auto power-on after a power failure (the setpci register varies by generation — verify for the model before poking):
 

--- a/apps/node/src/install.rs
+++ b/apps/node/src/install.rs
@@ -1,0 +1,165 @@
+//! `sudo lux-node install` — the binary installs itself as a systemd service.
+//!
+//! Idempotent: every step checks before it acts, so re-running upgrades the
+//! binary in place and fixes whatever is missing. All the sysadmin choreography
+//! (service user, dirs, unit, config, login-as-the-service-identity, enable)
+//! lives here so the runbook is two commands: download, `sudo ./lux-node
+//! install`.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+use crate::auth;
+use crate::config::{self, StoredSession};
+
+const BIN_PATH: &str = "/usr/local/bin/lux-node";
+const ETC_DIR: &str = "/etc/lux-node";
+const STATE_DIR: &str = "/var/lib/lux-node";
+const UNIT_PATH: &str = "/etc/systemd/system/lux-node.service";
+const SERVICE_USER: &str = "lux-node";
+const UNIT: &str = include_str!("../lux-node.service");
+
+pub fn install(keep_sleep: bool) -> Result<(), String> {
+    if !cfg!(target_os = "linux") {
+        return Err("lux-node install targets Linux (systemd)".into());
+    }
+    if !is_root() {
+        return Err("run as root: sudo ./lux-node install".into());
+    }
+
+    // 1. The binary itself.
+    let me = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    if me != Path::new(BIN_PATH) {
+        fs::copy(&me, BIN_PATH).map_err(|e| format!("install {BIN_PATH}: {e}"))?;
+        run("chmod", &["755", BIN_PATH])?;
+        println!("installed {BIN_PATH}");
+    }
+
+    // 2. Service user + dirs.
+    if !run_ok("id", &["-u", SERVICE_USER]) {
+        run(
+            "useradd",
+            &[
+                "--system",
+                "--home",
+                STATE_DIR,
+                "--shell",
+                "/usr/sbin/nologin",
+                SERVICE_USER,
+            ],
+        )?;
+        println!("created system user {SERVICE_USER}");
+    }
+    fs::create_dir_all(ETC_DIR).map_err(|e| format!("mkdir {ETC_DIR}: {e}"))?;
+    fs::create_dir_all(STATE_DIR).map_err(|e| format!("mkdir {STATE_DIR}: {e}"))?;
+    run("chown", &["-R", SERVICE_USER, STATE_DIR])?;
+
+    // 3. Config (prompt only when absent — rerunning never clobbers).
+    let config_path = format!("{ETC_DIR}/config.json");
+    if !Path::new(&config_path).exists() {
+        let setup_id = prompt("setup id (from the app's setups)")?;
+        let universe = prompt("sACN universe [1]")?;
+        let universe: u16 = if universe.is_empty() {
+            1
+        } else {
+            universe
+                .parse()
+                .map_err(|e| format!("bad universe {universe}: {e}"))?
+        };
+        let json = serde_json::json!({ "setupId": setup_id, "universe": universe });
+        fs::write(&config_path, format!("{:#}\n", json))
+            .map_err(|e| format!("write {config_path}: {e}"))?;
+        println!("wrote {config_path}");
+    }
+
+    // 4. Unit file (embedded in the binary, so they can't drift apart).
+    fs::write(UNIT_PATH, UNIT).map_err(|e| format!("write {UNIT_PATH}: {e}"))?;
+
+    // 5. Sign in as the service identity (skip when a session already exists).
+    let session_file = format!("{STATE_DIR}/lux-node/session.json");
+    if !Path::new(&session_file).exists() {
+        let email = prompt("lux account email")?;
+        let password = rpassword::prompt_password("password: ")
+            .map_err(|e| format!("password prompt: {e}"))?;
+        let env = config::endpoints()?;
+        let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+        let tokens = runtime.block_on(auth::sign_in(&env, &email, &password))?;
+        let refresh = tokens
+            .refresh
+            .ok_or("Cognito returned no refresh token; cannot run headless")?;
+        // Write via the same path the service reads (XDG under the state dir),
+        // then hand the file to the service user.
+        std::env::set_var("XDG_CONFIG_HOME", STATE_DIR);
+        config::save_session(&StoredSession {
+            email: email.clone(),
+            refresh_token: refresh,
+        })?;
+        run("chown", &["-R", SERVICE_USER, STATE_DIR])?;
+        println!("signed in as {email}");
+    }
+
+    // 6. Enable + start.
+    run("systemctl", &["daemon-reload"])?;
+    run("systemctl", &["enable", "--now", "lux-node"])?;
+
+    // 7. An always-on box should stay on (opt out with --keep-sleep).
+    if !keep_sleep {
+        run(
+            "systemctl",
+            &[
+                "mask",
+                "sleep.target",
+                "suspend.target",
+                "hibernate.target",
+                "hybrid-sleep.target",
+            ],
+        )?;
+        println!("sleep/suspend masked (rerun with --keep-sleep to skip this)");
+    }
+
+    println!("lux-node is running. Watch it: journalctl -u lux-node -f");
+    Ok(())
+}
+
+fn is_root() -> bool {
+    run_out("id", &["-u"]).is_some_and(|out| out.trim() == "0")
+}
+
+fn prompt(label: &str) -> Result<String, String> {
+    print!("{label}: ");
+    std::io::stdout().flush().map_err(|e| e.to_string())?;
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .map_err(|e| e.to_string())?;
+    Ok(line.trim().to_owned())
+}
+
+fn run(cmd: &str, args: &[&str]) -> Result<(), String> {
+    let status = Command::new(cmd)
+        .args(args)
+        .status()
+        .map_err(|e| format!("{cmd}: {e}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("{cmd} {} failed ({status})", args.join(" ")))
+    }
+}
+
+fn run_ok(cmd: &str, args: &[&str]) -> bool {
+    Command::new(cmd)
+        .args(args)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_out(cmd: &str, args: &[&str]) -> Option<String> {
+    let out = Command::new(cmd).args(args).output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).into_owned())
+}

--- a/apps/node/src/main.rs
+++ b/apps/node/src/main.rs
@@ -1,5 +1,8 @@
 //! lux-node — headless lux for an always-on Linux box.
 //!
+//!   sudo lux-node install      one-command setup: binary, user, unit, config,
+//!                              login, enable (idempotent; --keep-sleep to
+//!                              skip masking suspend)
 //!   lux-node login <email>     sign in once; stores the refresh token (0600)
 //!   lux-node run [--config P]  hold the user channel and drive the rig
 //!
@@ -8,6 +11,7 @@
 
 mod auth;
 mod config;
+mod install;
 mod node;
 
 use std::net::Ipv4Addr;
@@ -30,6 +34,7 @@ fn main() {
 fn dispatch() -> Result<(), String> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     match args.first().map(String::as_str) {
+        Some("install") => install::install(args.iter().any(|a| a == "--keep-sleep")),
         Some("login") => {
             let email = args
                 .get(1)
@@ -39,7 +44,7 @@ fn dispatch() -> Result<(), String> {
         }
         Some("run") | None => run(config_path(&args)?),
         Some(other) => Err(format!(
-            "unknown command {other}; usage: lux-node login <email> | lux-node run [--config <path>]"
+            "unknown command {other}; usage: lux-node install | lux-node login <email> | lux-node run [--config <path>]"
         )),
     }
 }


### PR DESCRIPTION
## Summary

Installing the node was a ten-command runbook; now it's:

```bash
curl -fsSL -o lux-node https://github.com/johncarmack1984/lux/releases/latest/download/lux-node-x86_64-linux
chmod +x lux-node && sudo ./lux-node install
```

- **`lux-node install`**: copies itself to `/usr/local/bin`, creates the `lux-node` system user + dirs, writes the systemd unit (embedded in the binary via `include_str!`, so unit and binary cannot drift apart), prompts for setup id + universe only when no config exists, signs in as the service identity (session written under the state dir and chowned), `daemon-reload` + `enable --now`, and masks sleep/suspend targets with a `--keep-sleep` opt-out. **Idempotent** — every step checks before acting, so re-running upgrades the binary and repairs whatever is missing.
- **`node-release` job**: each release uploads the musl binary as a public asset. It runs `needs: build-macos` deliberately — the assetless-release resolver treats "has assets" as "finished", so nothing may attach assets before the macOS publish does; `--clobber` keeps re-runs safe (the known updater-breaker was `latest.json`'s signature, which this never touches).
- README collapses to the three commands; the Actions-artifact and from-checkout paths remain documented as fallbacks.

## Test plan

- [x] `cargo test -p lux-node`; `cargo clippy -p lux-node -- -D warnings`
- [ ] PR gate
- [ ] Next release: `lux-node-x86_64-linux` appears on the release page; `curl …/releases/latest/download/…` resolves
- [ ] On the box: `sudo ./lux-node install` end to end, then re-run to confirm idempotence