### PR TITLE
fix(release): refuse dispatch rebuilds of served macOS artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,6 +302,24 @@ jobs:
         with:
           ref: ${{ env.TAG }}
 
+      # A dispatch rebuild of a tag whose macOS artifacts already shipped would
+      # re-sign and replace the served .dmg + latest.json — fresh signatures
+      # for a tag existing installs already fetched, the known updater-breaker.
+      # Refuse loudly: partial rebuilds belong to `gh run rerun <id> --failed`
+      # on the original release run (it never re-runs succeeded jobs), and a
+      # deliberate macOS rebuild means deleting the release's macOS assets
+      # first. Assetless tags (a run that died before publishing) pass.
+      - name: Refuse to rebuild served macOS artifacts (dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$TAG" --json assets --jq '.assets[].name' | grep -qE '\.dmg$|^latest\.json$'; then
+            echo "::error::$TAG already serves macOS artifacts — use 'gh run rerun <run-id> --failed' on the original release run, or delete the release's macOS assets first to rebuild deliberately."
+            exit 1
+          fi
+          echo "$TAG has no served macOS artifacts; rebuild is safe"
+
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: apps/desktop/package.json


### PR DESCRIPTION
Closes the standing updater footgun: a `workflow_dispatch` for an already-released tag rebuilds and re-signs the served `.dmg` + `latest.json`, breaking the updater for installs that already fetched them. `build-macos` now refuses on dispatch when the tag's release already serves macOS assets, with the two legitimate paths named in the error: `gh run rerun <run-id> --failed` on the original release run for partial rebuilds (never touches succeeded jobs — this is how v1.3.2's iOS half was recovered), or deliberately deleting the release's macOS assets first. Assetless tags pass, preserving the recovery path for runs that died before publishing. The iOS/MAS jobs stay unguarded on purpose — their uploads are duplicate-tolerant and never touch the updater.