### PR TITLE
feat(auth): add the sign in with apple backend

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -186,7 +186,7 @@ jobs:
           cache-targets: "false"
 
       - name: Build (static musl, release profile)
-        run: cargo build --release --target x86_64-unknown-linux-musl -p lux-sync-api -p lux-iot-authorizer -p lux-discord-bot
+        run: cargo build --release --target x86_64-unknown-linux-musl -p lux-sync-api -p lux-iot-authorizer -p lux-discord-bot -p lux-apple-auth
 
       - name: sccache stats
         if: ${{ always() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,18 +544,19 @@ jobs:
           retry-max-attempts: 6
 
       - name: Build (static musl)
-        run: cargo build --release --target x86_64-unknown-linux-musl -p lux-sync-api -p lux-iot-authorizer -p lux-discord-bot
+        run: cargo build --release --target x86_64-unknown-linux-musl -p lux-sync-api -p lux-iot-authorizer -p lux-discord-bot -p lux-apple-auth
 
       # provided.al2023 runs the zip's `bootstrap`; package each binary under
       # that name and wait until Lambda finishes swapping code before smoking.
       # Every deploy publishes a numbered version (rollback provenance). The
-      # sync-api and bot serve traffic from $LATEST (their Function URLs are
-      # unqualified), so the code swap is their cutover; the authorizer serves
-      # through the `live` alias, so its new version takes no traffic until the
-      # flip step below — after its smoke has passed against that exact version.
+      # sync-api, bot, and apple-auth serve traffic from $LATEST (their
+      # Function URLs are unqualified), so the code swap is their cutover; the
+      # authorizer serves through the `live` alias, so its new version takes no
+      # traffic until the flip step below — after its smoke has passed against
+      # that exact version.
       - name: Deploy
         run: |
-          for fn in lux-sync-api lux-iot-authorizer lux-discord-bot; do
+          for fn in lux-sync-api lux-iot-authorizer lux-discord-bot lux-apple-auth; do
             staging=$(mktemp -d)
             cp "target/x86_64-unknown-linux-musl/release/$fn" "$staging/bootstrap"
             (cd "$staging" && zip -q9 function.zip bootstrap)
@@ -581,6 +582,17 @@ jobs:
           code=$(curl -s -o /tmp/body -w '%{http_code}' "${url}setups")
           cat /tmp/body; echo
           test "$code" = "401" && grep -q '"error"' /tmp/body
+
+      # A garbage identity token answering the typed 401 proves the new binary
+      # cold-started (its init fetches the Cognito JWKS before serving), routes
+      # /auth/apple, and rejects unverifiable tokens.
+      - name: Smoke apple-auth
+        run: |
+          url=$(aws lambda get-function-url-config --function-name lux-apple-auth --query FunctionUrl --output text)
+          code=$(curl -s -o /tmp/apple-auth-body -w '%{http_code}' -X POST -H 'content-type: application/json' \
+            -d '{"identityToken":"smoke-test-garbage","authorizationCode":"x","rawNonce":"y"}' "${url}auth/apple")
+          cat /tmp/apple-auth-body; echo
+          test "$code" = "401" && grep -q '"error"' /tmp/apple-auth-body
 
       # Invoke the freshly published version directly (qualified) with a
       # garbage token: a well-formed deny proves it cold-started (JWKS fetch)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-secretsmanager"
+version = "1.108.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd24cfd47bda71881c399a7cc4850d5a61727246163d5cd1a7c0b48ef19983cb"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-sso"
 version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3737,6 +3762,29 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "lux-apple-auth"
+version = "0.1.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-cognitoidentityprovider",
+ "aws-sdk-dynamodb",
+ "aws-sdk-secretsmanager",
+ "base64 0.22.1",
+ "jsonwebtoken",
+ "lambda_runtime",
+ "lux-auth",
+ "lux-wire",
+ "reqwest",
+ "rustls 0.23.41",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/lux-auth",
     "crates/lux-engine",
     "crates/lux-wire",
+    "services/apple-auth",
     "services/bot",
     "services/iot-authorizer",
     "services/sync-api",

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -141,6 +141,88 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+pub mod apple {
+    //! Sign in with Apple: desktop ↔ `lux-apple-auth` wire.
+    //!
+    //! The desktop runs the native `ASAuthorizationController` sheet, then
+    //! posts the resulting Apple identity token here. The service verifies it
+    //! against Apple's JWKS (audience = the app's bundle id, nonce bound to
+    //! [`SignInRequest::raw_nonce`]), maps Apple's stable `sub` to a Cognito
+    //! user, and mints normal user-pool tokens through the pool's custom-auth
+    //! triggers — so everything downstream of sign-in sees the same JWTs the
+    //! SRP path produces.
+    //!
+    //! Routes (all `POST`, on the service's own Function URL):
+    //! - `/auth/apple`        — sign in (creating or linking a user on first use)
+    //! - `/auth/apple/link`   — bearer-authed: link the CALLER's account to the
+    //!   presented Apple credential, regardless of email (the Hide-My-Email path)
+    //! - `/auth/apple/revoke` — bearer-authed: revoke the stored Apple token and
+    //!   drop the link (account deletion runs this before wiping data)
+
+    use serde::{Deserialize, Serialize};
+
+    /// Path segments the service routes on: `/auth/apple[/link|/revoke]`.
+    pub const AUTH_SEGMENT: &str = "auth";
+    pub const APPLE_SEGMENT: &str = "apple";
+    pub const LINK_SEGMENT: &str = "link";
+    pub const REVOKE_SEGMENT: &str = "revoke";
+
+    /// Body for `POST /auth/apple` and `POST /auth/apple/link`.
+    ///
+    /// `email` and `full_name` ride along because **Apple surfaces them only on
+    /// the first authorization** — the service persists them then or they are
+    /// gone (the user can reset the grant in Settings). They are display/record
+    /// data only; the email that drives account linking always comes from the
+    /// verified token, never the body.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SignInRequest {
+        /// Apple's identity token (a JWT) from the authorization sheet.
+        pub identity_token: String,
+        /// The single-use, short-lived authorization code from the same sheet;
+        /// the service exchanges it for the revocable Apple refresh token that
+        /// account deletion is required to revoke.
+        pub authorization_code: String,
+        /// The raw nonce whose SHA-256 the client set on the sheet request; the
+        /// service re-hashes it and requires the token's `nonce` claim to match.
+        pub raw_nonce: String,
+        #[serde(default)]
+        pub email: Option<String>,
+        #[serde(default)]
+        pub full_name: Option<String>,
+    }
+
+    /// Response to a successful `POST /auth/apple` — Cognito user-pool tokens,
+    /// stored by the desktop exactly like an SRP sign-in's.
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SignInResponse {
+        pub id_token: String,
+        pub access_token: String,
+        pub refresh_token: String,
+        /// Access/id token lifetime in seconds, from Cognito.
+        pub expires_in: i32,
+        /// True when this sign-in created a brand-new account (vs. signing into
+        /// or auto-linking an existing one) — the UI's "welcome" cue.
+        #[serde(default)]
+        pub created: bool,
+    }
+
+    /// Response to a successful `POST /auth/apple/link`.
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct LinkResponse {
+        pub linked: bool,
+    }
+
+    /// Response to a successful `POST /auth/apple/revoke`.
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct RevokeResponse {
+        pub revoked: bool,
+    }
+}
+
 pub mod nudge {
     //! The change-nudge channel: tiny events, opaque to clients.
     //!
@@ -525,6 +607,90 @@ mod tests {
             serde_json::to_string(&body).unwrap(),
             r#"{"error":"conflict"}"#
         );
+    }
+
+    #[test]
+    fn apple_sign_in_request_shape() {
+        // First-authorization shape: email + name present.
+        let first = apple::SignInRequest {
+            identity_token: "eyJ0.a.b".into(),
+            authorization_code: "c0de".into(),
+            raw_nonce: "f3a1".into(),
+            email: Some("user@example.com".into()),
+            full_name: Some("Ada Lovelace".into()),
+        };
+        assert_eq!(
+            serde_json::to_string(&first).unwrap(),
+            r#"{"identityToken":"eyJ0.a.b","authorizationCode":"c0de","rawNonce":"f3a1","email":"user@example.com","fullName":"Ada Lovelace"}"#
+        );
+
+        // Every later authorization: Apple omits them; `null` on the wire.
+        let later = apple::SignInRequest {
+            identity_token: "eyJ0.a.b".into(),
+            authorization_code: "c0de".into(),
+            raw_nonce: "f3a1".into(),
+            email: None,
+            full_name: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&later).unwrap(),
+            r#"{"identityToken":"eyJ0.a.b","authorizationCode":"c0de","rawNonce":"f3a1","email":null,"fullName":null}"#
+        );
+
+        // A body without the optional fields at all still parses.
+        let bare: apple::SignInRequest = serde_json::from_str(
+            r#"{"identityToken":"t","authorizationCode":"c","rawNonce":"n"}"#,
+        )
+        .unwrap();
+        assert!(bare.email.is_none() && bare.full_name.is_none());
+    }
+
+    #[test]
+    fn apple_sign_in_response_shape() {
+        let body = apple::SignInResponse {
+            id_token: "id".into(),
+            access_token: "ac".into(),
+            refresh_token: "re".into(),
+            expires_in: 3600,
+            created: true,
+        };
+        assert_eq!(
+            serde_json::to_string(&body).unwrap(),
+            r#"{"idToken":"id","accessToken":"ac","refreshToken":"re","expiresIn":3600,"created":true}"#
+        );
+
+        // A reply without `created` (defaulted) still parses.
+        let old: apple::SignInResponse = serde_json::from_str(
+            r#"{"idToken":"id","accessToken":"ac","refreshToken":"re","expiresIn":3600}"#,
+        )
+        .unwrap();
+        assert!(!old.created);
+    }
+
+    #[test]
+    fn apple_link_and_revoke_shapes() {
+        assert_eq!(
+            serde_json::to_string(&apple::LinkResponse { linked: true }).unwrap(),
+            r#"{"linked":true}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&apple::RevokeResponse { revoked: true }).unwrap(),
+            r#"{"revoked":true}"#
+        );
+    }
+
+    #[test]
+    fn apple_segments() {
+        assert_eq!(
+            format!(
+                "/{}/{}",
+                apple::AUTH_SEGMENT,
+                apple::APPLE_SEGMENT
+            ),
+            "/auth/apple"
+        );
+        assert_eq!(apple::LINK_SEGMENT, "link");
+        assert_eq!(apple::REVOKE_SEGMENT, "revoke");
     }
 
     #[test]

--- a/infra/accounts.tf
+++ b/infra/accounts.tf
@@ -32,6 +32,19 @@ resource "aws_cognito_user_pool" "lux" {
   email_configuration {
     email_sending_account = "COGNITO_DEFAULT"
   }
+
+  # Sign in with Apple rides the CUSTOM_AUTH flow; all three triggers are the
+  # lux-apple-auth function (apple-auth.tf). The ARN is constructed, not a
+  # resource reference, deliberately: the function's env references this pool,
+  # so a reference here would be a dependency cycle. The trade is ordering —
+  # on a fresh stack (or the first apply adding this block) the pool update can
+  # land before the function exists; the release pipeline's auto-retry (and the
+  # documented two-apply bootstrap) converges it.
+  lambda_config {
+    define_auth_challenge          = "arn:aws:lambda:${data.aws_region.current.region}:${local.aws_account_id}:function:lux-apple-auth"
+    create_auth_challenge          = "arn:aws:lambda:${data.aws_region.current.region}:${local.aws_account_id}:function:lux-apple-auth"
+    verify_auth_challenge_response = "arn:aws:lambda:${data.aws_region.current.region}:${local.aws_account_id}:function:lux-apple-auth"
+  }
 }
 
 # Public/native app client — a desktop app can't keep a secret. SRP (the
@@ -45,6 +58,12 @@ resource "aws_cognito_user_pool_client" "lux_app" {
     "ALLOW_USER_SRP_AUTH",            # the app's flow — password never crosses the wire
     "ALLOW_REFRESH_TOKEN_AUTH",       # silent re-auth from the stored refresh token
     "ALLOW_ADMIN_USER_PASSWORD_AUTH", # admin-only (needs AWS creds), for minting test tokens via the CLI
+    # Sign in with Apple (lux-apple-auth drives it via AdminInitiateAuth). This
+    # also opens the flow to direct public-client calls — safe by design: the
+    # Verify trigger only accepts a valid Apple identity token linked to
+    # exactly the authenticating user, so there is no way through without the
+    # credential itself.
+    "ALLOW_CUSTOM_AUTH",
   ]
 
   access_token_validity  = 1

--- a/infra/apple-auth.tf
+++ b/infra/apple-auth.tf
@@ -1,0 +1,175 @@
+# Sign in with Apple: the lux-apple-auth Lambda (../services/apple-auth) — one
+# function serving both its Function URL routes (the desktop posts the native
+# sheet's identity token to /auth/apple[/link|/revoke]) and the user pool's
+# CUSTOM_AUTH trigger events (wired in accounts.tf). Same shape as the sync
+# API: public URL, handler-enforced auth, least-privilege role, placeholder
+# code owned by cargo-lambda deploys.
+#
+# The Apple-side signing key (`lux/siwa-key`) is a hand-created secret, never a
+# Terraform resource — the house pattern for true secrets (like
+# lux/apple-signing). The function references it by name and lazy-loads it, so
+# this stack applies and serves token verification before the secret exists;
+# only the routes that call Apple's token/revoke endpoints need it.
+
+# --- Role: logs, the link items, pool admin auth, the Apple signing key ------
+
+resource "aws_iam_role" "lux_apple_auth" {
+  name = "lux-apple-auth"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lux_apple_auth_logs" {
+  role       = aws_iam_role.lux_apple_auth.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# The Apple↔Cognito link items live in the lux-sync table but in their own
+# partitions; LeadingKeys pins this role to exactly those, so it can never
+# touch a user's sync data.
+resource "aws_iam_role_policy" "lux_apple_auth_ddb" {
+  name = "lux-apple-auth-dynamodb"
+  role = aws_iam_role.lux_apple_auth.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:ConditionCheckItem",
+      ]
+      Resource = aws_dynamodb_table.lux_sync.arn
+      Condition = {
+        "ForAllValues:StringLike" = {
+          "dynamodb:LeadingKeys" = ["APPLE#*", "APPLELINK#*"]
+        }
+      }
+    }]
+  })
+}
+
+# The admin half of the CUSTOM_AUTH dance: look up / create the user, start the
+# flow, answer the challenge. Trust still lives in the pool's Verify trigger
+# (this same binary) — these calls add reach, not authority.
+resource "aws_iam_role_policy" "lux_apple_auth_cognito" {
+  name = "lux-apple-auth-cognito"
+  role = aws_iam_role.lux_apple_auth.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "cognito-idp:ListUsers",
+        "cognito-idp:AdminCreateUser",
+        # Admin-created users land in FORCE_CHANGE_PASSWORD; a discarded random
+        # password (set permanent) moves them to CONFIRMED so auth can proceed.
+        "cognito-idp:AdminSetUserPassword",
+        # Apple verifying an email confirms a stalled self-signup for it.
+        "cognito-idp:AdminConfirmSignUp",
+        "cognito-idp:AdminInitiateAuth",
+        "cognito-idp:AdminRespondToAuthChallenge",
+      ]
+      Resource = aws_cognito_user_pool.lux.arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "lux_apple_auth_siwa_key" {
+  name = "lux-apple-auth-siwa-key"
+  role = aws_iam_role.lux_apple_auth.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = "arn:aws:secretsmanager:*:${local.aws_account_id}:secret:lux/siwa-key*"
+    }]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "lux_apple_auth" {
+  name              = "/aws/lambda/lux-apple-auth"
+  retention_in_days = 14
+}
+
+# --- Function + URL (placeholder code; cargo-lambda ships the real thing) ----
+
+data "archive_file" "apple_auth_placeholder" {
+  type        = "zip"
+  output_path = "${path.module}/.apple-auth-placeholder.zip"
+  source {
+    content  = "placeholder — real code is shipped by cargo-lambda"
+    filename = "bootstrap"
+  }
+}
+
+resource "aws_lambda_function" "lux_apple_auth" {
+  function_name = "lux-apple-auth"
+  role          = aws_iam_role.lux_apple_auth.arn
+  runtime       = "provided.al2023"
+  handler       = "bootstrap"
+  architectures = ["x86_64"]
+  memory_size   = 256
+  timeout       = 10
+
+  filename = data.archive_file.apple_auth_placeholder.output_path
+  lifecycle {
+    ignore_changes = [filename, source_code_hash]
+  }
+
+  environment {
+    variables = {
+      COGNITO_USER_POOL_ID  = aws_cognito_user_pool.lux.id
+      COGNITO_APP_CLIENT_ID = aws_cognito_user_pool_client.lux_app.id
+      COGNITO_REGION        = data.aws_region.current.region
+      DYNAMODB_TABLE        = aws_dynamodb_table.lux_sync.name
+      # Product identity, not environment: the bundle id is the token audience
+      # and Apple client_id for native flows.
+      APPLE_BUNDLE_ID = "com.johncarmack.lux"
+      # By-name reference to the hand-created secret (see the header comment).
+      SIWA_SECRET_ID = "lux/siwa-key"
+    }
+  }
+}
+
+# Public Function URL; the handler enforces auth (Apple identity token on
+# /auth/apple, Cognito bearer on /link and /revoke) — same model as the sync API.
+resource "aws_lambda_function_url" "lux_apple_auth" {
+  function_name      = aws_lambda_function.lux_apple_auth.function_name
+  authorization_type = "NONE"
+}
+
+resource "aws_lambda_permission" "lux_apple_auth_url" {
+  statement_id           = "FunctionURLAllowPublicAccess"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.lux_apple_auth.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}
+
+# Let the user pool invoke the trigger surface of the same function.
+resource "aws_lambda_permission" "lux_apple_auth_cognito" {
+  statement_id  = "AllowCognitoTriggerInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lux_apple_auth.function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = aws_cognito_user_pool.lux.arn
+}
+
+# Consumed by scripts/gen-endpoints in a follow-up: the endpoints file gains
+# `appleAuthUrl` only once this URL exists in applied state (the missing-field
+# case is "feature dark" in the app by design), so adding the output here does
+# not touch the drift gate.
+output "apple_auth_url" {
+  description = "APPLE_AUTH_URL — the Sign in with Apple bridge the app posts identity tokens to."
+  value       = aws_lambda_function_url.lux_apple_auth.function_url
+}

--- a/infra/terraform-ci.tf
+++ b/infra/terraform-ci.tf
@@ -310,6 +310,7 @@ locals {
     "arn:aws:lambda:*:${local.aws_account_id}:function:lux-sync-api",
     "arn:aws:lambda:*:${local.aws_account_id}:function:lux-iot-authorizer",
     "arn:aws:lambda:*:${local.aws_account_id}:function:lux-discord-bot",
+    "arn:aws:lambda:*:${local.aws_account_id}:function:lux-apple-auth",
   ]
 }
 

--- a/services/apple-auth/Cargo.toml
+++ b/services/apple-auth/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "lux-apple-auth"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# Sign in with Apple bridge on AWS Lambda (provided.al2023). One function, two
+# invoke surfaces sharing one binary: the Function URL routes the desktop calls
+# after running the native Apple sheet (`/auth/apple[/link|/revoke]`), and the
+# Cognito custom-auth trigger events (Define/Create/VerifyAuthChallenge) the
+# user pool invokes during the CUSTOM_AUTH flow those routes drive. Verifies
+# Apple identity tokens against Apple's JWKS and mints ordinary user-pool JWTs,
+# so everything downstream of sign-in is untouched. Built and deployed with the
+# same static-musl pipeline as the other services.
+
+[lints]
+workspace = true
+
+[dependencies]
+lux-auth = { path = "../../crates/lux-auth" }
+lux-wire = { path = "../../crates/lux-wire" }
+lambda_runtime = "1"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+aws-config = { workspace = true }
+aws-sdk-cognitoidentityprovider = "1"
+aws-sdk-dynamodb = "1"
+aws-sdk-secretsmanager = "1"
+# Same backend note as lux-auth: rust_crypto (rsa + sha2 + p256) covers our
+# RS256 verify and ES256 client-secret signing with no C, no musl-static risk.
+jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+reqwest = { workspace = true }
+# rustls with no baked-in crypto provider; main() installs ring as the process
+# default, sidestepping the aws-lc-rs C build that reqwest's `rustls` feature pulls.
+rustls = { workspace = true }
+sha2 = "0.11"
+base64 = "0.22"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/services/apple-auth/src/apple.rs
+++ b/services/apple-auth/src/apple.rs
@@ -1,0 +1,536 @@
+//! Apple-side crypto: identity-token verification against Apple's JWKS, and
+//! the signed-JWT client secret that authenticates lux to Apple's token and
+//! revocation endpoints.
+//!
+//! Verification here is the trust boundary for the whole sign-in path — the
+//! Function URL routes and the Cognito VerifyAuthChallenge trigger both run
+//! through [`AppleAuth::verify_token`], so a token that fails signature,
+//! issuer, audience, or expiry never touches a user record.
+
+use std::collections::HashMap;
+
+use jsonwebtoken::{decode, decode_header, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tokio::sync::RwLock;
+
+const APPLE_ISSUER: &str = "https://appleid.apple.com";
+const APPLE_JWKS_URL: &str = "https://appleid.apple.com/auth/keys";
+const APPLE_TOKEN_URL: &str = "https://appleid.apple.com/auth/token";
+const APPLE_REVOKE_URL: &str = "https://appleid.apple.com/auth/revoke";
+
+/// The Sign in with Apple key (`lux/siwa-key` in Secrets Manager): the `.p8`
+/// private key minted in the developer portal plus its identifiers. Signs the
+/// client-secret JWT; never leaves the Lambda.
+#[derive(Debug, Deserialize)]
+pub struct SiwaKey {
+    pub key_id: String,
+    pub team_id: String,
+    pub private_key: String,
+}
+
+/// What a verified identity token asserts. `email` is present only when the
+/// token carries one Apple marked verified — the only email account-linking
+/// may trust.
+#[derive(Debug)]
+pub struct AppleIdentity {
+    pub sub: String,
+    pub email: Option<String>,
+}
+
+/// The identity-token claims we read; signature/issuer/audience/expiry are
+/// validated from the raw token by the library.
+#[derive(Debug, Deserialize)]
+struct AppleClaims {
+    sub: String,
+    #[serde(default)]
+    email: Option<String>,
+    /// Apple sends `true` or, on some paths, the string `"true"`.
+    #[serde(default)]
+    email_verified: Option<Value>,
+    #[serde(default)]
+    nonce: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Jwks {
+    keys: Vec<Jwk>,
+}
+
+#[derive(Deserialize)]
+struct Jwk {
+    kid: String,
+    n: String,
+    e: String,
+}
+
+pub struct AppleAuth {
+    /// Expected token audience: the app's bundle id (native flows use it as
+    /// the Apple `client_id` too).
+    audience: String,
+    http: reqwest::Client,
+    /// Apple's signing keys by `kid`. Fetched lazily, replaced wholesale on a
+    /// `kid` miss (Apple rotates keys); one forced refetch, then fail.
+    keys: RwLock<HashMap<String, DecodingKey>>,
+}
+
+impl AppleAuth {
+    pub fn new(audience: String) -> Self {
+        Self {
+            audience,
+            http: reqwest::Client::new(),
+            keys: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Full verification for tokens arriving with their sheet context: claims
+    /// plus the nonce binding (the token's `nonce` must equal the SHA-256 of
+    /// the raw nonce the client minted for this sheet run).
+    pub async fn verify_identity(
+        &self,
+        token: &str,
+        raw_nonce: &str,
+    ) -> Result<AppleIdentity, String> {
+        let view = self.verify_token(token).await?;
+        let Some(nonce) = view.0.nonce.as_deref() else {
+            return Err("token has no nonce claim".into());
+        };
+        if nonce != sha256_hex(raw_nonce) {
+            return Err("nonce mismatch".into());
+        }
+        Ok(identity(view))
+    }
+
+    /// Signature/issuer/audience/expiry verification alone — the
+    /// VerifyAuthChallenge trigger's variant, which has no sheet context (the
+    /// nonce binding is enforced where the token enters the system; here the
+    /// binding that matters is Apple `sub` ↔ Cognito user, checked by the
+    /// caller against the link store).
+    pub async fn verify_token(&self, token: &str) -> Result<AppleClaimsView, String> {
+        let header = decode_header(token).map_err(|e| format!("bad token header: {e}"))?;
+        let kid = header.kid.ok_or_else(|| "token missing kid".to_owned())?;
+
+        if let Some(claims) = self.try_decode(token, &kid).await? {
+            return Ok(claims);
+        }
+        // Unknown kid: Apple rotated keys (or we never fetched). Refresh once.
+        self.refresh_keys().await?;
+        match self.try_decode(token, &kid).await? {
+            Some(claims) => Ok(claims),
+            None => Err(format!("unknown apple signing key {kid}")),
+        }
+    }
+
+    /// Decode against the cached key for `kid`, if present. `Ok(None)` means
+    /// "no such key cached"; a present-but-failing key is a hard error.
+    async fn try_decode(&self, token: &str, kid: &str) -> Result<Option<AppleClaimsView>, String> {
+        let keys = self.keys.read().await;
+        let Some(key) = keys.get(kid) else {
+            return Ok(None);
+        };
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_issuer(&[APPLE_ISSUER]);
+        validation.set_audience(&[&self.audience]);
+        let data = decode::<AppleClaims>(token, key, &validation)
+            .map_err(|e| format!("invalid token: {e}"))?;
+        Ok(Some(AppleClaimsView(data.claims)))
+    }
+
+    async fn refresh_keys(&self) -> Result<(), String> {
+        let jwks: Jwks = self
+            .http
+            .get(APPLE_JWKS_URL)
+            .send()
+            .await
+            .map_err(|e| format!("apple jwks fetch failed: {e}"))?
+            .json()
+            .await
+            .map_err(|e| format!("apple jwks malformed: {e}"))?;
+        let fresh: HashMap<String, DecodingKey> = jwks
+            .keys
+            .into_iter()
+            .filter_map(|k| {
+                DecodingKey::from_rsa_components(&k.n, &k.e)
+                    .ok()
+                    .map(|dk| (k.kid, dk))
+            })
+            .collect();
+        if fresh.is_empty() {
+            return Err("apple jwks contained no usable keys".into());
+        }
+        *self.keys.write().await = fresh;
+        Ok(())
+    }
+
+    /// Exchange the sheet's single-use authorization code for Apple's token
+    /// set; returns the refresh token (the revocable credential account
+    /// deletion is required to revoke).
+    pub async fn exchange_code(&self, key: &SiwaKey, code: &str) -> Result<String, String> {
+        #[derive(Deserialize)]
+        struct TokenResponse {
+            refresh_token: Option<String>,
+        }
+        let secret = self.client_secret(key)?;
+        let resp = self
+            .http
+            .post(APPLE_TOKEN_URL)
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(form_body(&[
+                ("client_id", self.audience.as_str()),
+                ("client_secret", secret.as_str()),
+                ("code", code),
+                ("grant_type", "authorization_code"),
+            ]))
+            .send()
+            .await
+            .map_err(|e| format!("apple token endpoint unreachable: {e}"))?;
+        if !resp.status().is_success() {
+            // Error bodies carry only an error code (e.g. invalid_grant) —
+            // safe to log, and the single useful diagnostic.
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("apple token exchange {status}: {body}"));
+        }
+        let tokens: TokenResponse = resp
+            .json()
+            .await
+            .map_err(|e| format!("apple token response malformed: {e}"))?;
+        tokens
+            .refresh_token
+            .ok_or_else(|| "apple token response had no refresh_token".into())
+    }
+
+    /// Revoke a stored Apple refresh token (account deletion's Apple-side duty).
+    pub async fn revoke(&self, key: &SiwaKey, refresh_token: &str) -> Result<(), String> {
+        let secret = self.client_secret(key)?;
+        let resp = self
+            .http
+            .post(APPLE_REVOKE_URL)
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(form_body(&[
+                ("client_id", self.audience.as_str()),
+                ("client_secret", secret.as_str()),
+                ("token", refresh_token),
+                ("token_type_hint", "refresh_token"),
+            ]))
+            .send()
+            .await
+            .map_err(|e| format!("apple revoke endpoint unreachable: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("apple revoke {status}: {body}"));
+        }
+        Ok(())
+    }
+
+    /// The client secret Apple's `/auth/token` and `/auth/revoke` require: a
+    /// short-lived ES256 JWT signed with the portal-minted `.p8` key.
+    fn client_secret(&self, key: &SiwaKey) -> Result<String, String> {
+        #[derive(Serialize)]
+        struct SecretClaims<'a> {
+            iss: &'a str,
+            iat: u64,
+            exp: u64,
+            aud: &'a str,
+            sub: &'a str,
+        }
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(key.key_id.clone());
+        let now = now_secs();
+        let claims = SecretClaims {
+            iss: &key.team_id,
+            iat: now,
+            exp: now + 300,
+            aud: APPLE_ISSUER,
+            sub: &self.audience,
+        };
+        let signer = EncodingKey::from_ec_pem(key.private_key.as_bytes())
+            .map_err(|e| format!("siwa private key unusable: {e}"))?;
+        encode(&header, &claims, &signer).map_err(|e| format!("client secret signing failed: {e}"))
+    }
+
+    #[cfg(test)]
+    async fn seed_key(&self, kid: &str, key: DecodingKey) {
+        self.keys.write().await.insert(kid.to_owned(), key);
+    }
+}
+
+/// Verified claims, exposed read-only so callers can't construct one without
+/// going through verification.
+pub struct AppleClaimsView(AppleClaims);
+
+impl AppleClaimsView {
+    pub fn sub(&self) -> &str {
+        &self.0.sub
+    }
+}
+
+fn identity(view: AppleClaimsView) -> AppleIdentity {
+    let claims = view.0;
+    let verified = match &claims.email_verified {
+        Some(Value::Bool(b)) => *b,
+        Some(Value::String(s)) => s == "true",
+        _ => false,
+    };
+    AppleIdentity {
+        sub: claims.sub,
+        email: claims.email.filter(|_| verified),
+    }
+}
+
+/// `application/x-www-form-urlencoded` body (this reqwest build compiles
+/// without its form support, and the values — JWTs, Apple codes — are simple).
+fn form_body(pairs: &[(&str, &str)]) -> String {
+    fn enc(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        for b in s.bytes() {
+            match b {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    out.push(b as char)
+                }
+                _ => {
+                    use std::fmt::Write;
+                    let _ = write!(out, "%{b:02X}");
+                }
+            }
+        }
+        out
+    }
+    pairs
+        .iter()
+        .map(|(k, v)| format!("{}={}", enc(k), enc(v)))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn sha256_hex(raw: &str) -> String {
+    let digest = Sha256::digest(raw.as_bytes());
+    digest.iter().fold(String::new(), |mut acc, b| {
+        use std::fmt::Write;
+        let _ = write!(acc, "{b:02x}");
+        acc
+    })
+}
+
+fn now_secs() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KID: &str = "apple-test-key";
+    const AUDIENCE: &str = "com.johncarmack.lux";
+
+    // The same throwaway 2048-bit RSA test keypair lux-auth's tests use.
+    const PRIVATE_PEM: &[u8] = b"-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCuCAG4yH4kvTeh
+MkF84jX4Q1RgR28rEbwHG0nbnVCKNtRKsD1DijWjvoXxcLPpLmCBixF6GmyHQ8j1
+tSJH5T6HSke/9mgSBnfrkpykIks/LKGJ1/6ox8h9DntfHf6z5uLUvg5geYIyXeg0
+6uOxQaaDSQSpOxHzT7VoGLiZCfG/+FwdLQCMOi0bRRxfBo53rBvCJTP8ZgJX3YSK
+I8Xj0NLQGZTnb1amI9HIqpxMfWRhPRpAy6kgGEai1WiMdAnDHvDxWNm5vl0rGBzB
+eNHhEMEsyIBTsWMs3biNGdt2rb6qDNa3HouPApuuMPLpNm7W1fvxZ7Gghrl2ehK9
+SYw1PoLzAgMBAAECggEAJesxsNjif0/JGLLSCQti1gKZllbKNpipHuVHvPW0cEEN
+FW78EkTBdjmThq1XTfXgailqd+/c+MYAueSrIP4mlyTMqFtghpjpNSdfQPYF7jBj
+zByHbLAHE5R9thZbgkhK4S6+BDBFeYLzjuAlF2CmDtHwlYz81sZl0NYeFp5PkdOH
+6nPLbD9CRPfvEB1A/QpHU/DD1/3T8/tDBO392mJKsVxzpG62r4MTr4sP+zyKqnaj
+tCO7XxkQUkOwv41JXJKLnUz6SNlSW8vz76qNcRIzccHLWrLtiIW2ZiR6fhF8lFHe
+7//HZXANIbdAs+Imao/S7ekWui4wypktYaa/tvnMjQKBgQDd0HFAFPXLlNKI7l4s
+sFDVBJ7nqr0G6s1cC+eJbPOVOoy7e+BSCzOp5ivk6YJjJx1yK0tmV5oqxQX17OaO
+5aqZOvTLRa5ck5WCl3Q+7mSxs3FpexH6l+SHVtZGLKAoOKwGekF0sJOMgFJO7HXJ
+bqLJni1UJTjkbnCMJJ+Q0PFnvwKBgQDI2lB99kOudVBcNCMD5QEcX33bpaqrGFCH
+JgDhkpZDVhVMNsONpCqNU7j2nNVEvjgbat/VcdAYGIF4dp90QJHpQxYonPZ/DWps
+IeNHuH5syfdYBdcrNP4WgthD0xNbluJPbcji9soofQp5uqMvdMyGNH/Z0KjlnAOJ
+ymJoXKVRzQKBgQDE0pX7X93vBKKAgMst6lH/gzchqF5NCgKpf6K3Tecibq68GiKl
+im0QgD5IxG8/XlEBoqsoJ+mTs/ojC1BWUjK7/xWCXdVnLkoHdC7hPJY7HFgxWdRN
+QYS2FvbRk/2VUxxKLydvzNNQY/klMSsfTz3Bm8rrFJBUGi9iG4k/bjgXbwKBgB+S
+oeCLG6yK6Gz2DSMJlpkdMa2bZy6qDc6Q3MaYwmInYAWw/iB/0+iPZp3tnWDG/g7h
+R/pHf8yp3YBQNVSS6dzfHNaZhe4G79m7ofyeNdFoFieSE3bJR7/GJbTTs1FMcJrH
+yTJUVQb0UPc9rXVCSPw3uHlG4aXmVnAMjleVaK9pAoGBANxk8XLmvRZoVoNKuUGZ
+f2GOeMvrbEBLrzaSDN3mGx1dxBisaYl6P6XeKsq8cO+Y5sq+D5gzm26aIxxn/e8e
+DZ9X7qMu4asofS1OhFYEzHASk/xQxzHWfQ4GElRg/DxZJv2Md3RmVPKVx8N8+Vw7
+p6mW1b1y0a1+HBXK3Q29CgPg
+-----END PRIVATE KEY-----
+";
+    const PUBLIC_PEM: &[u8] = b"-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArggBuMh+JL03oTJBfOI1
++ENUYEdvKxG8BxtJ251QijbUSrA9Q4o1o76F8XCz6S5ggYsRehpsh0PI9bUiR+U+
+h0pHv/ZoEgZ365KcpCJLPyyhidf+qMfIfQ57Xx3+s+bi1L4OYHmCMl3oNOrjsUGm
+g0kEqTsR80+1aBi4mQnxv/hcHS0AjDotG0UcXwaOd6wbwiUz/GYCV92EiiPF49DS
+0BmU529WpiPRyKqcTH1kYT0aQMupIBhGotVojHQJwx7w8VjZub5dKxgcwXjR4RDB
+LMiAU7FjLN24jRnbdq2+qgzWtx6LjwKbrjDy6TZu1tX78WexoIa5dnoSvUmMNT6C
+8wIDAQAB
+-----END PUBLIC KEY-----
+";
+
+    // A throwaway PKCS#8 P-256 key, standing in for a portal-minted `.p8`.
+    const EC_PRIVATE_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgMgrlg56UNdAIx8Sy
+PaNjgYD9H87aiu72kVM4feGqzpehRANCAAQE52G8sprGOcAIUFXU8WtoNLLD3Q80
++yf7BVFFsN+hOx/bqJD2Ums2zRu85qOnODSQ5Mchg4vs1zkk4CHviX8W
+-----END PRIVATE KEY-----
+";
+
+    #[derive(Serialize)]
+    struct TestClaims {
+        sub: String,
+        iss: String,
+        aud: String,
+        exp: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        nonce: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        email: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        email_verified: Option<Value>,
+    }
+
+    impl Default for TestClaims {
+        fn default() -> Self {
+            Self {
+                sub: "001234.abcdef.5678".into(),
+                iss: APPLE_ISSUER.into(),
+                aud: AUDIENCE.into(),
+                exp: 4_102_444_800, // 2100-01-01
+                nonce: Some(sha256_hex("raw-nonce")),
+                email: Some("user@example.com".into()),
+                email_verified: Some(Value::Bool(true)),
+            }
+        }
+    }
+
+    fn sign(claims: &TestClaims) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(KID.to_string());
+        encode(
+            &header,
+            claims,
+            &EncodingKey::from_rsa_pem(PRIVATE_PEM).expect("test key parses"),
+        )
+        .expect("test token signs")
+    }
+
+    async fn auth() -> AppleAuth {
+        // Prod installs ring in main() before any client exists; tests mirror it.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let auth = AppleAuth::new(AUDIENCE.into());
+        auth.seed_key(
+            KID,
+            DecodingKey::from_rsa_pem(PUBLIC_PEM).expect("test key parses"),
+        )
+        .await;
+        auth
+    }
+
+    #[tokio::test]
+    async fn verifies_a_valid_token_with_nonce_and_verified_email() {
+        let identity = auth()
+            .await
+            .verify_identity(&sign(&TestClaims::default()), "raw-nonce")
+            .await
+            .expect("verifies");
+        assert_eq!(identity.sub, "001234.abcdef.5678");
+        assert_eq!(identity.email.as_deref(), Some("user@example.com"));
+    }
+
+    #[tokio::test]
+    async fn accepts_apples_stringly_email_verified() {
+        let claims = TestClaims {
+            email_verified: Some(Value::String("true".into())),
+            ..TestClaims::default()
+        };
+        let identity = auth()
+            .await
+            .verify_identity(&sign(&claims), "raw-nonce")
+            .await
+            .expect("verifies");
+        assert_eq!(identity.email.as_deref(), Some("user@example.com"));
+    }
+
+    #[tokio::test]
+    async fn withholds_an_unverified_email() {
+        let claims = TestClaims {
+            email_verified: Some(Value::Bool(false)),
+            ..TestClaims::default()
+        };
+        let identity = auth()
+            .await
+            .verify_identity(&sign(&claims), "raw-nonce")
+            .await
+            .expect("verifies");
+        assert!(identity.email.is_none(), "unverified email must not link");
+    }
+
+    #[tokio::test]
+    async fn rejects_a_nonce_mismatch() {
+        let err = auth()
+            .await
+            .verify_identity(&sign(&TestClaims::default()), "some-other-nonce")
+            .await
+            .expect_err("must reject");
+        assert!(err.contains("nonce"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_a_missing_nonce() {
+        let claims = TestClaims {
+            nonce: None,
+            ..TestClaims::default()
+        };
+        assert!(auth()
+            .await
+            .verify_identity(&sign(&claims), "raw-nonce")
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_a_wrong_audience() {
+        let claims = TestClaims {
+            aud: "com.example.other".into(),
+            ..TestClaims::default()
+        };
+        assert!(auth().await.verify_token(&sign(&claims)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_a_wrong_issuer() {
+        let claims = TestClaims {
+            iss: "https://evil.example".into(),
+            ..TestClaims::default()
+        };
+        assert!(auth().await.verify_token(&sign(&claims)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_an_expired_token() {
+        let claims = TestClaims {
+            exp: 946_684_800, // 2000-01-01
+            ..TestClaims::default()
+        };
+        assert!(auth().await.verify_token(&sign(&claims)).await.is_err());
+    }
+
+    #[test]
+    fn client_secret_is_a_signed_es256_jwt() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let auth = AppleAuth::new(AUDIENCE.into());
+        let key = SiwaKey {
+            key_id: "ABC123DEFG".into(),
+            team_id: "T3UN6N5K6Z".into(),
+            private_key: EC_PRIVATE_PEM.into(),
+        };
+        let secret = auth.client_secret(&key).expect("mints");
+        assert_eq!(secret.split('.').count(), 3, "compact JWT");
+        let header = decode_header(&secret).expect("header parses");
+        assert_eq!(header.alg, Algorithm::ES256);
+        assert_eq!(header.kid.as_deref(), Some("ABC123DEFG"));
+    }
+}

--- a/services/apple-auth/src/cognito.rs
+++ b/services/apple-auth/src/cognito.rs
@@ -1,0 +1,199 @@
+//! Cognito admin operations: user lookup/creation and the CUSTOM_AUTH dance
+//! that turns a verified Apple identity into ordinary user-pool tokens.
+//!
+//! Users created here follow the pool's shape exactly (`username_attributes =
+//! ["email"]`): the email is the username at creation and `email_verified` is
+//! set because Apple already verified it — so a later "add a password" or
+//! SRP sign-in path needs nothing special.
+
+use aws_sdk_cognitoidentityprovider::types::{
+    AttributeType, AuthFlowType, ChallengeNameType, MessageActionType, UserStatusType, UserType,
+};
+
+use crate::Ctx;
+
+#[derive(Debug)]
+pub struct User {
+    pub username: String,
+    pub sub: String,
+    /// A self-signup that never entered its confirmation code. Apple verifying
+    /// the same email is at least as strong a proof, so the sign-in flow
+    /// confirms these instead of stranding them.
+    pub unconfirmed: bool,
+}
+
+#[derive(Debug)]
+pub struct Tokens {
+    pub id_token: String,
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_in: i32,
+}
+
+pub async fn find_user_by_email(ctx: &Ctx, email: &str) -> Result<Option<User>, String> {
+    find_one(ctx, "email", email).await
+}
+
+pub async fn find_user_by_sub(ctx: &Ctx, sub: &str) -> Result<Option<User>, String> {
+    find_one(ctx, "sub", sub).await
+}
+
+async fn find_one(ctx: &Ctx, attr: &str, value: &str) -> Result<Option<User>, String> {
+    // The filter grammar quotes the value; a quote can't appear in a valid
+    // email or sub, so refuse rather than build a broken (or clever) filter.
+    if value.contains('"') || value.contains('\\') {
+        return Err(format!("unfilterable {attr} value"));
+    }
+    let out = ctx
+        .cognito
+        .list_users()
+        .user_pool_id(&ctx.pool_id)
+        .filter(format!("{attr} = \"{value}\""))
+        .limit(1)
+        .send()
+        .await
+        .map_err(|e| format!("user lookup failed: {e}"))?;
+    Ok(out.users().first().and_then(user_from))
+}
+
+/// Create the Cognito user for a first-time Apple sign-in: email as username,
+/// pre-verified, no invite mail — there is no password to deliver.
+///
+/// Admin-created users land in FORCE_CHANGE_PASSWORD, which blocks auth, so a
+/// random password is set permanent immediately (generated and discarded —
+/// nobody ever knows it) to move the user to CONFIRMED. "Forgot password"
+/// still works against the verified email if they ever want a real one.
+pub async fn create_user(ctx: &Ctx, email: &str) -> Result<User, String> {
+    let attr = |name: &str, value: &str| {
+        AttributeType::builder()
+            .name(name)
+            .value(value)
+            .build()
+            .map_err(|e| format!("attribute build failed: {e}"))
+    };
+    let out = ctx
+        .cognito
+        .admin_create_user()
+        .user_pool_id(&ctx.pool_id)
+        .username(email)
+        .user_attributes(attr("email", email)?)
+        .user_attributes(attr("email_verified", "true")?)
+        .message_action(MessageActionType::Suppress)
+        .send()
+        .await
+        .map_err(|e| format!("user create failed: {e}"))?;
+    let user = out
+        .user()
+        .and_then(user_from)
+        .ok_or_else(|| "user create returned no user".to_owned())?;
+
+    ctx.cognito
+        .admin_set_user_password()
+        .user_pool_id(&ctx.pool_id)
+        .username(&user.username)
+        .password(discarded_password()?)
+        .permanent(true)
+        .send()
+        .await
+        .map_err(|e| format!("user activation failed: {e}"))?;
+
+    Ok(User {
+        unconfirmed: false,
+        ..user
+    })
+}
+
+/// Confirm a stalled self-signup (see [`User::unconfirmed`]).
+pub async fn confirm_user(ctx: &Ctx, username: &str) -> Result<(), String> {
+    ctx.cognito
+        .admin_confirm_sign_up()
+        .user_pool_id(&ctx.pool_id)
+        .username(username)
+        .send()
+        .await
+        .map_err(|e| format!("user confirm failed: {e}"))?;
+    Ok(())
+}
+
+/// 32 bytes of OS randomness as hex, plus an uppercase letter to satisfy the
+/// pool's password policy. Never stored, never returned to anyone.
+fn discarded_password() -> Result<String, String> {
+    use std::io::Read;
+    let mut bytes = [0u8; 32];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut f| f.read_exact(&mut bytes))
+        .map_err(|e| format!("no OS randomness: {e}"))?;
+    let hex = bytes.iter().fold(String::new(), |mut acc, b| {
+        use std::fmt::Write;
+        let _ = write!(acc, "{b:02x}");
+        acc
+    });
+    Ok(format!("A{hex}"))
+}
+
+/// Run the pool's CUSTOM_AUTH flow for `username`, answering the challenge
+/// with the Apple identity token. The VerifyAuthChallenge trigger (this same
+/// binary) re-verifies the token and its link to exactly this user, so these
+/// admin calls add reach, not trust.
+pub async fn custom_auth(ctx: &Ctx, username: &str, identity_token: &str) -> Result<Tokens, String> {
+    let start = ctx
+        .cognito
+        .admin_initiate_auth()
+        .user_pool_id(&ctx.pool_id)
+        .client_id(&ctx.client_id)
+        .auth_flow(AuthFlowType::CustomAuth)
+        .auth_parameters("USERNAME", username)
+        .send()
+        .await
+        .map_err(|e| format!("auth initiate failed: {e}"))?;
+
+    if start.challenge_name() != Some(&ChallengeNameType::CustomChallenge) {
+        return Err(format!(
+            "expected CUSTOM_CHALLENGE, got {:?}",
+            start.challenge_name()
+        ));
+    }
+    let session = start.session().ok_or("auth initiate returned no session")?;
+
+    let done = ctx
+        .cognito
+        .admin_respond_to_auth_challenge()
+        .user_pool_id(&ctx.pool_id)
+        .client_id(&ctx.client_id)
+        .challenge_name(ChallengeNameType::CustomChallenge)
+        .session(session)
+        .challenge_responses("USERNAME", username)
+        .challenge_responses("ANSWER", identity_token)
+        .send()
+        .await
+        .map_err(|e| format!("challenge response failed: {e}"))?;
+
+    let result = done
+        .authentication_result()
+        .ok_or("challenge did not issue tokens")?;
+    let s = |v: Option<&str>, what: &str| -> Result<String, String> {
+        v.map(str::to_owned)
+            .ok_or_else(|| format!("auth result missing {what}"))
+    };
+    Ok(Tokens {
+        id_token: s(result.id_token(), "id token")?,
+        access_token: s(result.access_token(), "access token")?,
+        refresh_token: s(result.refresh_token(), "refresh token")?,
+        expires_in: result.expires_in(),
+    })
+}
+
+fn user_from(user: &UserType) -> Option<User> {
+    let username = user.username()?.to_owned();
+    let sub = user
+        .attributes()
+        .iter()
+        .find(|a| a.name() == "sub")
+        .and_then(|a| a.value())
+        .map(str::to_owned)?;
+    Some(User {
+        username,
+        sub,
+        unconfirmed: user.user_status() == Some(&UserStatusType::Unconfirmed),
+    })
+}

--- a/services/apple-auth/src/http.rs
+++ b/services/apple-auth/src/http.rs
@@ -1,0 +1,391 @@
+//! The Function URL surface: parse the Lambda URL (payload v2) event, route,
+//! and reply in `lux-wire` shapes. Identity on `/link` and `/revoke` comes only
+//! from the verified Cognito bearer token; identity on `/auth/apple` comes only
+//! from the verified Apple identity token — a request body never names a user.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use lambda_runtime::Error;
+use lux_wire::apple::{
+    LinkResponse, RevokeResponse, SignInRequest, SignInResponse, APPLE_SEGMENT, AUTH_SEGMENT,
+    LINK_SEGMENT, REVOKE_SEGMENT,
+};
+use lux_wire::ErrorResponse;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::{apple, cognito, store, Ctx};
+
+/// The slice of a Function URL (payload format 2.0) event we route on.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct UrlEvent {
+    raw_path: String,
+    headers: HashMap<String, String>,
+    body: Option<String>,
+    is_base64_encoded: bool,
+    request_context: RequestContext,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct RequestContext {
+    http: HttpContext,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct HttpContext {
+    method: String,
+}
+
+pub async fn handle(ctx: &Arc<Ctx>, payload: Value) -> Result<Value, Error> {
+    let event: UrlEvent = match serde_json::from_value(payload) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::error!("unroutable invoke payload: {e}");
+            return reply(400, &error("unroutable request"));
+        }
+    };
+
+    let method = event.request_context.http.method.as_str();
+    let path = event.raw_path.clone();
+    let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
+
+    match (method, segments.as_slice()) {
+        ("POST", [a, b]) if *a == AUTH_SEGMENT && *b == APPLE_SEGMENT => {
+            sign_in(ctx, &event).await
+        }
+        ("POST", [a, b, c]) if *a == AUTH_SEGMENT && *b == APPLE_SEGMENT && *c == LINK_SEGMENT => {
+            link(ctx, &event).await
+        }
+        ("POST", [a, b, c])
+            if *a == AUTH_SEGMENT && *b == APPLE_SEGMENT && *c == REVOKE_SEGMENT =>
+        {
+            revoke(ctx, &event).await
+        }
+        _ => reply(404, &error("not found")),
+    }
+}
+
+/// `POST /auth/apple` — sign in with a verified Apple identity token, creating
+/// or auto-linking a Cognito user on first use.
+async fn sign_in(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
+    let req: SignInRequest = match parse_body(event) {
+        Ok(b) => b,
+        Err(e) => return reply(400, &error(&e)),
+    };
+
+    let identity = match ctx
+        .apple
+        .verify_identity(&req.identity_token, &req.raw_nonce)
+        .await
+    {
+        Ok(i) => i,
+        Err(e) => {
+            tracing::warn!("apple identity token rejected: {e}");
+            return reply(401, &error("invalid apple identity token"));
+        }
+    };
+
+    let (username, created) = match store::get_link(ctx, &identity.sub).await {
+        Err(e) => {
+            tracing::error!("link lookup failed: {e}");
+            return reply(500, &error("internal"));
+        }
+        Ok(Some(link)) => {
+            // Known Apple user. Refresh the stored (revocable) Apple token
+            // best-effort — the sign-in itself must not depend on Apple's
+            // token endpoint being reachable once a link exists.
+            match refresh_apple_token(ctx, &identity.sub, &req.authorization_code).await {
+                Ok(()) => {}
+                Err(e) => tracing::warn!("apple refresh-token update skipped: {e}"),
+            }
+            (link.username, false)
+        }
+        Ok(None) => match first_sign_in(ctx, &identity, &req).await {
+            Ok(x) => x,
+            Err(e) => return Ok(e),
+        },
+    };
+
+    let tokens = match cognito::custom_auth(ctx, &username, &req.identity_token).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!("custom auth failed for linked user: {e}");
+            return reply(500, &error("internal"));
+        }
+    };
+
+    reply(
+        200,
+        &SignInResponse {
+            id_token: tokens.id_token,
+            access_token: tokens.access_token,
+            refresh_token: tokens.refresh_token,
+            expires_in: tokens.expires_in,
+            created,
+        },
+    )
+}
+
+/// First use of this Apple credential: attach it to the account whose verified
+/// email matches, or create a fresh account (relay emails land here by
+/// construction). Returns the Function URL error reply on failure.
+async fn first_sign_in(
+    ctx: &Arc<Ctx>,
+    identity: &apple::AppleIdentity,
+    req: &SignInRequest,
+) -> Result<(String, bool), Value> {
+    let Some(email) = identity.email.as_deref() else {
+        // No verified email in the token and no existing link: the only path
+        // here is a stale prior grant. The user resets it in Settings → Sign
+        // in with Apple; the client surfaces this text.
+        return Err(fail(
+            400,
+            "apple grant has no email; remove lux under Settings > Sign in with Apple and retry",
+        ));
+    };
+
+    let (user, created) = match cognito::find_user_by_email(ctx, email).await {
+        Err(e) => {
+            tracing::error!("user lookup failed: {e}");
+            return Err(fail(500, "internal"));
+        }
+        Ok(Some(user)) => {
+            // A self-signup that never entered its confirmation code: Apple
+            // just verified the same address, so confirm and proceed.
+            if user.unconfirmed {
+                if let Err(e) = cognito::confirm_user(ctx, &user.username).await {
+                    tracing::error!("user confirm failed: {e}");
+                    return Err(fail(500, "internal"));
+                }
+            }
+            (user, false)
+        }
+        Ok(None) => match cognito::create_user(ctx, email).await {
+            Ok(u) => (u, true),
+            Err(e) => {
+                tracing::error!("user create failed: {e}");
+                return Err(fail(500, "internal"));
+            }
+        },
+    };
+
+    // The code exchange is required on first link: a mapping without a
+    // revocable Apple token could never honor account deletion's revocation
+    // duty, so fail loud instead (the sheet mints a fresh code on retry).
+    let apple_refresh = match exchange_code(ctx, &req.authorization_code).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!("apple code exchange failed: {e}");
+            return Err(fail(502, "apple token exchange failed"));
+        }
+    };
+
+    if let Err(e) = store::put_link(
+        ctx,
+        &identity.sub,
+        &user.username,
+        &user.sub,
+        &apple_refresh,
+        req.email.as_deref().or(Some(email)),
+        req.full_name.as_deref(),
+    )
+    .await
+    {
+        tracing::error!("link write failed: {e}");
+        return Err(fail(500, "internal"));
+    }
+
+    Ok((user.username, created))
+}
+
+/// `POST /auth/apple/link` — bearer-authed: bind the caller's account to the
+/// presented Apple credential regardless of email (the Hide My Email path).
+/// Links are 1:1 — an Apple id links one account, an account links one Apple id.
+async fn link(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
+    let Some(caller_sub) = caller(ctx, event) else {
+        return reply(401, &error("invalid or missing token"));
+    };
+    let req: SignInRequest = match parse_body(event) {
+        Ok(b) => b,
+        Err(e) => return reply(400, &error(&e)),
+    };
+    let identity = match ctx
+        .apple
+        .verify_identity(&req.identity_token, &req.raw_nonce)
+        .await
+    {
+        Ok(i) => i,
+        Err(e) => {
+            tracing::warn!("apple identity token rejected: {e}");
+            return reply(401, &error("invalid apple identity token"));
+        }
+    };
+
+    match store::get_link(ctx, &identity.sub).await {
+        Err(e) => {
+            tracing::error!("link lookup failed: {e}");
+            return reply(500, &error("internal"));
+        }
+        Ok(Some(link)) if link.sub == caller_sub => {
+            return reply(200, &LinkResponse { linked: true })
+        }
+        Ok(Some(_)) => return reply(409, &error("apple id already linked to another account")),
+        Ok(None) => {}
+    }
+    match store::get_reverse(ctx, &caller_sub).await {
+        Err(e) => {
+            tracing::error!("reverse link lookup failed: {e}");
+            return reply(500, &error("internal"));
+        }
+        Ok(Some(_)) => return reply(409, &error("account already linked to an apple id")),
+        Ok(None) => {}
+    }
+
+    let user = match cognito::find_user_by_sub(ctx, &caller_sub).await {
+        Ok(Some(u)) => u,
+        Ok(None) => return reply(404, &error("account not found")),
+        Err(e) => {
+            tracing::error!("user lookup failed: {e}");
+            return reply(500, &error("internal"));
+        }
+    };
+
+    let apple_refresh = match exchange_code(ctx, &req.authorization_code).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!("apple code exchange failed: {e}");
+            return reply(502, &error("apple token exchange failed"));
+        }
+    };
+
+    if let Err(e) = store::put_link(
+        ctx,
+        &identity.sub,
+        &user.username,
+        &user.sub,
+        &apple_refresh,
+        identity.email.as_deref(),
+        req.full_name.as_deref(),
+    )
+    .await
+    {
+        tracing::error!("link write failed: {e}");
+        return reply(500, &error("internal"));
+    }
+
+    reply(200, &LinkResponse { linked: true })
+}
+
+/// `POST /auth/apple/revoke` — bearer-authed: revoke the stored Apple refresh
+/// token and drop the link. Account deletion calls this first; on Apple-side
+/// failure the link is kept and the call is retryable.
+async fn revoke(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
+    let Some(caller_sub) = caller(ctx, event) else {
+        return reply(401, &error("invalid or missing token"));
+    };
+
+    let apple_sub = match store::get_reverse(ctx, &caller_sub).await {
+        Err(e) => {
+            tracing::error!("reverse link lookup failed: {e}");
+            return reply(500, &error("internal"));
+        }
+        Ok(None) => return reply(200, &RevokeResponse { revoked: false }),
+        Ok(Some(s)) => s,
+    };
+    let link = match store::get_link(ctx, &apple_sub).await {
+        Ok(Some(l)) => l,
+        Ok(None) => return reply(200, &RevokeResponse { revoked: false }),
+        Err(e) => {
+            tracing::error!("link lookup failed: {e}");
+            return reply(500, &error("internal"));
+        }
+    };
+
+    let key = match ctx.siwa_key().await {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::error!("{e}");
+            return reply(500, &error("apple signing key unavailable"));
+        }
+    };
+    if let Err(e) = ctx.apple.revoke(key, &link.apple_refresh_token).await {
+        tracing::error!("apple revoke failed: {e}");
+        return reply(502, &error("apple revoke failed"));
+    }
+
+    if let Err(e) = store::delete_link(ctx, &apple_sub, &caller_sub).await {
+        // The Apple-side revoke succeeded; a dangling mapping row is only
+        // local noise, but surface it — deletion flows should be silent-clean.
+        tracing::error!("link delete failed after revoke: {e}");
+        return reply(500, &error("internal"));
+    }
+
+    reply(200, &RevokeResponse { revoked: true })
+}
+
+// --- shared steps -------------------------------------------------------------
+
+/// Exchange the sheet's single-use authorization code for Apple's revocable
+/// refresh token (needs the Apple-side signing key).
+async fn exchange_code(ctx: &Arc<Ctx>, code: &str) -> Result<String, String> {
+    let key = ctx.siwa_key().await?;
+    ctx.apple.exchange_code(key, code).await
+}
+
+/// Best-effort on re-auth: keep the stored revocable token fresh.
+async fn refresh_apple_token(ctx: &Arc<Ctx>, apple_sub: &str, code: &str) -> Result<(), String> {
+    let token = exchange_code(ctx, code).await?;
+    store::set_refresh_token(ctx, apple_sub, &token).await
+}
+
+// --- request/response helpers -------------------------------------------------
+
+/// The verified caller (`sub`) from the bearer token, if any.
+fn caller(ctx: &Ctx, event: &UrlEvent) -> Option<String> {
+    let token = event
+        .headers
+        .get("authorization")?
+        .strip_prefix("Bearer ")?;
+    ctx.verifier.verify(token).ok().map(|c| c.sub)
+}
+
+fn parse_body<T: for<'de> Deserialize<'de>>(event: &UrlEvent) -> Result<T, String> {
+    let raw = event.body.as_deref().unwrap_or_default();
+    let bytes = if event.is_base64_encoded {
+        BASE64
+            .decode(raw)
+            .map_err(|e| format!("bad body encoding: {e}"))?
+    } else {
+        raw.as_bytes().to_vec()
+    };
+    serde_json::from_slice(&bytes).map_err(|e| format!("bad body: {e}"))
+}
+
+fn error(message: &str) -> ErrorResponse {
+    ErrorResponse {
+        error: message.to_owned(),
+    }
+}
+
+/// A Function URL (payload v2) response.
+fn reply<T: serde::Serialize>(status: u16, body: &T) -> Result<Value, Error> {
+    Ok(json!({
+        "statusCode": status,
+        "headers": { "content-type": "application/json" },
+        "body": serde_json::to_string(body)?,
+    }))
+}
+
+/// Same as [`reply`] but usable where a `Value` (not a `Result`) is needed.
+fn fail(status: u16, message: &str) -> Value {
+    json!({
+        "statusCode": status,
+        "headers": { "content-type": "application/json" },
+        "body": serde_json::to_string(&error(message)).unwrap_or_else(|_| "{}".into()),
+    })
+}

--- a/services/apple-auth/src/main.rs
+++ b/services/apple-auth/src/main.rs
@@ -1,0 +1,135 @@
+//! lux-apple-auth — the Sign in with Apple bridge, on AWS Lambda.
+//!
+//! The desktop runs the native `ASAuthorizationController` sheet and posts the
+//! resulting Apple identity token to this Function URL (`lux_wire::apple`).
+//! The handler verifies the token against Apple's JWKS (audience = the app's
+//! bundle id, nonce-bound), maps Apple's stable `sub` to a Cognito user via
+//! items in the `lux-sync` table (`APPLE#…`/`APPLELINK#…` partitions — never
+//! the pool schema, never the sync partitions), and mints ordinary user-pool
+//! JWTs through the pool's CUSTOM_AUTH flow. The same binary also serves that
+//! flow's three Cognito trigger events (`triggers`), so the challenge's
+//! verifier is this exact code: even a client calling Cognito directly can
+//! only ever custom-auth into the account its Apple token is linked to.
+//!
+//! Invoke surfaces, branched on payload shape (`triggerSource` is only ever
+//! present on Cognito trigger events):
+//! - Function URL: `POST /auth/apple` (sign in / first-use create-or-link),
+//!   `POST /auth/apple/link` (bearer-authed explicit link — the Hide My Email
+//!   path), `POST /auth/apple/revoke` (bearer-authed; account deletion's
+//!   required Apple token revocation).
+//! - Cognito triggers: DefineAuthChallenge / CreateAuthChallenge /
+//!   VerifyAuthChallengeResponse.
+//!
+//! The Apple-side private key (`lux/siwa-key`, Secrets Manager) is loaded
+//! lazily and cached: it is only needed for the code-exchange and revoke calls
+//! to Apple, so token verification and the trigger path keep working — and P1
+//! ships dark — before the secret is seeded.
+
+mod apple;
+mod cognito;
+mod http;
+mod store;
+mod triggers;
+
+use std::sync::Arc;
+
+use aws_config::BehaviorVersion;
+use lambda_runtime::{run, service_fn, Error, LambdaEvent};
+use serde_json::Value;
+
+pub(crate) struct Ctx {
+    pub cognito: aws_sdk_cognitoidentityprovider::Client,
+    pub ddb: aws_sdk_dynamodb::Client,
+    pub secrets: aws_sdk_secretsmanager::Client,
+    pub verifier: lux_auth::Verifier,
+    pub apple: apple::AppleAuth,
+    /// The Apple-side signing key, loaded from Secrets Manager on first use.
+    pub siwa_key: tokio::sync::OnceCell<apple::SiwaKey>,
+    pub pool_id: String,
+    pub client_id: String,
+    pub table: String,
+    pub siwa_secret_id: String,
+}
+
+impl Ctx {
+    /// The Apple-side private key, fetched once per warm container. An unseeded
+    /// or malformed secret is a runtime error on the routes that talk to Apple,
+    /// never a startup crash — verification-only paths must keep working.
+    pub async fn siwa_key(&self) -> Result<&apple::SiwaKey, String> {
+        self.siwa_key
+            .get_or_try_init(|| async {
+                let out = self
+                    .secrets
+                    .get_secret_value()
+                    .secret_id(&self.siwa_secret_id)
+                    .send()
+                    .await
+                    .map_err(|e| format!("siwa key secret read failed: {e}"))?;
+                let raw = out
+                    .secret_string()
+                    .ok_or("siwa key secret has no string value")?;
+                serde_json::from_str::<apple::SiwaKey>(raw)
+                    .map_err(|e| format!("siwa key secret is malformed: {e}"))
+            })
+            .await
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .without_time()
+        .init();
+
+    // reqwest uses rustls with no baked provider; install ring as the process
+    // default before any TLS (Cognito JWKS below, Apple JWKS on first verify).
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let pool_id = env("COGNITO_USER_POOL_ID")?;
+    let client_id = env("COGNITO_APP_CLIENT_ID")?;
+    let region = env("COGNITO_REGION")?;
+    let table = env("DYNAMODB_TABLE")?;
+    let bundle_id = env("APPLE_BUNDLE_ID")?;
+    let siwa_secret_id = env("SIWA_SECRET_ID")?;
+
+    let verifier = lux_auth::Verifier::new(&region, &pool_id, &client_id)
+        .await
+        .expect("failed to fetch Cognito JWKS");
+
+    let conf = aws_config::load_defaults(BehaviorVersion::latest()).await;
+
+    let ctx = Arc::new(Ctx {
+        cognito: aws_sdk_cognitoidentityprovider::Client::new(&conf),
+        ddb: aws_sdk_dynamodb::Client::new(&conf),
+        secrets: aws_sdk_secretsmanager::Client::new(&conf),
+        verifier,
+        apple: apple::AppleAuth::new(bundle_id),
+        siwa_key: tokio::sync::OnceCell::new(),
+        pool_id,
+        client_id,
+        table,
+        siwa_secret_id,
+    });
+
+    run(service_fn(move |event: LambdaEvent<Value>| {
+        let ctx = ctx.clone();
+        async move { handle(ctx, event.payload).await }
+    }))
+    .await
+}
+
+async fn handle(ctx: Arc<Ctx>, payload: Value) -> Result<Value, Error> {
+    // Cognito trigger events are the only payloads carrying `triggerSource`;
+    // everything else is a Function URL request.
+    if payload.get("triggerSource").is_some() {
+        triggers::handle(&ctx, payload).await
+    } else {
+        http::handle(&ctx, payload).await
+    }
+}
+
+fn env(key: &str) -> Result<String, Error> {
+    std::env::var(key).map_err(|_| format!("missing required env var {key}").into())
+}

--- a/services/apple-auth/src/store.rs
+++ b/services/apple-auth/src/store.rs
@@ -1,0 +1,192 @@
+//! The Apple↔Cognito link store: two mirrored items per link in the `lux-sync`
+//! table, written transactionally.
+//!
+//! - `pk = APPLE#<apple_sub>,   sk = LINK` — forward: which Cognito user this
+//!   Apple credential signs into (plus the revocable Apple refresh token).
+//! - `pk = APPLELINK#<sub>,     sk = LINK` — reverse: which Apple credential
+//!   the Cognito user is bound to (revoke/deletion's lookup).
+//!
+//! Both partitions are deliberately disjoint from the sync data's `USER#<sub>`
+//! partitions, so sync's list query never sees them and account deletion's
+//! partition wipe never races the revoke flow — cleaning these up is the
+//! revoke route's job. The IAM policy pins this service to exactly these key
+//! prefixes (`dynamodb:LeadingKeys`).
+
+use std::collections::HashMap;
+
+use aws_sdk_dynamodb::types::{AttributeValue, Delete, Put, TransactWriteItem};
+
+use crate::Ctx;
+
+/// One Apple↔Cognito link, as read from the forward item.
+#[derive(Debug)]
+pub struct Link {
+    pub username: String,
+    pub sub: String,
+    pub apple_refresh_token: String,
+}
+
+fn forward_pk(apple_sub: &str) -> String {
+    format!("APPLE#{apple_sub}")
+}
+
+fn reverse_pk(sub: &str) -> String {
+    format!("APPLELINK#{sub}")
+}
+
+const LINK_SK: &str = "LINK";
+
+pub async fn get_link(ctx: &Ctx, apple_sub: &str) -> Result<Option<Link>, String> {
+    let out = ctx
+        .ddb
+        .get_item()
+        .table_name(&ctx.table)
+        .key("pk", AttributeValue::S(forward_pk(apple_sub)))
+        .key("sk", AttributeValue::S(LINK_SK.into()))
+        .send()
+        .await
+        .map_err(|e| format!("link get failed: {e}"))?;
+    let Some(item) = out.item else {
+        return Ok(None);
+    };
+    let s = |k: &str| -> Result<String, String> {
+        item.get(k)
+            .and_then(|v| v.as_s().ok())
+            .cloned()
+            .ok_or_else(|| format!("link item missing {k}"))
+    };
+    Ok(Some(Link {
+        username: s("username")?,
+        sub: s("sub")?,
+        apple_refresh_token: s("appleRefreshToken")?,
+    }))
+}
+
+/// The linked Apple `sub` for a Cognito user, if any.
+pub async fn get_reverse(ctx: &Ctx, sub: &str) -> Result<Option<String>, String> {
+    let out = ctx
+        .ddb
+        .get_item()
+        .table_name(&ctx.table)
+        .key("pk", AttributeValue::S(reverse_pk(sub)))
+        .key("sk", AttributeValue::S(LINK_SK.into()))
+        .send()
+        .await
+        .map_err(|e| format!("reverse link get failed: {e}"))?;
+    Ok(out
+        .item
+        .and_then(|item| item.get("appleSub").and_then(|v| v.as_s().ok()).cloned()))
+}
+
+/// Write (or overwrite) both halves of a link transactionally.
+#[allow(clippy::too_many_arguments)]
+pub async fn put_link(
+    ctx: &Ctx,
+    apple_sub: &str,
+    username: &str,
+    sub: &str,
+    apple_refresh_token: &str,
+    email_seen: Option<&str>,
+    name_seen: Option<&str>,
+) -> Result<(), String> {
+    let mut forward: HashMap<String, AttributeValue> = HashMap::from([
+        ("pk".into(), AttributeValue::S(forward_pk(apple_sub))),
+        ("sk".into(), AttributeValue::S(LINK_SK.into())),
+        ("username".into(), AttributeValue::S(username.into())),
+        ("sub".into(), AttributeValue::S(sub.into())),
+        (
+            "appleRefreshToken".into(),
+            AttributeValue::S(apple_refresh_token.into()),
+        ),
+        (
+            "createdAt".into(),
+            AttributeValue::N(now_millis().to_string()),
+        ),
+    ]);
+    // First-authorization extras: Apple only ever sends these once, so they are
+    // recorded on the link or nowhere.
+    if let Some(email) = email_seen {
+        forward.insert("emailSeen".into(), AttributeValue::S(email.into()));
+    }
+    if let Some(name) = name_seen {
+        forward.insert("nameSeen".into(), AttributeValue::S(name.into()));
+    }
+
+    let reverse: HashMap<String, AttributeValue> = HashMap::from([
+        ("pk".into(), AttributeValue::S(reverse_pk(sub))),
+        ("sk".into(), AttributeValue::S(LINK_SK.into())),
+        ("appleSub".into(), AttributeValue::S(apple_sub.into())),
+    ]);
+
+    // Links are written once (re-auth refreshes ride `set_refresh_token`), so
+    // both puts insist on inserting: a concurrent duplicate first-link loses
+    // cleanly instead of half-overwriting a 1:1 pair.
+    let put = |item| {
+        Put::builder()
+            .table_name(&ctx.table)
+            .set_item(Some(item))
+            .condition_expression("attribute_not_exists(pk)")
+            .build()
+            .map_err(|e| format!("link put malformed: {e}"))
+    };
+    ctx.ddb
+        .transact_write_items()
+        .transact_items(TransactWriteItem::builder().put(put(forward)?).build())
+        .transact_items(TransactWriteItem::builder().put(put(reverse)?).build())
+        .send()
+        .await
+        .map_err(|e| format!("link write failed: {e}"))?;
+    Ok(())
+}
+
+/// Update the stored revocable Apple token on a re-auth (best-effort caller).
+pub async fn set_refresh_token(ctx: &Ctx, apple_sub: &str, token: &str) -> Result<(), String> {
+    ctx.ddb
+        .update_item()
+        .table_name(&ctx.table)
+        .key("pk", AttributeValue::S(forward_pk(apple_sub)))
+        .key("sk", AttributeValue::S(LINK_SK.into()))
+        .update_expression("SET appleRefreshToken = :t")
+        .expression_attribute_values(":t", AttributeValue::S(token.into()))
+        .condition_expression("attribute_exists(pk)")
+        .send()
+        .await
+        .map_err(|e| format!("refresh token update failed: {e}"))?;
+    Ok(())
+}
+
+/// Drop both halves of a link transactionally (after a successful revoke).
+pub async fn delete_link(ctx: &Ctx, apple_sub: &str, sub: &str) -> Result<(), String> {
+    let delete = |pk: String| {
+        Delete::builder()
+            .table_name(&ctx.table)
+            .key("pk", AttributeValue::S(pk))
+            .key("sk", AttributeValue::S(LINK_SK.into()))
+            .build()
+            .map_err(|e| format!("link delete malformed: {e}"))
+    };
+    ctx.ddb
+        .transact_write_items()
+        .transact_items(
+            TransactWriteItem::builder()
+                .delete(delete(forward_pk(apple_sub))?)
+                .build(),
+        )
+        .transact_items(
+            TransactWriteItem::builder()
+                .delete(delete(reverse_pk(sub))?)
+                .build(),
+        )
+        .send()
+        .await
+        .map_err(|e| format!("link delete failed: {e}"))?;
+    Ok(())
+}
+
+fn now_millis() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/services/apple-auth/src/triggers.rs
+++ b/services/apple-auth/src/triggers.rs
@@ -1,0 +1,168 @@
+//! The pool's CUSTOM_AUTH triggers, served from the same binary as the routes
+//! that drive the flow.
+//!
+//! Trust lives in Verify: the challenge answer is the Apple identity token,
+//! re-verified here from scratch (signature via Apple's JWKS, issuer,
+//! audience, expiry) and then bound to the authenticating user through the
+//! link store — `answerCorrect` only when the token's Apple `sub` is linked to
+//! exactly this Cognito user. That holds even if a client calls Cognito's
+//! public CUSTOM_AUTH directly and skips our Function URL: without a valid,
+//! linked Apple token there is no way through. (The nonce binding is enforced
+//! at the Function URL, where the sheet context exists; here a token is a
+//! bearer credential with Apple's own 10-minute expiry.)
+//!
+//! Cognito requires the whole event echoed back with `response` filled in.
+
+use lambda_runtime::Error;
+use serde_json::{json, Value};
+
+use crate::{store, Ctx};
+
+pub async fn handle(ctx: &Ctx, mut event: Value) -> Result<Value, Error> {
+    let source = event
+        .get("triggerSource")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    match source.as_str() {
+        "DefineAuthChallenge_Authentication" => define(&mut event),
+        "CreateAuthChallenge_Authentication" => create(&mut event),
+        "VerifyAuthChallengeResponse_Authentication" => verify(ctx, &mut event).await,
+        other => return Err(format!("unsupported trigger source {other}").into()),
+    }
+    Ok(event)
+}
+
+/// One custom challenge, one shot: issue tokens after a correct answer, fail
+/// the auth after a wrong one (the client never retries within a session —
+/// each sheet run starts a fresh auth).
+fn define(event: &mut Value) {
+    let session = event
+        .pointer("/request/session")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let succeeded = session.iter().any(|attempt| {
+        attempt
+            .get("challengeResult")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    });
+
+    let response = &mut event["response"];
+    if succeeded {
+        response["issueTokens"] = json!(true);
+        response["failAuthentication"] = json!(false);
+    } else if session.is_empty() {
+        response["issueTokens"] = json!(false);
+        response["failAuthentication"] = json!(false);
+        response["challengeName"] = json!("CUSTOM_CHALLENGE");
+    } else {
+        response["issueTokens"] = json!(false);
+        response["failAuthentication"] = json!(true);
+    }
+}
+
+/// The challenge itself carries nothing secret — Verify does the real work —
+/// but Cognito requires the parameter objects to exist.
+fn create(event: &mut Value) {
+    let response = &mut event["response"];
+    response["publicChallengeParameters"] = json!({ "challenge": "apple-identity-token" });
+    response["privateChallengeParameters"] = json!({});
+    response["challengeMetadata"] = json!("APPLE_IDENTITY_TOKEN");
+}
+
+/// A bad token, an unlinked credential, or a link to a different user are all
+/// the same outcome: `answerCorrect = false`. Only infrastructure failures
+/// (the link store erroring) surface as invoke errors.
+async fn verify(ctx: &Ctx, event: &mut Value) {
+    let answer = event
+        .pointer("/request/challengeAnswer")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    let user_sub = event
+        .pointer("/request/userAttributes/sub")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+
+    let correct = answer_is_correct(ctx, &answer, &user_sub).await;
+    event["response"]["answerCorrect"] = json!(correct);
+}
+
+async fn answer_is_correct(ctx: &Ctx, answer: &str, user_sub: &str) -> bool {
+    if answer.is_empty() || user_sub.is_empty() {
+        return false;
+    }
+    let claims = match ctx.apple.verify_token(answer).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("challenge answer rejected: {e}");
+            return false;
+        }
+    };
+    match store::get_link(ctx, claims.sub()).await {
+        Ok(Some(link)) => link.sub == user_sub,
+        Ok(None) => {
+            tracing::warn!("challenge answer for an unlinked apple credential");
+            false
+        }
+        Err(e) => {
+            tracing::error!("link lookup failed during verify: {e}");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(source: &str, session: Value) -> Value {
+        json!({
+            "triggerSource": source,
+            "request": { "session": session },
+            "response": {}
+        })
+    }
+
+    #[test]
+    fn define_starts_with_a_custom_challenge() {
+        let mut e = event("DefineAuthChallenge_Authentication", json!([]));
+        define(&mut e);
+        assert_eq!(e["response"]["challengeName"], "CUSTOM_CHALLENGE");
+        assert_eq!(e["response"]["issueTokens"], false);
+        assert_eq!(e["response"]["failAuthentication"], false);
+    }
+
+    #[test]
+    fn define_issues_tokens_after_a_correct_answer() {
+        let mut e = event(
+            "DefineAuthChallenge_Authentication",
+            json!([{ "challengeName": "CUSTOM_CHALLENGE", "challengeResult": true }]),
+        );
+        define(&mut e);
+        assert_eq!(e["response"]["issueTokens"], true);
+        assert_eq!(e["response"]["failAuthentication"], false);
+    }
+
+    #[test]
+    fn define_fails_after_a_wrong_answer() {
+        let mut e = event(
+            "DefineAuthChallenge_Authentication",
+            json!([{ "challengeName": "CUSTOM_CHALLENGE", "challengeResult": false }]),
+        );
+        define(&mut e);
+        assert_eq!(e["response"]["issueTokens"], false);
+        assert_eq!(e["response"]["failAuthentication"], true);
+    }
+
+    #[test]
+    fn create_fills_the_required_parameter_objects() {
+        let mut e = event("CreateAuthChallenge_Authentication", json!([]));
+        create(&mut e);
+        assert!(e["response"]["publicChallengeParameters"].is_object());
+        assert!(e["response"]["privateChallengeParameters"].is_object());
+    }
+}


### PR DESCRIPTION
Adds `lux-apple-auth`: the backend half of native Sign in with Apple. Ships dark — no client calls it yet; the desktop/iOS client, entitlements, and the `appleAuthUrl` endpoints key land in a follow-up once the Function URL exists in applied state.

## What's here

- **`services/apple-auth`** — one Lambda, two invoke surfaces in one binary, branched on payload shape:
  - Function URL routes: `POST /auth/apple` (sign in; first use links by verified email or creates the user), `POST /auth/apple/link` (bearer-authed explicit link — the Hide My Email path), `POST /auth/apple/revoke` (bearer-authed; account deletion's required Apple token revocation).
  - The user pool's CUSTOM_AUTH triggers (Define/Create/Verify). The challenge answer is the Apple identity token, re-verified from scratch (Apple JWKS, issuer, audience, expiry) and bound to the authenticating user through the link store — so a client calling Cognito's public CUSTOM_AUTH directly still can't cross accounts.
- **`crates/lux-wire`** — the `apple` module: request/response shapes + segments, golden-tested like the rest of the wire.
- **`infra/apple-auth.tf`** — function, Function URL, least-privilege role: DynamoDB access pinned by `dynamodb:LeadingKeys` to the `APPLE#*`/`APPLELINK#*` link partitions (disjoint from sync's `USER#` data by construction), pool-scoped admin auth actions, read on `lux/siwa-key`. Plus the `apple_auth_url` output.
- **`infra/accounts.tf`** — `lambda_config` trigger wiring (constructed ARN on purpose: a resource reference would cycle through the function's environment; the apply retry converges the one-time ordering) and `ALLOW_CUSTOM_AUTH` on the app client.
- **Pipeline** — the PR gate's musl build and the release deploy loop cover the fourth function; a typed-401 smoke (`POST /auth/apple` with a garbage token) gates the release like the sync-api's.

## Design notes

- Everything downstream of sign-in is untouched: the flow mints ordinary user-pool JWTs, so sync-api, the IoT authorizer, and nudges see nothing new.
- Admin-created users land in FORCE_CHANGE_PASSWORD, which blocks auth — creation immediately sets a discarded 32-byte random password (permanent) to reach CONFIRMED. A stalled UNCONFIRMED self-signup with the same email is confirmed instead (Apple just verified the address).
- The first sign-in exchanges the authorization code for Apple's revocable refresh token and stores it on the link — a link without one could never honor the deletion revocation duty, so that exchange fails loud. Link writes are insert-only (`attribute_not_exists` on both halves of the 1:1 pair).
- `endpoints.prod.json` and `scripts/gen-endpoints` are deliberately untouched: the app treats a missing endpoint field as "not configured", so the key is added together with the client once the URL is real — both drift gates stay green through the transition.

## Prerequisite before the client ships

Create a Sign in with Apple key in the developer portal (Keys → new key with SIWA enabled; no Services ID needed for native flows) and store it as Secrets Manager secret `lux/siwa-key`: `{"key_id": "…", "team_id": "T3UN6N5K6Z", "private_key": "-----BEGIN PRIVATE KEY-----…"}`. Until it exists, routes that call Apple's token/revoke endpoints fail loud while token verification, the triggers, and the release smoke all work — which is the intended dark-ship state.