### PR TITLE
chore(deps): pin specta rc.26 and ttipc from git revs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1823,7 +1823,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2147,7 +2147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3056,7 +3056,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3997,7 +3997,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4471,7 +4471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5355,7 +5355,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5434,7 +5434,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6020,7 +6020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6073,9 +6073,8 @@ dependencies = [
 
 [[package]]
 name = "specta"
-version = "2.0.0-rc.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f9a30cbcbb7011f1da7d73483983bf838af123883e45f2b36ed76328df9c50"
+version = "2.0.0-rc.26"
+source = "git+https://github.com/specta-rs/specta?rev=ef21f0544e153b944ff5d1b3afd20472afcf760c#ef21f0544e153b944ff5d1b3afd20472afcf760c"
 dependencies = [
  "rustc_version",
  "specta-macros",
@@ -6083,9 +6082,8 @@ dependencies = [
 
 [[package]]
 name = "specta-macros"
-version = "2.0.0-rc.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce14957ecc2897f1f848b8255b6531d13ddf49cbcf506b7c2c9fb1d005593bb"
+version = "2.0.0-rc.26"
+source = "git+https://github.com/specta-rs/specta?rev=ef21f0544e153b944ff5d1b3afd20472afcf760c#ef21f0544e153b944ff5d1b3afd20472afcf760c"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -6095,9 +6093,8 @@ dependencies = [
 
 [[package]]
 name = "specta-serde"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8a72b755ddb8949fd8f17c5db43f0e8a806ea587d9bc602ee3f73240c00029"
+version = "0.0.13"
+source = "git+https://github.com/specta-rs/specta?rev=ef21f0544e153b944ff5d1b3afd20472afcf760c#ef21f0544e153b944ff5d1b3afd20472afcf760c"
 dependencies = [
  "specta",
  "specta-macros",
@@ -6105,9 +6102,8 @@ dependencies = [
 
 [[package]]
 name = "specta-typescript"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639404ee95557f2f8b7e4cb773ffefd45304c7ab8ba21ac83b69051595e083c0"
+version = "0.0.13"
+source = "git+https://github.com/specta-rs/specta?rev=ef21f0544e153b944ff5d1b3afd20472afcf760c#ef21f0544e153b944ff5d1b3afd20472afcf760c"
 dependencies = [
  "specta",
 ]
@@ -6630,8 +6626,7 @@ dependencies = [
 [[package]]
 name = "tauri-typed-ipc"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bccc4bdfe2d4e6eac37c8f7578b3a4d98af4f63866590fa239811d668f269e1e"
+source = "git+https://github.com/johncarmack1984/tauri-typed-ipc?rev=f9f4e74a38accb5a087d6ee3b72dbdc9d056a87d#f9f4e74a38accb5a087d6ee3b72dbdc9d056a87d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6646,8 +6641,7 @@ dependencies = [
 [[package]]
 name = "tauri-typed-ipc-macros"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10513fcb8c2c9f59ba074d26439994118ed7e24d2fb6f03b016d403dd3ae1979"
+source = "git+https://github.com/johncarmack1984/tauri-typed-ipc?rev=f9f4e74a38accb5a087d6ee3b72dbdc9d056a87d#f9f4e74a38accb5a087d6ee3b72dbdc9d056a87d"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -6717,7 +6711,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7153,7 +7147,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7201,7 +7195,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7625,7 +7619,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,13 @@ strip = true
 # unaffected. Upstream PR: gtk-rs/gtk-rs-core#1991. Must be at the workspace root.
 [patch.crates-io]
 glib = { git = "https://github.com/johncarmack1984/gtk-rs-core", branch = "lux/glib-0.18-patch" }
+
+# specta 2.0.0-rc.26 and the 0.0.13 exporters are merged on specta main but unpublished
+# (crates.io still serves rc.25 / 0.0.12), and ttipc's crates.io release exact-pins rc.25 --
+# resolving it from crates.io would split the graph into two spectas. Pin all of them to
+# revs until the releases land, then drop these entries (ttipc rev = its specta-rc26 branch,
+# which carries main's async-injection support as of 0.1.6).
+specta = { git = "https://github.com/specta-rs/specta", rev = "ef21f0544e153b944ff5d1b3afd20472afcf760c" }
+specta-serde = { git = "https://github.com/specta-rs/specta", rev = "ef21f0544e153b944ff5d1b3afd20472afcf760c" }
+specta-typescript = { git = "https://github.com/specta-rs/specta", rev = "ef21f0544e153b944ff5d1b3afd20472afcf760c" }
+tauri-typed-ipc = { git = "https://github.com/johncarmack1984/tauri-typed-ipc", rev = "f9f4e74a38accb5a087d6ee3b72dbdc9d056a87d" }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -45,7 +45,7 @@ log = "^0.4.33"
 serde_json.workspace = true
 serde.workspace = true
 strum = { version = "0.28.0", features = ["derive"] }
-specta = { version = "=2.0.0-rc.25", features = ["derive"] }
+specta = { version = "=2.0.0-rc.26", features = ["derive"] }
 strum_macros = "0.28.0"
 tauri = { version = "~2.11", features = [
     "isolation",


### PR DESCRIPTION
crates.io still serves specta rc.25 and ttipc's published release exact-pins it; resolving from crates.io would split the graph into two spectas. Pinned revs until the releases land. Generated bindings.ts is unchanged (drift test passes untouched).