### PR TITLE
fix(desktop): register tauri-plugin-positioner and forward tray events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tauri-plugin-positioner",
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
@@ -6386,6 +6387,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "tauri-plugin-positioner"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a285cd1dca2bef15e45a591694050773d0beadbe133a55779d5251d08fa2396"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -90,6 +90,7 @@ gethostname = "1.1.0"
 enttecopendmx = "0.1.1"
 libftd2xx = { version = "0.33.1", features = ["static"] }
 tauri = { version = "~2.11", features = ["tray-icon"] }
+tauri-plugin-positioner = { version = "2", features = ["tray-icon"] }
 tauri-plugin-updater = "2"
 
 # keyring's Apple Keychain backend requires the data-protection Keychain API on

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "core:menu:default",
     "core:tray:default",
     "shell:allow-open",
+    "positioner:default",
     "log:default",
     "core:webview:default",
     "shell:default",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -78,6 +78,11 @@ pub async fn run() {
         .manage(DmxOutput::default())
         .manage(cloud::LuxSync::default())
         .manage(nudge::LuxNudge::default());
+    // Window positioning relative to monitors and the tray, backing the
+    // frontend's @tauri-apps/plugin-positioner API. Desktop-only: mobile has
+    // no movable windows and no tray.
+    #[cfg(desktop)]
+    let builder = builder.plugin(tauri_plugin_positioner::init());
     // The self-updater is desktop-only (mobile updates ship through the App
     // Store), so add its plugin only when building for desktop — and not in
     // the Mac App Store flavor (`mas` feature), where the store owns updates

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -24,6 +24,11 @@ pub fn build<R: Runtime>(app: &App<R>) -> tauri::Result<()> {
         .icon(Image::from_bytes(include_bytes!("../icons/tray.png"))?)
         .icon_as_template(true)
         .menu(&menu)
+        .on_tray_icon_event(|tray, event| {
+            // Feed raw tray events to the positioner plugin so its Tray*
+            // positions know the icon's rect (it caches the last event).
+            tauri_plugin_positioner::on_tray_event(tray.app_handle(), &event);
+        })
         .on_menu_event(move |app, event| match event.id.as_ref() {
             "quit" => app.exit(0),
             "rescan" => devices::rescan(app),


### PR DESCRIPTION
The frontend has shipped @tauri-apps/plugin-positioner without the Rust side ever registering the plugin, so any positioner call fails at runtime. This wires the crate into the desktop-only dependency table, inits the plugin, forwards tray icon events so the Tray* positions know the icon rect, and grants positioner:default.