### PR TITLE
ci: build lux-node for aarch64 alongside x86_64

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -1,7 +1,11 @@
-# Builds the lux-node static musl binary and stages it as an artifact —
-# dispatch it, download lux-node-x86_64-linux, and follow apps/node/README.md.
-# Same toolchain the Lambda deploys use; nothing here touches AWS or signs
-# anything, so it is safe to run from any ref.
+# Builds the lux-node static musl binaries and stages them as artifacts —
+# dispatch it, download lux-node-x86_64-linux or lux-node-aarch64-linux, and
+# follow apps/node/README.md. Same toolchain the Lambda deploys use; nothing
+# here touches AWS or signs anything, so it is safe to run from any ref.
+#
+# Each target builds natively on a runner of its own arch: Ubuntu's musl-tools
+# only ships musl-gcc for the host arch, so cross-compiling would mean a
+# hand-rolled toolchain instead of the distro package.
 name: node-build
 
 on:
@@ -12,7 +16,16 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            artifact: lux-node-x86_64-linux
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            artifact: lux-node-aarch64-linux
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     env:
       RUSTC_WRAPPER: sccache
@@ -23,7 +36,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          targets: x86_64-unknown-linux-musl
+          targets: ${{ matrix.target }}
 
       - name: Install musl-gcc
         run: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -34,12 +47,13 @@ jobs:
         with:
           workspaces: "."
           cache-targets: "false"
+          key: ${{ matrix.target }}
 
       - name: Build (static musl)
-        run: cargo build --release --target x86_64-unknown-linux-musl -p lux-node
+        run: cargo build --release --target ${{ matrix.target }} -p lux-node
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: lux-node-x86_64-linux
-          path: target/x86_64-unknown-linux-musl/release/lux-node
+          name: ${{ matrix.artifact }}
+          path: target/${{ matrix.target }}/release/lux-node
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1014,7 +1014,18 @@ jobs:
   node-release:
     needs: [release, build-macos]
     if: ${{ needs.release.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Native runner per target: Ubuntu's musl-tools only ships musl-gcc
+          # for the host arch. aarch64 is the Raspberry Pi / small-ARM-box story.
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            asset: lux-node-x86_64-linux
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            asset: lux-node-aarch64-linux
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: write # upload the release asset
@@ -1030,7 +1041,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          targets: x86_64-unknown-linux-musl
+          targets: ${{ matrix.target }}
 
       - name: Install musl-gcc
         run: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -1041,14 +1052,15 @@ jobs:
         with:
           workspaces: "."
           cache-targets: "false"
+          key: ${{ matrix.target }}
 
       - name: Build (static musl)
-        run: cargo build --release --target x86_64-unknown-linux-musl -p lux-node
+        run: cargo build --release --target ${{ matrix.target }} -p lux-node
 
       - name: Upload as a release asset
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          cp target/x86_64-unknown-linux-musl/release/lux-node lux-node-x86_64-linux
-          gh release upload "$TAG" lux-node-x86_64-linux --clobber
-          echo "uploaded lux-node-x86_64-linux to $TAG"
+          cp "target/${{ matrix.target }}/release/lux-node" "${{ matrix.asset }}"
+          gh release upload "$TAG" "${{ matrix.asset }}" --clobber
+          echo "uploaded ${{ matrix.asset }} to $TAG"

--- a/apps/node/README.md
+++ b/apps/node/README.md
@@ -7,16 +7,18 @@ It transmits at E1.31 priority 90 (surfaces send 100), so touching a fader on an
 ## Install
 
 ```bash
-curl -fsSL -o lux-node https://github.com/johncarmack1984/lux/releases/latest/download/lux-node-x86_64-linux
+curl -fsSL -o lux-node "https://github.com/johncarmack1984/lux/releases/latest/download/lux-node-$(uname -m)-linux"
 chmod +x lux-node
 sudo ./lux-node install
 ```
+
+Assets exist for `x86_64` and `aarch64` (Raspberry Pi 3/4/5/Zero 2 W on a 64-bit OS), named to match `uname -m`.
 
 `install` does everything and is safe to re-run (it upgrades the binary and fixes whatever is missing): copies itself to `/usr/local/bin`, creates the `lux-node` system user and dirs, writes the systemd unit, signs in as the service identity, then lists the account's setups so you pick by name (universe comes from the record; a UUID prompt only appears if the sync API is unreachable — and only when no config exists yet), enables the service, and masks sleep/suspend — pass `--keep-sleep` to skip that last part. Watch it with `journalctl -u lux-node -f`.
 
 The setup id is the id of the setup this node applies — visible in the app's sync record, or ask any signed-in device. Optional keys in `/etc/lux-node/config.json`: `"interface"` (IPv4 of the NIC to egress multicast from, for multi-homed hosts) and `"priority"` (default 90).
 
-(No release with the asset yet, or hacking on a checkout? The **node-build** workflow's `lux-node-x86_64-linux` artifact and `cargo build --release --target x86_64-unknown-linux-musl -p lux-node` produce the same binary.)
+(No release with the asset yet, or hacking on a checkout? The **node-build** workflow's `lux-node-x86_64-linux` / `lux-node-aarch64-linux` artifacts and `cargo build --release --target <arch>-unknown-linux-musl -p lux-node` produce the same binaries.)
 
 On an Intel Mac mini, also enable auto power-on after a power failure (the setpci register varies by generation — verify for the model before poking):
 


### PR DESCRIPTION
## What

Adds `aarch64-unknown-linux-musl` as a second leg of the **node-build** and **node-release** matrices, built natively on GitHub's `ubuntu-24.04-arm` runners (musl-tools only ships a host-arch musl-gcc, so native runners beat a hand-rolled cross toolchain).

## Why

lux-node runs in 8.5 MB of RAM — the endgame is a Raspberry-Pi-class appliance next to the router. `lux-engine` is already Tauri-free and the binary is already static musl, so the Pi port is exactly this build-matrix change.

## Details

- Release assets: `lux-node-x86_64-linux` (unchanged) + new `lux-node-aarch64-linux`, named to match `uname -m` — the README install one-liner is now arch-agnostic.
- `Swatinem/rust-cache` gets `key: matrix.target` so the two legs don't share caches.
- No source changes: nothing in the node hardcodes the asset name (only the README did).

## Testing

- Both workflow files parse clean.
- Dispatched **node-build** on this branch to exercise both legs.