### PR TITLE
build(release): collapse release-prep bursts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,14 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Merge bursts collapse to one rebuild: ordinary pushes share a group and
+    # the newest cancels the rest (each run regenerates the whole branch, so
+    # only the last matters). A release-PR merge gets a unique group instead —
+    # a shipping run's prep stage must never be cancellable by a push landing
+    # behind it (the downstream ship jobs hang off this job's outputs).
+    concurrency:
+      group: ${{ startsWith(github.event.head_commit.message, 'chore(main): release') && format('release-ship-{0}', github.run_id) || 'release-prep' }}
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

A burst of merges to main produced one release-branch rebuild per merge — three merges in twenty minutes meant three quiet-rebuild + gated-push cycles stacking up the release PR's timeline. The `release-please` job gains job-level concurrency:

- **Ordinary pushes** share a `release-prep` group with `cancel-in-progress`: a burst collapses to the newest run. Safe because every run regenerates the branch from main wholesale — a cancelled mid-rebuild state is fully redone by its canceller.
- **Release-PR merges** get a unique per-run group (`release-ship-<run id>`): the shipping jobs hang off this job's outputs, so its prep stage must never be cancellable by an ordinary push landing seconds behind the release merge. (Even in that worst case the assetless-release resolver would heal on the next run, but not-getting-cancelled is strictly better than healing.)
- `head_commit.message` can be null on exotic pushes; the expression then falls through to the shared group, which is the safe default.

## Test plan

- [x] Expression reviewed against push-event payload shapes; actionlint via the PR gate
- [ ] PR gate
- [ ] Next merge burst: exactly one rebuild cycle appears on the release PR