### PR TITLE
feat(node): pick the setup by name at install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,7 @@ dependencies = [
  "log",
  "lux-engine",
  "lux-wire",
+ "reqwest",
  "rpassword",
  "rumqttc",
  "rustls 0.23.41",

--- a/apps/node/Cargo.toml
+++ b/apps/node/Cargo.toml
@@ -23,6 +23,7 @@ aws-cognito-srp = "0.2.5"
 aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
 gethostname = "1.1.0"
 log = "^0.4.33"
+reqwest = { workspace = true }
 env_logger = "0.11"
 rpassword = "7"
 rumqttc = { version = "0.25", features = ["websocket"] }

--- a/apps/node/README.md
+++ b/apps/node/README.md
@@ -12,7 +12,7 @@ chmod +x lux-node
 sudo ./lux-node install
 ```
 
-`install` does everything and is safe to re-run (it upgrades the binary and fixes whatever is missing): copies itself to `/usr/local/bin`, creates the `lux-node` system user and dirs, writes the systemd unit, prompts for the setup id + universe (only when no config exists), signs in as the service identity, enables the service, and masks sleep/suspend — pass `--keep-sleep` to skip that last part. Watch it with `journalctl -u lux-node -f`.
+`install` does everything and is safe to re-run (it upgrades the binary and fixes whatever is missing): copies itself to `/usr/local/bin`, creates the `lux-node` system user and dirs, writes the systemd unit, signs in as the service identity, then lists the account's setups so you pick by name (universe comes from the record; a UUID prompt only appears if the sync API is unreachable — and only when no config exists yet), enables the service, and masks sleep/suspend — pass `--keep-sleep` to skip that last part. Watch it with `journalctl -u lux-node -f`.
 
 The setup id is the id of the setup this node applies — visible in the app's sync record, or ask any signed-in device. Optional keys in `/etc/lux-node/config.json`: `"interface"` (IPv4 of the NIC to egress multicast from, for multi-homed hosts) and `"priority"` (default 90).
 

--- a/apps/node/src/config.rs
+++ b/apps/node/src/config.rs
@@ -19,6 +19,7 @@ pub struct Endpoints {
     pub cognito_user_pool_id: String,
     pub cognito_app_client_id: String,
     pub nudge_endpoint: String,
+    pub sync_url: String,
 }
 
 pub fn endpoints() -> Result<Endpoints, String> {
@@ -131,6 +132,7 @@ mod tests {
         let e = endpoints().expect("endpoints parse");
         assert!(!e.cognito_region.is_empty());
         assert!(!e.nudge_endpoint.is_empty());
+        assert!(e.sync_url.starts_with("https://"));
     }
 
     #[test]

--- a/apps/node/src/install.rs
+++ b/apps/node/src/install.rs
@@ -13,6 +13,7 @@ use std::process::Command;
 
 use crate::auth;
 use crate::config::{self, StoredSession};
+use crate::setups;
 
 const BIN_PATH: &str = "/usr/local/bin/lux-node";
 const ETC_DIR: &str = "/etc/lux-node";
@@ -56,17 +57,53 @@ pub fn install(keep_sleep: bool) -> Result<(), String> {
     fs::create_dir_all(STATE_DIR).map_err(|e| format!("mkdir {STATE_DIR}: {e}"))?;
     run("chown", &["-R", SERVICE_USER, STATE_DIR])?;
 
-    // 3. Config (prompt only when absent — rerunning never clobbers).
+    // 3. Sign in as the service identity (reuse a stored session when one
+    //    exists) — sign-in comes before config so the setup picker below can
+    //    ask the sync API instead of making a human type a UUID.
+    let env = config::endpoints()?;
+    let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+    std::env::set_var("XDG_CONFIG_HOME", STATE_DIR);
+    let session_file = format!("{STATE_DIR}/lux-node/session.json");
+    let id_token = if Path::new(&session_file).exists() {
+        let session = config::load_session()?;
+        runtime
+            .block_on(auth::refresh(&env, &session.refresh_token))?
+            .id
+    } else {
+        let email = prompt("lux account email")?;
+        let password = rpassword::prompt_password("password: ")
+            .map_err(|e| format!("password prompt: {e}"))?;
+        let tokens = runtime.block_on(auth::sign_in(&env, &email, &password))?;
+        let refresh = tokens
+            .refresh
+            .ok_or("Cognito returned no refresh token; cannot run headless")?;
+        // Write via the same path the service reads (XDG under the state
+        // dir), then hand the file to the service user.
+        config::save_session(&StoredSession {
+            email: email.clone(),
+            refresh_token: refresh,
+        })?;
+        run("chown", &["-R", SERVICE_USER, STATE_DIR])?;
+        println!("signed in as {email}");
+        tokens.id
+    };
+
+    // 4. Config: pick the setup from the account (name + universe come from
+    //    the sync record); a UUID prompt is only the unreachable-API fallback.
+    //    Prompt only when no config exists — rerunning never clobbers.
     let config_path = format!("{ETC_DIR}/config.json");
     if !Path::new(&config_path).exists() {
-        let setup_id = prompt("setup id (from the app's setups)")?;
-        let universe = prompt("sACN universe [1]")?;
-        let universe: u16 = if universe.is_empty() {
-            1
-        } else {
-            universe
-                .parse()
-                .map_err(|e| format!("bad universe {universe}: {e}"))?
+        let (setup_id, universe) = match runtime.block_on(setups::list(&env, &id_token)) {
+            Ok(setups) if !setups.is_empty() => pick_setup(&setups)?,
+            Ok(_) => {
+                println!("no setups on this account yet — create one in the app first,");
+                println!("or enter an id by hand:");
+                prompt_manual()?
+            }
+            Err(e) => {
+                println!("could not list setups ({e}); falling back to manual entry");
+                prompt_manual()?
+            }
         };
         let json = serde_json::json!({ "setupId": setup_id, "universe": universe });
         fs::write(&config_path, format!("{:#}\n", json))
@@ -74,31 +111,8 @@ pub fn install(keep_sleep: bool) -> Result<(), String> {
         println!("wrote {config_path}");
     }
 
-    // 4. Unit file (embedded in the binary, so they can't drift apart).
+    // 5. Unit file (embedded in the binary, so they can't drift apart).
     fs::write(UNIT_PATH, UNIT).map_err(|e| format!("write {UNIT_PATH}: {e}"))?;
-
-    // 5. Sign in as the service identity (skip when a session already exists).
-    let session_file = format!("{STATE_DIR}/lux-node/session.json");
-    if !Path::new(&session_file).exists() {
-        let email = prompt("lux account email")?;
-        let password = rpassword::prompt_password("password: ")
-            .map_err(|e| format!("password prompt: {e}"))?;
-        let env = config::endpoints()?;
-        let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
-        let tokens = runtime.block_on(auth::sign_in(&env, &email, &password))?;
-        let refresh = tokens
-            .refresh
-            .ok_or("Cognito returned no refresh token; cannot run headless")?;
-        // Write via the same path the service reads (XDG under the state dir),
-        // then hand the file to the service user.
-        std::env::set_var("XDG_CONFIG_HOME", STATE_DIR);
-        config::save_session(&StoredSession {
-            email: email.clone(),
-            refresh_token: refresh,
-        })?;
-        run("chown", &["-R", SERVICE_USER, STATE_DIR])?;
-        println!("signed in as {email}");
-    }
 
     // 6. Enable + start.
     run("systemctl", &["daemon-reload"])?;
@@ -121,6 +135,42 @@ pub fn install(keep_sleep: bool) -> Result<(), String> {
 
     println!("lux-node is running. Watch it: journalctl -u lux-node -f");
     Ok(())
+}
+
+/// Numbered pick over the account's setups; returns (id, universe). The short
+/// id disambiguates same-named setups.
+fn pick_setup(setups: &[lux_wire::SetupRecord]) -> Result<(String, u16), String> {
+    println!("setups on this account:");
+    for (i, setup) in setups.iter().enumerate() {
+        let short: String = setup.id.chars().take(8).collect();
+        println!(
+            "  {}. {} — universe {} ({short})",
+            i + 1,
+            setup.name,
+            setup.universe
+        );
+    }
+    let choice = prompt(&format!("apply which setup [1-{}]", setups.len()))?;
+    let index: usize = choice
+        .parse()
+        .ok()
+        .filter(|n| (1..=setups.len()).contains(n))
+        .ok_or_else(|| format!("pick a number between 1 and {}", setups.len()))?;
+    let picked = &setups[index - 1];
+    Ok((picked.id.clone(), picked.universe))
+}
+
+fn prompt_manual() -> Result<(String, u16), String> {
+    let setup_id = prompt("setup id (from the app's setups)")?;
+    let universe = prompt("sACN universe [1]")?;
+    let universe: u16 = if universe.is_empty() {
+        1
+    } else {
+        universe
+            .parse()
+            .map_err(|e| format!("bad universe {universe}: {e}"))?
+    };
+    Ok((setup_id, universe))
 }
 
 fn is_root() -> bool {

--- a/apps/node/src/main.rs
+++ b/apps/node/src/main.rs
@@ -13,6 +13,7 @@ mod auth;
 mod config;
 mod install;
 mod node;
+mod setups;
 
 use std::net::Ipv4Addr;
 use std::path::PathBuf;

--- a/apps/node/src/setups.rs
+++ b/apps/node/src/setups.rs
@@ -1,0 +1,33 @@
+//! Read the account's setups from the sync API — the same authenticated pull
+//! the apps do — so install can offer a pick list instead of a UUID prompt.
+
+use lux_wire::{ListSetupsResponse, SetupRecord};
+
+use crate::config::Endpoints;
+use lux_engine::tls::webpki_pem_bundle;
+
+pub async fn list(env: &Endpoints, id_token: &str) -> Result<Vec<SetupRecord>, String> {
+    let certs = reqwest::Certificate::from_pem_bundle(webpki_pem_bundle())
+        .map_err(|e| format!("webpki bundle: {e}"))?;
+    let client = reqwest::Client::builder()
+        .tls_certs_only(certs)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let base = env.sync_url.trim_end_matches('/');
+    let resp = client
+        .get(format!("{base}/{}", lux_wire::SETUPS_SEGMENT))
+        .bearer_auth(id_token)
+        .send()
+        .await
+        .map_err(|e| format!("sync api unreachable: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("sync api answered {}", resp.status()));
+    }
+    let list: ListSetupsResponse = resp.json().await.map_err(|e| format!("bad reply: {e}"))?;
+    Ok(list
+        .setups
+        .into_iter()
+        .filter(|setup| !setup.deleted)
+        .collect())
+}


### PR DESCRIPTION
## Summary

The installer asked a human to type a setup UUID. Now it signs in first (or reuses the stored session), asks the sync API for the account's setups — the same authenticated `GET /setups` pull the apps do, over a webpki-pinned reqwest client (`tls_certs_only`, matching the house's bundled-roots posture) — and offers a numbered pick showing name, universe, and a short id (disambiguates same-named setups; tombstoned records filtered out). The universe is auto-filled from the picked record, so the happy path asks exactly three human things: email, password, a number. Manual UUID entry survives only as the fallback when the API is unreachable or the account has no setups yet.

## Test plan

- [x] `cargo test -p lux-node`; `cargo clippy -p lux-node -- -D warnings`
- [ ] PR gate
- [ ] On the box: `sudo ./lux-node install` shows the setups list; picking writes id + universe; rerun is still a no-op