### PR TITLE
chore(infra): drop the release-bot App key from the signing role

### DIFF
--- a/infra/release-signing.tf
+++ b/infra/release-signing.tf
@@ -3,8 +3,7 @@
 # live only in AWS Secrets Manager (created out-of-band): the Tauri updater
 # signing key, the Apple signing material (Developer ID + ASC API key), the
 # Mac App Store signing material (Apple Distribution + installer certs and the
-# provisioning profile), and the release-bot GitHub App private key
-# (release-please mints an installation token from it).
+# provisioning profile), and the Anthropic key the store-notes draft uses.
 
 data "aws_iam_openid_connect_provider" "github" {
   url = "https://token.actions.githubusercontent.com"
@@ -18,17 +17,12 @@ data "aws_secretsmanager_secret" "apple_signing" {
   name = "lux/apple-signing"
 }
 
-data "aws_secretsmanager_secret" "release_app_private_key" {
-  name = "lux/release-app-private-key"
-}
-
 data "aws_secretsmanager_secret" "mas_signing" {
   name = "lux/mas-signing"
 }
 
-# The release-please job drafts the App Store notes onto the release branch
-# (one consolidated push with the version stamps), so this main-pinned role
-# reads the Anthropic key.
+# The store-notes job drafts the App Store notes at ship time (release.yml),
+# so this main-pinned role reads the Anthropic key.
 data "aws_secretsmanager_secret" "anthropic_api_key" {
   name = "lux/anthropic-api-key"
 }
@@ -66,7 +60,6 @@ resource "aws_iam_role_policy" "read_updater_signing_key" {
       Resource = [
         data.aws_secretsmanager_secret.updater_signing_key.arn,
         data.aws_secretsmanager_secret.apple_signing.arn,
-        data.aws_secretsmanager_secret.release_app_private_key.arn,
         data.aws_secretsmanager_secret.mas_signing.arn,
         data.aws_secretsmanager_secret.anthropic_api_key.arn,
       ]


### PR DESCRIPTION
Final infra step of the GitHub App removal: nothing in CI reads `lux/release-app-private-key` after #184, so the data source and the read grant on `lux-release-signing` come out.

**Hold until a release has shipped clean end to end on the App-free pipeline** — while this is unmerged, reverting #184 restores the App-token path intact (the key stays readable). Merging this rides the apply of the release after the verification release.

Companion manual steps once verified (outside this PR): delete the `john-carmack-bot` GitHub App, the `RELEASE_APP_CLIENT_ID` repo variable, and the `lux/release-app-private-key` secret in Secrets Manager.