### PR TITLE
fix(release): unstick the stamp tripwire and approve held gate runs

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -12,12 +12,12 @@ name: desktop
 
 on:
   pull_request:
-    # release-please's branches are excluded: their pushes are GITHUB_TOKEN-
-    # authored, so runs here could only ever sit "action_required" awaiting
-    # manual approval — and the release pipeline re-runs this exact gate at
-    # the tag (release.yml's ci job) before anything ships, so the machine
-    # PR carries no checks by design.
-    branches-ignore: ["release-please--**"]
+    # Release-please's GITHUB_TOKEN branch pushes land this workflow's runs in
+    # the action_required state (GitHub holds runs for events its own token
+    # caused, and pull_request branch filters can only match the BASE branch,
+    # so the machine branches cannot be excluded here). release.yml approves
+    # those held runs right after pushing; the authoritative gate is its ci
+    # job at the release tag either way.
     paths:
       - 'apps/desktop/**'
       - 'apps/site/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
     permissions:
       contents: write # release-please's branch pushes + the tag/release cut below
       pull-requests: write # release-please's PR bookkeeping + the label flip
+      actions: write # approve the release branch's held gate runs
     outputs:
       release_created: ${{ steps.effective.outputs.release_created }}
       tag_name: ${{ steps.effective.outputs.tag_name }}
@@ -74,13 +75,45 @@ jobs:
             exit 0
           fi
           git fetch --depth=1 origin "$BRANCH"
-          tree="origin/$BRANCH"
+          # FETCH_HEAD, not origin/<branch>: it exists regardless of the
+          # checkout's fetch refspec. The awk matchers scan to end of stream —
+          # an early exit SIGPIPEs git show under pipefail (exit 141).
+          tree=FETCH_HEAD
           want=$(git show "$tree:.release-please-manifest.json" | jq -r '."."')
-          lock=$(git show "$tree:Cargo.lock" | awk '/^name = "lux"$/ {getline; sub(/^version = "/, ""); sub(/"$/, ""); print; exit}')
-          plist=$(git show "$tree:apps/desktop/src-tauri/gen/apple/lux_iOS/Info.plist" | awk '/CFBundleShortVersionString/ {getline; gsub(/[[:space:]]*<\/?string>/, ""); print; exit}')
+          lock=$(git show "$tree:Cargo.lock" | awk '/^name = "lux"$/ {getline; sub(/^version = "/, ""); sub(/"$/, ""); print}')
+          plist=$(git show "$tree:apps/desktop/src-tauri/gen/apple/lux_iOS/Info.plist" | awk '/CFBundleShortVersionString/ {getline; gsub(/[[:space:]]*<\/?string>/, ""); print}')
           echo "release branch wants $want (Cargo.lock: $lock, Info.plist: $plist)"
           [ "$lock" = "$want" ] && [ "$plist" = "$want" ] \
             || { echo "::error::release branch stamps out of sync with $want — check the extra-files updaters in release-please-config.json"; exit 1; }
+
+      # A GITHUB_TOKEN branch push creates the release PR's gate run in the
+      # action_required state (GitHub holds workflow runs for events the token
+      # caused; pull_request branch filters can't exclude a head branch, they
+      # match the base). Approve those held runs so the release PR carries a
+      # live green gate instead of an "awaiting approval" banner. Fail-soft:
+      # if the token may not approve its own event's runs, the held run is
+      # cosmetic — merging is not blocked and the authoritative gate is the
+      # ci job at the tag.
+      - name: Approve the release branch's held gate runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: release-please--branches--main--components--lux
+        run: |
+          if ! git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
+            echo "no open release branch; nothing to approve"
+            exit 0
+          fi
+          ids=""
+          for i in 1 2 3; do
+            sleep 10
+            ids=$(gh run list --branch "$BRANCH" --status action_required --limit 10 --json databaseId --jq '.[].databaseId')
+            [ -n "$ids" ] && break
+          done
+          for id in $ids; do
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/$id/approve" >/dev/null \
+              && echo "approved held run $id" \
+              || echo "::warning::could not approve held run $id (cosmetic; the tag gate still rules)"
+          done
 
       # The pipeline keys off observable repo state, never a tool's memory of
       # what it did. The manifest names the current version; from there: no


### PR DESCRIPTION
Two fixes from the first run of the App-free release job (its release-please half worked: the branch regenerated as a single stamped commit on `github.token`, so #182 now carries both stamps inside the generated commit with no follow-up pushes).

- **Tripwire exit 141**: the step fetched the release branch and then read `origin/<branch>` — a spelling that depends on the checkout's fetch refspec — and its awk matchers exited at first match, which SIGPIPEs `git show` under `pipefail`. It now reads `FETCH_HEAD` and scans to end of stream. Verified against the live branch: `want=1.3.2 lock=1.3.2 plist=1.3.2`.
- **Held gate runs**: `branches-ignore` on desktop.yml's `pull_request` trigger was ineffective — those filters match the PR's *base* branch, so the rebuild's gate run was created anyway, in the `action_required` state (GitHub holds runs for events caused by its own token). The release job now approves the held runs right after the rebuild, giving the release PR a live green gate instead of an "awaiting approval" banner. The approval is fail-soft: if the token may not approve its own event's runs, the held run stays cosmetic — merging is not blocked (no required checks) and the authoritative gate remains the `ci` job at the release tag.

The push run for this merge doubles as the test: the tripwire must pass against the rebuilt #182 branch, and the approve step should pick up both the fresh held run and the one left by the previous rebuild.