### PR TITLE
fix(infra): grant the terraform-apply role lambda alias actions

### DIFF
--- a/infra/terraform-ci.tf
+++ b/infra/terraform-ci.tf
@@ -130,6 +130,10 @@ resource "aws_iam_role_policy" "terraform_apply" {
           "lambda:CreateFunction", "lambda:GetFunction", "lambda:GetFunctionConfiguration",
           "lambda:UpdateFunctionCode", "lambda:UpdateFunctionConfiguration", "lambda:DeleteFunction",
           "lambda:ListVersionsByFunction", "lambda:AddPermission", "lambda:RemovePermission",
+          # The IoT authorizer's `live` alias (blue/green Phase 1, nudge.tf):
+          # terraform creates + owns the alias, the deploy pipeline flips it.
+          "lambda:CreateAlias", "lambda:GetAlias", "lambda:UpdateAlias",
+          "lambda:DeleteAlias", "lambda:ListAliases",
           "lambda:GetPolicy", "lambda:CreateFunctionUrlConfig", "lambda:GetFunctionUrlConfig",
           "lambda:UpdateFunctionUrlConfig", "lambda:DeleteFunctionUrlConfig",
           "lambda:TagResource", "lambda:UntagResource", "lambda:ListTags",


### PR DESCRIPTION
## Summary

Blue/green Phase 1 (#168) added the IoT authorizer's `live` alias to `nudge.tf` and granted the **deploy** role the runtime flip actions — but never gave the **terraform-apply** role, which creates and owns the alias, `lambda:CreateAlias`. The first 1.3.0 apply failed `AccessDeniedException` on exactly that, blocking deploy-lambdas and everything downstream.

Adds `CreateAlias/GetAlias/UpdateAlias/DeleteAlias/ListAliases` to the role's `ManageLuxLambda` statement (`AddPermission` was already there for the qualified invoke permission). Targeted plan is one in-place policy update, nothing else.

## Note

This should have been in #168. Because IAM role-policy changes don't take effect within the same assume-role session, granting the live role needs a one-time out-of-band `terraform apply -target=aws_iam_role_policy.terraform_apply` (admin creds) before the release re-run can create the alias.

## Test plan

- [x] `terraform plan -target=aws_iam_role_policy.terraform_apply` = 1 in-place change (adds the alias actions)
- [ ] PR gate
- [ ] After the grant + a consistent v1.3.0 tag: terraform-apply creates the alias, ship completes