### PR TITLE
fix(release): restore the App token to release-please

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -61,10 +61,13 @@ permissions:
 # own parent (GitHub kills the job at startup; broke the v0.12.2 run).
 concurrency:
   group: ${{ github.workflow }}-gate-${{ github.ref }}
-  # (Release branches receive exactly one run-starting push per rebuild — the
-  # consolidated stamps+notes push in release.yml — so PR-cancel never fires
-  # on a release PR's history.)
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Cancel superseded runs on ordinary PRs (fast feedback), but let them finish
+  # on release-please branches: a rebuild there lands two pushes seconds apart
+  # (release-please's App-token branch rebuild, then the consolidated
+  # stamps+notes push), and cancelling the first paints a red ✗ on the
+  # superseded commit in the release PR. Finishing both keeps the history green
+  # at the cost of duplicate public-runner minutes.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--') }}
 
 jobs:
   deny:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
     # a shipping run's prep stage must never be cancellable by a push landing
     # behind it (the downstream ship jobs hang off this job's outputs).
     concurrency:
-      group: ${{ startsWith(github.event.head_commit.message, 'chore(main): release') && format('release-ship-{0}', github.run_id) || 'release-prep' }}
+      # Quoted: the ': ' inside the message literal is a nested-mapping to a
+      # plain YAML scalar (GitHub's parser tolerates it, stricter ones don't).
+      group: "${{ startsWith(github.event.head_commit.message, 'chore(main): release') && format('release-ship-{0}', github.run_id) || 'release-prep' }}"
       cancel-in-progress: true
     permissions:
       contents: write
@@ -88,18 +90,20 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
 
-      # release-please gets the DEFAULT token on purpose: its branch rebuild
-      # (force-push) and PR bookkeeping then start no workflow runs. The
-      # consolidated stamps+notes push below — made with the App token via the
-      # checkout — is the branch's single run-starting push, so each rebuild
-      # produces exactly one gate run, on the final tip: no superseded runs to
-      # cancel (red ✗ litter) and no duplicate jobs to pay for.
+      # release-please MUST use the App token: creating the GitHub release (on a
+      # release-PR merge) and opening the release PR are "not accessible by
+      # integration" for the default GITHUB_TOKEN in this repo. Its branch
+      # rebuild does then trigger a gate run, and the consolidated stamps+notes
+      # push below triggers a second — both are kept green (not cancelled) by
+      # desktop.yml's release-branch finish-both carve-out, so the timeline
+      # shows no red ✗. (Collapsing prep to a single gate run while keeping the
+      # App token is a known follow-up — see the release-pipeline memory.)
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       # The pipeline keys off observable repo state, never off the action's
       # memory of what it did (release-please publishes the release FIRST, so
@@ -160,6 +164,11 @@ jobs:
           VER="$version" perl -0pi -e 's/(<key>CFBundleShortVersionString<\/key>\s*<string>)[^<]*/$1$ENV{VER}/; s/(<key>CFBundleVersion<\/key>\s*<string>)[^<]*/$1$ENV{VER}/' "$PLIST"
           perl -0pi -e 's/\n\z//' "$PLIST"
 
+      # NOTE: with release-please back on the App token, its branch rebuild
+      # already triggers one gate run; this consolidated push triggers a
+      # second. Both finish green (desktop.yml release-branch carve-out). The
+      # push still consolidates stamps + notes into one commit, which is worth
+      # keeping regardless of the run count.
       # The store-notes draft rides the same push as the stamps (below): the
       # rebuild discarded the branch's copy, so restore a human edit from run
       # history, else draft once (the draft script is write-once).


### PR DESCRIPTION
## Summary

**Production fix — release 1.3.0 merged but never shipped.** Moving release-please to the default `GITHUB_TOKEN` (#172) broke it: creating the GitHub release on a release-PR merge, and opening the release PR, are both `Resource not accessible by integration` for the default token in this repo. So #162 squashed to main, but release-please failed before tagging — no v1.3.0 release, and every downstream ship job skipped.

- **release-please → App token** (restored). The App holds the release/PR-creation grants (this is what #84 established; 1.2.0 shipped fine on it).
- **desktop.yml release-branch finish-both carve-out** (restored, from #171): with the App token, release-please's branch rebuild triggers one gate run and the consolidated stamps+notes push triggers a second — finish-both keeps both green instead of one cancelled-red.
- **Quoted the release-please concurrency group** so the `': '` inside its `chore(main): release` literal parses as a plain scalar for strict YAML tools, not only GitHub's lenient parser.

## Recovery

#162 is merged and still labeled `autorelease: pending` (verified — no v1.3.0 tag exists), so merging this makes release-please retry that pending release and ship v1.3.0 through the full pipeline (first alias flip, first node-release asset, Phase-1 apply).

## Honest note

The 'collapse prep to a single gate run' goal (#172) is genuinely in tension with 'release-please needs the App token' — the App-token push can't be made quiet. Correctness + green wins here; the single-run optimization is a documented follow-up, not worth risking the release path for.

## Test plan

- [x] Both workflow files parse (strict YAML); token expression matches the working checkout's
- [ ] PR gate
- [ ] On merge: release-please tags + creates v1.3.0; full ship completes; release timeline stays green (no red ✗)