### PR TITLE
fix(authorizer): grant iot:RetainPublish for the ctl space

### DIFF
--- a/services/iot-authorizer/src/main.rs
+++ b/services/iot-authorizer/src/main.rs
@@ -162,7 +162,10 @@ fn allow(region: &str, account: &str, sub: &str) -> Value {
                 },
                 {
                     "Effect": "Allow",
-                    "Action": "iot:Publish",
+                    // RetainPublish too: presence cards, state echoes, and the
+                    // connection's Last Will are all retained — and IoT refuses
+                    // the CONNECT itself when the retained will isn't covered.
+                    "Action": ["iot:Publish", "iot:RetainPublish"],
                     "Resource": format!("{prefix}:topic/{ctl_prefix}/*"),
                 },
             ],
@@ -280,8 +283,12 @@ mod tests {
         );
 
         // The one genuinely new capability: publish, ctl space only — nothing
-        // grants publish on the nudge topic or anyone else's prefix.
-        assert_eq!(statements[3]["Action"], "iot:Publish");
+        // grants publish on the nudge topic or anyone else's prefix. Retained
+        // publish rides along for the presence card, state echo, and the will.
+        assert_eq!(
+            statements[3]["Action"],
+            json!(["iot:Publish", "iot:RetainPublish"])
+        );
         assert_eq!(
             statements[3]["Resource"],
             arn("topic/lux/ctl/user/abc-123/*").as_str()


### PR DESCRIPTION
## Root cause of the dead realtime channel

The authorizer's policy grants `iot:Publish` on `topic/lux/ctl/user/<sub>/*` — but the presence card, the state echo, and the connection's **Last Will** are all **retained** publishes, and AWS IoT requires `iot:RetainPublish` for those. Critically, IoT evaluates the retained will **at CONNECT time** and closes the connection when it isn't covered — before any MQTT error reaches the client and without the authorizer logging anything (the allow path is silent).

Net effect: every #173-era client (lux-node, desktop, iOS) authenticates successfully and is then dropped at CONNECT, presenting as `Connection closed by peer abruptly` on infinite retry. HTTP sync masks it.

## Evidence (probed against the live endpoint)

| CONNECT variant | Result |
|---|---|
| no will | ✅ ACCEPTED |
| non-retained will, same topic | ✅ ACCEPTED |
| **retained will (what every client sends)** | ❌ closed by IoT |
| + SUBSCRIBE `lux/ctl/user/<sub>/#` | ✅ GRANTED |
| client id outside the allowed prefix (control) | ❌ closed |

A direct `lambda invoke` of `lux-iot-authorizer:live` with a fresh real ID token returns `isAuthenticated: true` with the expected policy — the verifier and Cognito wiring are healthy; only the retain permission is missing.

## Fix

Extend the ctl-space publish statement to `["iot:Publish", "iot:RetainPublish"]` (same resource scope — still nothing on the nudge topic or other users' prefixes). Test updated to match.

Ships with the next release cut (deploy-lambdas flips the authorizer alias); lux-node on the mini is retrying every 30s and will connect on its own the moment the new version is live.