### PR TITLE
fix(release): keep store notes on the release, not main

### DIFF
--- a/.github/workflows/appstore.yml
+++ b/.github/workflows/appstore.yml
@@ -42,9 +42,21 @@ jobs:
           echo "VERSION=$v" >> "$GITHUB_ENV"
 
       - name: Require approved store notes
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          test -f "apps/desktop/store-notes/${VERSION}.md" || {
-            echo "::error::apps/desktop/store-notes/${VERSION}.md is missing — the release's store-notes job drafts it onto main (or write it there) before submitting"
+          file="apps/desktop/store-notes/${VERSION}.md"
+          if [ ! -f "$file" ]; then
+            # Notes live in the GitHub Release body (between the store-notes
+            # markers) since the release job started attaching them there;
+            # materialize the section at the path the submit script reads.
+            # Committed files (releases predating that flow) take precedence.
+            mkdir -p "$(dirname "$file")"
+            gh release view "v${VERSION}" --json body --jq .body \
+              | awk '/<!-- store-notes -->/{grab=1; next} /<!-- \/store-notes -->/{exit} grab{print}' > "$file"
+          fi
+          grep -q . "$file" || {
+            echo "::error::no store notes for ${VERSION} — edit the store-notes section on the v${VERSION} release (or commit ${file}) before submitting"
             exit 1
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,20 +179,21 @@ jobs:
               || echo "::warning::could not flip the autorelease label on PR #$n"
           done
 
-  # Draft the App Store "What's New" for the version just cut and land it on
-  # main through an immediately-merged PR: the main ruleset requires changes
-  # to arrive by PR, and a GITHUB_TOKEN squash-merge satisfies it while
-  # starting no workflow runs. The draft is write-once (the script refuses to
-  # touch an existing file) — edit the committed file on main any time before
-  # appstore.yml submits the version; it refuses to submit without the file.
+  # Draft the App Store "What's New" for the version just cut and attach it to
+  # the GitHub Release body inside <!-- store-notes --> markers (invisible on
+  # the rendered page) — no commit to main, nothing to merge. The draft is
+  # write-once: a release whose body already carries a section is never
+  # redrafted. Edit the section on the release page any time before
+  # appstore.yml submits the version (it extracts the section and refuses to
+  # submit without one); delete the section and re-run this job for a fresh
+  # draft.
   store-notes:
     needs: release
     if: ${{ needs.release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write # push the notes branch
-      pull-requests: write # open + merge the notes PR
+      contents: write # edit the release body
       id-token: write # AWS OIDC, to read the Anthropic key
     env:
       TAG: ${{ needs.release.outputs.tag_name }}
@@ -212,53 +213,37 @@ jobs:
           role-to-assume: arn:aws:iam::735853783919:role/lux-release-signing
           aws-region: us-west-1
 
-      - name: Draft the notes (write-once)
-        run: |
-          set -euo pipefail
-          version="${TAG#v}"
-          git fetch --depth=1 origin main
-          if git cat-file -e "origin/main:apps/desktop/store-notes/$version.md" 2>/dev/null; then
-            echo "notes for $version already on main; skipping the draft"
-            exit 0
-          fi
-          key=$(aws secretsmanager get-secret-value --secret-id lux/anthropic-api-key --query SecretString --output text)
-          echo "::add-mask::$key"
-          ANTHROPIC_API_KEY="$key" bun scripts/draft-store-notes.ts
-
-      - name: Land the draft on main (squash-merged PR)
+      - name: Draft the notes and attach them to the release (write-once)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           version="${TAG#v}"
-          file="apps/desktop/store-notes/$version.md"
-          if [ -z "$(git status --porcelain -- "$file")" ]; then
-            echo "no fresh draft ($file is already committed); nothing to land"
+          if gh release view "$TAG" --json body --jq .body | grep -q '<!-- store-notes -->'; then
+            echo "release $TAG already carries store notes; leaving them alone"
             exit 0
           fi
-          if git cat-file -e "origin/main:$file" 2>/dev/null; then
-            echo "$file already exists on main; leaving it alone"
-            exit 0
-          fi
-          branch="store-notes/$version"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$branch" origin/main
-          git add "$file"
-          git commit -m "chore: draft App Store notes for $version"
-          git push -f origin "$branch"
-          gh pr create --head "$branch" \
-            --title "chore: draft App Store notes for $version" \
-            --body "Automated draft from the $TAG changelog. Edit apps/desktop/store-notes/$version.md on main any time before submitting the version in appstore.yml."
-          for attempt in 1 2 3 4 5; do
-            if gh pr merge "$branch" --squash --delete-branch; then
-              echo "notes landed on main"
-              exit 0
+          # Voice anchor for the drafter: the newest earlier release carrying
+          # a section; the script falls back to the notes files committed
+          # before this flow existed when none is found.
+          for prev in $(gh release list --limit 6 --json tagName --jq ".[].tagName" | grep -vx "$TAG"); do
+            gh release view "$prev" --json body --jq .body \
+              | awk '/<!-- store-notes -->/{grab=1; next} /<!-- \/store-notes -->/{exit} grab{print}' \
+              > "$RUNNER_TEMP/prev-notes.md" || true
+            if grep -q . "$RUNNER_TEMP/prev-notes.md"; then
+              echo "voice anchor: $prev"
+              break
             fi
-            sleep 5
           done
-          echo "::error::could not merge the notes PR for $version"
-          exit 1
+          key=$(aws secretsmanager get-secret-value --secret-id lux/anthropic-api-key --query SecretString --output text)
+          echo "::add-mask::$key"
+          PREV_NOTES_FILE="$RUNNER_TEMP/prev-notes.md" ANTHROPIC_API_KEY="$key" bun scripts/draft-store-notes.ts
+          file="apps/desktop/store-notes/$version.md"
+          [ -s "$file" ] || { echo "no draft produced (no changelog section?); nothing to attach"; exit 0; }
+          body=$(gh release view "$TAG" --json body --jq .body)
+          printf '%s\n\n<!-- store-notes -->\n%s\n<!-- /store-notes -->\n' "$body" "$(cat "$file")" \
+            | gh release edit "$TAG" --notes-file -
+          echo "attached store notes to $TAG"
 
   # The release gate: the same checks as the PR/main `desktop` workflow
   # (tauri-versions, frontend build/typecheck/lint, cargo test --workspace),

--- a/scripts/draft-store-notes.ts
+++ b/scripts/draft-store-notes.ts
@@ -1,16 +1,16 @@
 // Draft the App Store "What's New" for the release just cut, from its
 // CHANGELOG section. Runs at ship time (release.yml's store-notes job, checked
-// out at the release tag); the job lands the file on main through an
-// immediately-merged PR, and appstore.yml refuses to submit a version whose
-// file is missing — edit the committed file on main any time before then.
+// out at the release tag); the job attaches the drafted text to the GitHub
+// Release body between <!-- store-notes --> markers, and appstore.yml
+// extracts that section at submit time — edit it on the release page any
+// time before then. This script only writes the local file; write-once
+// against the release body is the workflow's job.
 //
-// The draft is exactly that — a draft, written once: the file is only created
-// when it doesn't exist. Existing files are never rewritten (human edits are
-// sacred; regenerating a draft produces different text — see the guard
-// below). To force a fresh draft, delete the file on main and re-run the
-// store-notes job for the tag.
+// The voice-anchor example comes from PREV_NOTES_FILE when the workflow
+// provides one (extracted from the previous release's section), else from
+// the newest notes file committed back when drafts landed on main.
 //
-// Usage: ANTHROPIC_API_KEY=... bun scripts/draft-store-notes.ts
+// Usage: [PREV_NOTES_FILE=...] ANTHROPIC_API_KEY=... bun scripts/draft-store-notes.ts
 
 import Anthropic from "@anthropic-ai/sdk";
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "fs";
@@ -27,10 +27,9 @@ if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
 
 const notesPath = join(NOTES_DIR, `${version}.md`);
 
-// Never redraft an existing file, whoever wrote it. Human edits are sacred,
-// and regenerating a draft through the model produces *different* text (the
-// model is nondeterministic), so a re-run must never replace what shipped to
-// the repo. Delete the file on main to force a redraft explicitly.
+// Never redraft an existing file (committed notes from the drafts-on-main
+// era, or a prior local draft): regenerating through the model produces
+// *different* text, and existing text may carry human edits.
 if (existsSync(notesPath)) {
   console.log(`${notesPath} already exists; leaving it alone.`);
   process.exit(0);
@@ -50,7 +49,13 @@ if (!section) {
   process.exit(0);
 }
 
-// The most recent shipped notes file anchors the voice.
+// The most recent shipped notes anchor the voice: the workflow-provided file
+// (previous release's section) when present, else the newest committed file.
+const prevNotesFile = process.env.PREV_NOTES_FILE;
+const fromRelease =
+  prevNotesFile && existsSync(prevNotesFile)
+    ? readFileSync(prevNotesFile, "utf8").trim()
+    : "";
 const previous = existsSync(NOTES_DIR)
   ? readdirSync(NOTES_DIR)
       .filter((f) => f.endsWith(".md") && f !== `${version}.md`)
@@ -58,9 +63,9 @@ const previous = existsSync(NOTES_DIR)
         b.localeCompare(a, undefined, { numeric: true, sensitivity: "base" })
       )[0]
   : undefined;
-const example = previous
-  ? readFileSync(join(NOTES_DIR, previous), "utf8").trim()
-  : undefined;
+const example =
+  fromRelease ||
+  (previous ? readFileSync(join(NOTES_DIR, previous), "utf8").trim() : undefined);
 
 const client = new Anthropic();
 const response = await client.messages.create({


### PR DESCRIPTION
Removes the per-release `chore:` commit on main. The store-notes job no longer opens and self-merges a PR — the draft attaches to the GitHub Release body between `<!-- store-notes -->` markers (invisible on the rendered release page). Editing flow: the release page's Edit textarea, any time before submitting; delete the section and re-run the job for a fresh draft. Write-once now checks the release body instead of main.

`appstore.yml` extracts the section into `apps/desktop/store-notes/<version>.md` at submit time — the exact path `appstore-submit.ts` already reads, so the script is untouched. Committed notes files from the drafts-on-main era take precedence, keeping older versions submittable. The submit gate still refuses a version with no notes anywhere.

Side effect worth naming: this removes the only workflow that exercised GITHUB_TOKEN's create-and-self-merge-a-PR capability; the `store-notes` job drops `pull-requests: write` entirely. First live exercise is the next release's ship run.