### PR TITLE
fix(node): make install runnable without a tty

### DIFF
--- a/apps/node/src/install.rs
+++ b/apps/node/src/install.rs
@@ -7,7 +7,7 @@
 //! install`.
 
 use std::fs;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::Path;
 use std::process::Command;
 
@@ -22,7 +22,64 @@ const UNIT_PATH: &str = "/etc/systemd/system/lux-node.service";
 const SERVICE_USER: &str = "lux-node";
 const UNIT: &str = include_str!("../lux-node.service");
 
-pub fn install(keep_sleep: bool) -> Result<(), String> {
+/// Everything the installer needs, so it can run unattended: each field has a
+/// flag and (for the two secrets-adjacent ones) an env var, and only when a
+/// value is *absent and stdin is a real terminal* does the installer prompt.
+/// A pipe or an automation harness that isn't a controlling tty therefore
+/// never wedges on a prompt — it gets a clear "pass --x / set LUX_NODE_X"
+/// error instead. (rpassword opens /dev/tty directly, so it is only ever
+/// called on the interactive path.)
+#[derive(Debug, Default)]
+pub struct Options {
+    pub email: Option<String>,
+    pub password: Option<String>,
+    pub password_stdin: bool,
+    pub setup_id: Option<String>,
+    pub setup_name: Option<String>,
+    pub universe: Option<u16>,
+    pub keep_sleep: bool,
+}
+
+impl Options {
+    /// Parse `install`'s args (after the subcommand) and the `LUX_NODE_*`
+    /// env vars. Flags: `--email`, `--password-stdin`, `--setup-id`,
+    /// `--setup <name>`, `--universe`, `--keep-sleep`.
+    pub fn parse(args: &[String]) -> Result<Self, String> {
+        let mut opts = Options {
+            email: std::env::var("LUX_NODE_EMAIL")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            password: std::env::var("LUX_NODE_PASSWORD")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            ..Default::default()
+        };
+        let mut it = args.iter();
+        while let Some(arg) = it.next() {
+            let mut value = || {
+                it.next()
+                    .cloned()
+                    .ok_or_else(|| format!("{arg} needs a value"))
+            };
+            match arg.as_str() {
+                "--email" => opts.email = Some(value()?),
+                "--password-stdin" => opts.password_stdin = true,
+                "--setup-id" => opts.setup_id = Some(value()?),
+                "--setup" => opts.setup_name = Some(value()?),
+                "--universe" => {
+                    let v = value()?;
+                    opts.universe =
+                        Some(v.parse().map_err(|e| format!("bad --universe {v}: {e}"))?);
+                }
+                "--keep-sleep" => opts.keep_sleep = true,
+                other => return Err(format!("unknown install flag {other}")),
+            }
+        }
+        Ok(opts)
+    }
+}
+
+pub fn install(opts: Options) -> Result<(), String> {
     if !cfg!(target_os = "linux") {
         return Err("lux-node install targets Linux (systemd)".into());
     }
@@ -70,9 +127,8 @@ pub fn install(keep_sleep: bool) -> Result<(), String> {
             .block_on(auth::refresh(&env, &session.refresh_token))?
             .id
     } else {
-        let email = prompt("lux account email")?;
-        let password = rpassword::prompt_password("password: ")
-            .map_err(|e| format!("password prompt: {e}"))?;
+        let email = value_or_prompt(opts.email.clone(), "lux account email", "--email")?;
+        let password = read_password(&opts)?;
         let tokens = runtime.block_on(auth::sign_in(&env, &email, &password))?;
         let refresh = tokens
             .refresh
@@ -93,21 +149,12 @@ pub fn install(keep_sleep: bool) -> Result<(), String> {
     //    Prompt only when no config exists — rerunning never clobbers.
     let config_path = format!("{ETC_DIR}/config.json");
     if !Path::new(&config_path).exists() {
-        let (setup_id, universe) = match runtime.block_on(setups::list(&env, &id_token)) {
-            Ok(setups) if !setups.is_empty() => pick_setup(&setups)?,
-            Ok(_) => {
-                println!("no setups on this account yet — create one in the app first,");
-                println!("or enter an id by hand:");
-                prompt_manual()?
-            }
-            Err(e) => {
-                println!("could not list setups ({e}); falling back to manual entry");
-                prompt_manual()?
-            }
-        };
+        let setups = runtime.block_on(setups::list(&env, &id_token));
+        let (setup_id, universe) = resolve_setup(&opts, setups)?;
         let json = serde_json::json!({ "setupId": setup_id, "universe": universe });
         fs::write(&config_path, format!("{:#}\n", json))
             .map_err(|e| format!("write {config_path}: {e}"))?;
+        println!("using setup {setup_id} on universe {universe}");
         println!("wrote {config_path}");
     }
 
@@ -119,7 +166,7 @@ pub fn install(keep_sleep: bool) -> Result<(), String> {
     run("systemctl", &["enable", "--now", "lux-node"])?;
 
     // 7. An always-on box should stay on (opt out with --keep-sleep).
-    if !keep_sleep {
+    if !opts.keep_sleep {
         run(
             "systemctl",
             &[
@@ -137,9 +184,83 @@ pub fn install(keep_sleep: bool) -> Result<(), String> {
     Ok(())
 }
 
+/// Decide which setup this node applies, from flags first, then the fetched
+/// list, then (only at a terminal) an interactive pick. `universe` prefers
+/// `--universe`, else the matched record's, else 1.
+fn resolve_setup(
+    opts: &Options,
+    setups: Result<Vec<lux_wire::SetupRecord>, String>,
+) -> Result<(String, u16), String> {
+    // Explicit id wins outright; universe from the flag, or the record if the
+    // list came back, or 1.
+    if let Some(id) = &opts.setup_id {
+        let universe = opts.universe.unwrap_or_else(|| {
+            setups
+                .as_ref()
+                .ok()
+                .and_then(|list| list.iter().find(|s| &s.id == id))
+                .map(|s| s.universe)
+                .unwrap_or(1)
+        });
+        return Ok((id.clone(), universe));
+    }
+
+    let list = match setups {
+        Ok(list) if !list.is_empty() => list,
+        Ok(_) => {
+            return Err(
+                "no setups on this account yet — create one in the app, then pass --setup-id"
+                    .into(),
+            )
+        }
+        Err(e) => {
+            return Err(format!(
+                "could not list setups ({e}); pass --setup-id <uuid> [--universe <n>] to proceed"
+            ))
+        }
+    };
+
+    // Resolve `--setup <name>` against the list (exact, case-insensitive).
+    if let Some(name) = &opts.setup_name {
+        let matches: Vec<&lux_wire::SetupRecord> = list
+            .iter()
+            .filter(|s| s.name.eq_ignore_ascii_case(name))
+            .collect();
+        return match matches.as_slice() {
+            [one] => Ok((one.id.clone(), opts.universe.unwrap_or(one.universe))),
+            [] => Err(format!("no setup named {name:?}; {}", available(&list))),
+            _ => Err(format!(
+                "{} setups named {name:?} — disambiguate with --setup-id",
+                matches.len()
+            )),
+        };
+    }
+
+    // Nothing specified: pick interactively, or explain the flag if headless.
+    if !std::io::stdin().is_terminal() {
+        return Err(format!(
+            "no setup chosen and not a terminal; pass --setup-id <uuid> or --setup <name>. {}",
+            available(&list)
+        ));
+    }
+    pick_setup(&list, opts.universe)
+}
+
+/// A one-line summary of the account's setups for error messages.
+fn available(list: &[lux_wire::SetupRecord]) -> String {
+    let names: Vec<String> = list
+        .iter()
+        .map(|s| format!("{} ({})", s.name, &s.id[..8.min(s.id.len())]))
+        .collect();
+    format!("available: {}", names.join(", "))
+}
+
 /// Numbered pick over the account's setups; returns (id, universe). The short
 /// id disambiguates same-named setups.
-fn pick_setup(setups: &[lux_wire::SetupRecord]) -> Result<(String, u16), String> {
+fn pick_setup(
+    setups: &[lux_wire::SetupRecord],
+    universe_override: Option<u16>,
+) -> Result<(String, u16), String> {
     println!("setups on this account:");
     for (i, setup) in setups.iter().enumerate() {
         let short: String = setup.id.chars().take(8).collect();
@@ -157,24 +278,141 @@ fn pick_setup(setups: &[lux_wire::SetupRecord]) -> Result<(String, u16), String>
         .filter(|n| (1..=setups.len()).contains(n))
         .ok_or_else(|| format!("pick a number between 1 and {}", setups.len()))?;
     let picked = &setups[index - 1];
-    Ok((picked.id.clone(), picked.universe))
+    Ok((
+        picked.id.clone(),
+        universe_override.unwrap_or(picked.universe),
+    ))
 }
 
-fn prompt_manual() -> Result<(String, u16), String> {
-    let setup_id = prompt("setup id (from the app's setups)")?;
-    let universe = prompt("sACN universe [1]")?;
-    let universe: u16 = if universe.is_empty() {
-        1
-    } else {
-        universe
-            .parse()
-            .map_err(|e| format!("bad universe {universe}: {e}"))?
-    };
-    Ok((setup_id, universe))
+/// A flag/env value if present, else an interactive prompt, else a clear error
+/// naming the flag to set — so a non-terminal run fails loud, never hangs.
+fn value_or_prompt(value: Option<String>, label: &str, flag: &str) -> Result<String, String> {
+    if let Some(v) = value.filter(|v| !v.is_empty()) {
+        return Ok(v);
+    }
+    if std::io::stdin().is_terminal() {
+        return prompt(label);
+    }
+    Err(format!(
+        "{label} not provided and not a terminal; pass {flag}"
+    ))
+}
+
+/// The password from `--password-stdin` / `LUX_NODE_PASSWORD` / an interactive
+/// prompt (in that order). rpassword opens /dev/tty, so it is reached only
+/// when stdin is a real terminal.
+pub fn read_password(opts: &Options) -> Result<String, String> {
+    if let Some(pw) = opts.password.clone().filter(|p| !p.is_empty()) {
+        return Ok(pw);
+    }
+    if opts.password_stdin {
+        let mut pw = String::new();
+        std::io::stdin()
+            .read_line(&mut pw)
+            .map_err(|e| format!("read password from stdin: {e}"))?;
+        return Ok(pw.trim_end_matches(['\r', '\n']).to_owned());
+    }
+    if std::io::stdin().is_terminal() {
+        return rpassword::prompt_password("password: ")
+            .map_err(|e| format!("password prompt: {e}"));
+    }
+    Err("no password: set LUX_NODE_PASSWORD, pass --password-stdin, or run in a terminal".into())
 }
 
 fn is_root() -> bool {
     run_out("id", &["-u"]).is_some_and(|out| out.trim() == "0")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(a: &[&str]) -> Vec<String> {
+        a.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn record(id: &str, name: &str, universe: u16) -> lux_wire::SetupRecord {
+        lux_wire::SetupRecord {
+            id: id.into(),
+            name: name.into(),
+            universe,
+            fixtures: serde_json::json!([]),
+            rev: 0,
+            updated_at: 0,
+            deleted: false,
+        }
+    }
+
+    #[test]
+    fn parses_flags() {
+        let o = Options::parse(&args(&[
+            "--email",
+            "a@b.com",
+            "--setup",
+            "Home",
+            "--universe",
+            "3",
+            "--keep-sleep",
+            "--password-stdin",
+        ]))
+        .unwrap();
+        assert_eq!(o.email.as_deref(), Some("a@b.com"));
+        assert_eq!(o.setup_name.as_deref(), Some("Home"));
+        assert_eq!(o.universe, Some(3));
+        assert!(o.keep_sleep);
+        assert!(o.password_stdin);
+        assert!(Options::parse(&args(&["--nope"])).is_err());
+        assert!(Options::parse(&args(&["--email"])).is_err()); // missing value
+    }
+
+    #[test]
+    fn setup_id_flag_wins_without_the_network() {
+        let o = Options {
+            setup_id: Some("abc".into()),
+            universe: Some(7),
+            ..Default::default()
+        };
+        // Even with the list unavailable, an explicit id resolves.
+        assert_eq!(
+            resolve_setup(&o, Err("offline".into())).unwrap(),
+            ("abc".into(), 7)
+        );
+        // Universe falls back to the matched record when not given.
+        let o = Options {
+            setup_id: Some("abc".into()),
+            ..Default::default()
+        };
+        let list = Ok(vec![record("abc", "Home", 4)]);
+        assert_eq!(resolve_setup(&o, list).unwrap(), ("abc".into(), 4));
+    }
+
+    #[test]
+    fn setup_name_resolves_and_flags_ambiguity() {
+        let list = vec![record("id1", "Home", 1), record("id2", "Home", 1)];
+        let one = Options {
+            setup_name: Some("home".into()), // case-insensitive
+            ..Default::default()
+        };
+        // Two "Home"s → refuse rather than guess.
+        assert!(resolve_setup(&one, Ok(list.clone())).is_err());
+
+        let unique = vec![record("id1", "Church", 2)];
+        let o = Options {
+            setup_name: Some("Church".into()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_setup(&o, Ok(unique)).unwrap(), ("id1".into(), 2));
+    }
+
+    #[test]
+    fn no_setup_and_no_terminal_errors_instead_of_prompting() {
+        // Nothing specified + a list present: the terminal check gates the
+        // picker, so under `cargo test` (no tty) this must be an error, never
+        // a hang.
+        let o = Options::default();
+        let err = resolve_setup(&o, Ok(vec![record("id1", "Home", 1)])).unwrap_err();
+        assert!(err.contains("--setup-id") || err.contains("--setup"));
+    }
 }
 
 fn prompt(label: &str) -> Result<String, String> {

--- a/apps/node/src/main.rs
+++ b/apps/node/src/main.rs
@@ -35,18 +35,31 @@ fn main() {
 fn dispatch() -> Result<(), String> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     match args.first().map(String::as_str) {
-        Some("install") => install::install(args.iter().any(|a| a == "--keep-sleep")),
+        Some("install") => install::install(install::Options::parse(&args[1..])?),
         Some("login") => {
-            let email = args
-                .get(1)
-                .ok_or("usage: lux-node login <email>")?
-                .to_owned();
-            login(email)
+            // `login [<email>] [--password-stdin]` — email positional or
+            // --email / $LUX_NODE_EMAIL, password interactive or non-interactive
+            // (same rules as install), so login scripts too.
+            let opts = install::Options::parse(&login_args(&args[1..]))?;
+            login(opts)
         }
         Some("run") | None => run(config_path(&args)?),
         Some(other) => Err(format!(
-            "unknown command {other}; usage: lux-node install | lux-node login <email> | lux-node run [--config <path>]"
+            "unknown command {other}; usage: lux-node install | lux-node login [<email>] | lux-node run [--config <path>]"
         )),
+    }
+}
+
+/// Let `login <email>` keep its positional-email ergonomics while reusing the
+/// installer's option parser: a bare first arg becomes `--email <it>`.
+fn login_args(args: &[String]) -> Vec<String> {
+    match args.first() {
+        Some(first) if !first.starts_with("--") => {
+            let mut rest = vec!["--email".to_owned(), first.clone()];
+            rest.extend_from_slice(&args[1..]);
+            rest
+        }
+        _ => args.to_vec(),
     }
 }
 
@@ -60,10 +73,14 @@ fn config_path(args: &[String]) -> Result<PathBuf, String> {
     config::default_config_path()
 }
 
-fn login(email: String) -> Result<(), String> {
+fn login(opts: install::Options) -> Result<(), String> {
     let env = config::endpoints()?;
-    let password =
-        rpassword::prompt_password("password: ").map_err(|e| format!("password prompt: {e}"))?;
+    let email = opts
+        .email
+        .clone()
+        .filter(|e| !e.is_empty())
+        .ok_or("usage: lux-node login <email> (or --email / $LUX_NODE_EMAIL)")?;
+    let password = install::read_password(&opts)?;
     let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
     let tokens = runtime.block_on(auth::sign_in(&env, &email, &password))?;
     let refresh = tokens


### PR DESCRIPTION
## Summary

`lux-node install` assumed a human at a terminal: it prompted via stdin and `rpassword::prompt_password` (which opens `/dev/tty` directly). Any non-terminal caller — a provisioning script, config management, an automation agent — hung on the prompt or failed outright. Now the whole flow is scriptable:

- **Every input has a non-interactive source**: `--email` (`$LUX_NODE_EMAIL`), password via `--password-stdin` or `$LUX_NODE_PASSWORD`, `--setup <name>` or `--setup-id <uuid>`, `--universe <n>`, `--keep-sleep`. `login` honors the same.
- **Prompts are terminal-gated**: a value is prompted only when it's both unset *and* `stdin.is_terminal()`. Otherwise the installer returns a clear error naming the flag to set — it never wedges waiting on a pipe. `rpassword` is reached only on the interactive path.
- **`--setup <name>`** resolves against the account's setups (case-insensitive, exact); duplicate names refuse rather than guess (use `--setup-id`). The interactive numbered picker remains, but only at a terminal.
- Parser and resolver are unit-tested with no tty (6 tests): flag parsing, id-wins-offline, name resolution + ambiguity, and the headless-no-prompt guard.

Interactive `sudo ./lux-node install` at a real terminal is unchanged.

## Test plan

- [x] `cargo test -p lux-node` (6); `cargo clippy -p lux-node -- -D warnings`
- [ ] PR gate
- [ ] Unattended: `echo $PW | sudo ./lux-node install --email … --setup-id … --password-stdin` completes with no tty; missing-value case errors instead of hanging