### PR TITLE
build(release): stamp Cargo.lock + Info.plist via release-please extra-files

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,22 @@
       "extra-files": [
         { "type": "json", "path": "apps/desktop/package.json", "jsonpath": "$.version" },
         { "type": "json", "path": "apps/desktop/src-tauri/tauri.conf.json", "jsonpath": "$.version" },
-        "apps/desktop/src-tauri/Cargo.toml"
+        "apps/desktop/src-tauri/Cargo.toml",
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name.value=='lux')].version"
+        },
+        {
+          "type": "xml",
+          "path": "apps/desktop/src-tauri/gen/apple/lux_iOS/Info.plist",
+          "xpath": "//key[text()='CFBundleShortVersionString']/following-sibling::string[1]"
+        },
+        {
+          "type": "xml",
+          "path": "apps/desktop/src-tauri/gen/apple/lux_iOS/Info.plist",
+          "xpath": "//key[text()='CFBundleVersion']/following-sibling::string[1]"
+        }
       ]
     }
   }


### PR DESCRIPTION
The `lux` version line in `Cargo.lock` and the two CFBundle version strings in the committed iOS `Info.plist` are derived stamps that `release.yml` currently syncs onto the release branch with a scripted push after every branch rebuild. This declares them as release-please `extra-files` so they are stamped inside the release-PR commit itself.

Updater behavior, verified against the current files with the release-please library:

- `toml`: the tagged span-preserving parser edits only the `version` line of the `[[package]]` entry whose `name` is `lux` — no reformatting, trailing newline intact. The parser wraps scalars as `{start, end, value}`, which is why the filter compares `@.name.value`.
- `xml` (two entries, one per CFBundle key): rewrites only the matching `<string>` value and preserves the plist byte-for-byte otherwise, including its no-trailing-newline layout (tauri writes the file without one).

The workflow's stamp-sync step is untouched and degrades to a no-op when the stamps already match; it comes out once a release demonstrates the extra-files path end to end. Verification on the next release-PR rebuild: the release-please commit should carry both stamp changes, and the "sync version stamps" push should log nothing to sync.