### PR TITLE
feat(auth): native sign in with apple on iOS and the Mac App Store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3741,6 +3741,7 @@ dependencies = [
  "keyring-core",
  "libftd2xx 0.33.1",
  "log",
+ "lux-apple-id",
  "lux-engine",
  "lux-wire",
  "reqwest",
@@ -3748,6 +3749,7 @@ dependencies = [
  "rustls 0.23.41",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "specta",
  "strum",
  "strum_macros",
@@ -3785,6 +3787,16 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lux-apple-id"
+version = "0.1.0"
+dependencies = [
+ "objc2",
+ "objc2-app-kit",
+ "objc2-authentication-services",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4164,9 +4176,32 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-authentication-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6d6f7dab884a28adaec1012eb3889257a49cc145724e35f93ece2d209f8b25"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "objc2",
+ "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+ "objc2-security",
 ]
 
 [[package]]
@@ -4186,6 +4221,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -4244,6 +4280,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -4307,6 +4356,16 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "apps/desktop/src-tauri",
     "apps/node",
+    "crates/lux-apple-id",
     "crates/lux-auth",
     "crates/lux-engine",
     "crates/lux-wire",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -64,6 +64,10 @@ uuid = { version = "1.23.4", features = [
 # Cloud-sync HTTP client to the lux-sync-api Function URL; shares the workspace
 # reqwest (rustls-no-provider, riding the app's process-default ring provider).
 reqwest.workspace = true
+# The native Sign in with Apple sheet (the workspace's one unsafe-FFI leaf).
+lux-apple-id = { path = "../../../crates/lux-apple-id" }
+# Nonce hashing for the Apple sheet (the token's nonce claim is SHA-256(raw)).
+sha2 = "0.11"
 # The desktop↔sync-api wire contract — the same crate the Lambda serializes
 # with, so the two sides cannot drift (see crates/lux-wire).
 lux-engine = { path = "../../../crates/lux-engine" }

--- a/apps/desktop/src-tauri/Entitlements.mas.plist
+++ b/apps/desktop/src-tauri/Entitlements.mas.plist
@@ -8,6 +8,10 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<!-- Outbound: sACN/Art-Net UDP, AWS (Cognito/sync/IoT-WSS). -->
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/apps/desktop/src-tauri/gen/apple/lux_iOS/lux_iOS.entitlements
+++ b/apps/desktop/src-tauri/gen/apple/lux_iOS/lux_iOS.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.developer.networking.multicast</key>
 	<true/>
 	<key>com.apple.developer.associated-domains</key>

--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -52,6 +52,17 @@ fn load_config() -> Option<Config> {
         .then_some(config)
 }
 
+/// How the current session was established. Password sessions can change
+/// their password and re-auth by SRP; Apple sessions re-auth by sheet. Stored
+/// with the session so a restart keeps the distinction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, Type)]
+#[serde(rename_all = "lowercase")]
+pub enum Provider {
+    #[default]
+    Password,
+    Apple,
+}
+
 /// The signed-in session, held in memory. The refresh token is also persisted to
 /// the keychain so sign-in survives a restart; the id/access tokens are short
 /// lived and recreated on refresh.
@@ -61,6 +72,7 @@ struct Session {
     id_token: Option<String>,
     access_token: Option<String>,
     refresh_token: Option<String>,
+    provider: Provider,
 }
 
 impl Session {
@@ -78,6 +90,9 @@ pub struct LuxAccount {
     /// Base URL of the lux-sync-api Function URL (`LUX_SYNC_URL`); `None`
     /// disables cloud sync even when auth is configured.
     sync_url: Option<String>,
+    /// Base URL of the lux-apple-auth Function URL; `None` keeps Sign in with
+    /// Apple dark (endpoints field absent/empty).
+    apple_auth_url: Option<String>,
     session: Arc<Mutex<Session>>,
 }
 
@@ -89,6 +104,11 @@ pub struct AuthStatus {
     pub configured: bool,
     pub signed_in: bool,
     pub email: Option<String>,
+    /// How the signed-in session was established; `None` when signed out.
+    pub provider: Option<Provider>,
+    /// Whether native Sign in with Apple is available in this build (platform
+    /// carries the entitlement AND the backend URL is configured).
+    pub apple: bool,
 }
 
 /// Tokens returned by a Cognito auth flow. `refresh` is `None` on a refresh
@@ -100,10 +120,13 @@ struct Tokens {
 }
 
 /// What we persist to the keychain — enough to restore a session on next launch.
+/// `provider` defaults for items written by pre-Apple builds.
 #[derive(Serialize, Deserialize)]
 struct StoredSession {
     refresh_token: String,
     email: String,
+    #[serde(default)]
+    provider: Provider,
 }
 
 impl LuxAccount {
@@ -115,12 +138,16 @@ impl LuxAccount {
                 "accounts not configured (endpoints file has no Cognito values); sign-in disabled"
             ),
         }
-        let sync_url = Some(crate::endpoints::effective().sync_url.clone())
-            .filter(|url| !url.is_empty())
-            .map(|url| url.trim_end_matches('/').to_string());
+        let base_url = |url: &str| {
+            Some(url.to_string())
+                .filter(|url| !url.is_empty())
+                .map(|url| url.trim_end_matches('/').to_string())
+        };
+        let endpoints = crate::endpoints::effective();
         LuxAccount {
             config,
-            sync_url,
+            sync_url: base_url(&endpoints.sync_url),
+            apple_auth_url: base_url(&endpoints.apple_auth_url),
             session: Arc::new(Mutex::new(Session::default())),
         }
     }
@@ -167,7 +194,19 @@ impl LuxAccount {
             configured: self.config.is_some(),
             signed_in: session.signed_in(),
             email: session.email.clone(),
+            provider: session.signed_in().then_some(session.provider),
+            apple: self.apple_sign_in_available(),
         }
+    }
+
+    /// Native Sign in with Apple, on THIS build: the backend must be
+    /// configured, accounts must be configured, and the binary must carry the
+    /// applesignin entitlement — iOS and the Mac App Store flavor today. The
+    /// Developer ID .dmg stays dark until it embeds a provisioning profile
+    /// with the entitlement.
+    fn apple_sign_in_available(&self) -> bool {
+        let entitled = cfg!(target_os = "ios") || (cfg!(target_os = "macos") && cfg!(feature = "mas"));
+        entitled && self.config.is_some() && self.apple_auth_url.is_some()
     }
 
     fn config(&self) -> Result<Config, String> {
@@ -193,10 +232,135 @@ impl LuxAccount {
             save_session(&StoredSession {
                 refresh_token: refresh.clone(),
                 email: email.clone(),
+                provider: Provider::Password,
             });
         }
-        self.apply(tokens, Some(email));
+        self.apply(tokens, Some(email), Some(Provider::Password));
         Ok(self.status())
+    }
+
+    /// Sign in with Apple: run the native sheet, then trade its identity token
+    /// for ordinary user-pool tokens at the lux-apple-auth service. Async on
+    /// purpose — the sheet is user-paced, and this must never block the main
+    /// thread the sheet's callbacks are delivered on.
+    pub async fn sign_in_with_apple(&self, app: &AppHandle) -> Result<AuthStatus, String> {
+        if !self.apple_sign_in_available() {
+            return Err("sign in with apple is not available in this build".into());
+        }
+        let base = self
+            .apple_auth_url
+            .clone()
+            .ok_or("sign in with apple is not configured")?;
+
+        // The token's nonce claim must be SHA-256(raw); the raw value goes only
+        // to our backend, which re-hashes and compares — binding the token to
+        // this sheet run.
+        let raw_nonce = format!(
+            "{}{}",
+            uuid::Uuid::new_v4().simple(),
+            uuid::Uuid::new_v4().simple()
+        );
+        let hashed_nonce = sha256_hex(&raw_nonce);
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        app.run_on_main_thread(move || {
+            lux_apple_id::authorize(
+                &hashed_nonce,
+                Box::new(move |result| {
+                    let _ = tx.send(result);
+                }),
+            );
+        })
+        .map_err(|e| format!("could not present the sign-in sheet: {e}"))?;
+        let authorization = rx
+            .await
+            .map_err(|_| "the sign-in sheet never completed".to_string())??;
+
+        let request = lux_wire::apple::SignInRequest {
+            identity_token: authorization.identity_token,
+            authorization_code: authorization.authorization_code,
+            raw_nonce,
+            email: authorization.email,
+            full_name: authorization.full_name,
+        };
+        let response = reqwest::Client::new()
+            .post(format!(
+                "{base}/{}/{}",
+                lux_wire::apple::AUTH_SEGMENT,
+                lux_wire::apple::APPLE_SEGMENT
+            ))
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| format!("could not reach the sign-in service: {e}"))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let message = response
+                .json::<lux_wire::ErrorResponse>()
+                .await
+                .map(|body| body.error)
+                .unwrap_or_else(|_| format!("sign-in service answered {status}"));
+            return Err(message);
+        }
+        let tokens: lux_wire::apple::SignInResponse = response
+            .json()
+            .await
+            .map_err(|e| format!("malformed sign-in response: {e}"))?;
+
+        // The session's email (the local store's cloud-binding key) comes from
+        // our own id token — the sheet only carries one on first authorization.
+        let email = email_from_id_token(&tokens.id_token)
+            .ok_or("sign-in response carried no email")?;
+        save_session(&StoredSession {
+            refresh_token: tokens.refresh_token.clone(),
+            email: email.clone(),
+            provider: Provider::Apple,
+        });
+        self.apply(
+            Tokens {
+                id: tokens.id_token,
+                access: tokens.access_token,
+                refresh: Some(tokens.refresh_token),
+            },
+            Some(email),
+            Some(Provider::Apple),
+        );
+        Ok(self.status())
+    }
+
+    /// Best-effort Apple-side revocation ahead of account deletion (App Store
+    /// guideline 5.1.1): the backend revokes the stored Apple token and drops
+    /// the link. Never linked is a quiet no-op; a failure is logged and
+    /// deletion proceeds — the user can still revoke from Settings, and the
+    /// sign-in path self-heals a stale link.
+    pub fn revoke_apple_link(&self) {
+        let Some(base) = self.apple_auth_url.clone() else {
+            return;
+        };
+        let Some(token) = self.current_id_token() else {
+            return;
+        };
+        let result = block_on(async move {
+            let response = reqwest::Client::new()
+                .post(format!(
+                    "{base}/{}/{}/{}",
+                    lux_wire::apple::AUTH_SEGMENT,
+                    lux_wire::apple::APPLE_SEGMENT,
+                    lux_wire::apple::REVOKE_SEGMENT
+                ))
+                .bearer_auth(token)
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            if response.status().is_success() {
+                Ok(())
+            } else {
+                Err(format!("revoke answered {}", response.status()))
+            }
+        });
+        if let Err(e) = result {
+            log::warn!("apple revoke skipped ({e}); continuing with deletion");
+        }
     }
 
     pub fn sign_out(&self) -> AuthStatus {
@@ -229,7 +393,7 @@ impl LuxAccount {
                 .clone()
                 .ok_or_else(|| first.clone())?;
             let tokens = block_on(do_refresh(cfg.clone(), refresh)).map_err(|_| first.clone())?;
-            self.apply(tokens, None);
+            self.apply(tokens, None, None);
             let access = self
                 .session
                 .lock_or_recover()
@@ -244,9 +408,10 @@ impl LuxAccount {
         Ok(self.status())
     }
 
-    /// Store freshly-issued tokens. `email` is set on sign-in; left untouched on
-    /// a silent refresh (it carries over from the restored session).
-    fn apply(&self, tokens: Tokens, email: Option<String>) {
+    /// Store freshly-issued tokens. `email`/`provider` are set on sign-in and
+    /// left untouched on a silent refresh (they carry over from the restored
+    /// session).
+    fn apply(&self, tokens: Tokens, email: Option<String>, provider: Option<Provider>) {
         let mut session = self.session.lock_or_recover();
         session.id_token = Some(tokens.id);
         session.access_token = Some(tokens.access);
@@ -255,6 +420,9 @@ impl LuxAccount {
         }
         if email.is_some() {
             session.email = email;
+        }
+        if let Some(provider) = provider {
+            session.provider = provider;
         }
     }
 }
@@ -280,12 +448,9 @@ pub fn restore_on_startup(app: &AppHandle) {
                     s.access_token = Some(tokens.access);
                     s.refresh_token = load_session().map(|s| s.refresh_token);
                     s.email = Some(stored.email.clone());
+                    s.provider = stored.provider;
                 }
-                let status = AuthStatus {
-                    configured: true,
-                    signed_in: true,
-                    email: Some(stored.email),
-                };
+                let status = app.state::<LuxAccount>().status();
                 let _ = CmdEvent::AuthChanged { status }.emit(&app);
                 log::info!("restored signed-in session from keychain");
                 // Pull any setups changed on other devices since last run, and
@@ -449,6 +614,32 @@ fn tokens_from(
         access: r.access_token().unwrap_or_default().to_owned(),
         refresh: r.refresh_token().map(str::to_owned),
     })
+}
+
+fn sha256_hex(raw: &str) -> String {
+    use sha2::{Digest, Sha256};
+    Sha256::digest(raw.as_bytes())
+        .iter()
+        .fold(String::new(), |mut acc, b| {
+            use std::fmt::Write;
+            let _ = write!(acc, "{b:02x}");
+            acc
+        })
+}
+
+/// The `email` claim from our OWN Cognito id token, parsed without
+/// verification on purpose: the desktop holds tokens, it doesn't verify them
+/// (that's the services' job), and this one just arrived over TLS from our
+/// backend.
+fn email_from_id_token(id_token: &str) -> Option<String> {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    let payload = id_token.split('.').nth(1)?;
+    let bytes = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    claims
+        .get("email")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
 }
 
 /// Best-effort message from a Cognito SDK error — the modeled service message

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -107,6 +107,13 @@ pub trait CmdMethods {
         email: String,
         password: String,
     ) -> Result<AuthStatus, String>;
+    /// Run the native Sign in with Apple sheet and exchange its identity token
+    /// for a session. Async: the sheet is user-paced and its callbacks arrive
+    /// on the main thread, which must stay unblocked — a sync procedure would
+    /// run (and block) exactly there. No injected parameters (a ttipc async
+    /// limitation); the impl reaches the app handle through `crate::app_handle`.
+    /// Rejects with "canceled" (verbatim) when the user dismisses the sheet.
+    async fn sign_in_with_apple(&self) -> Result<AuthStatus, String>;
     fn sign_out(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
     fn delete_account(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
     // Cloud sync — current status for the indicator, and a manual pull (fired on
@@ -395,6 +402,20 @@ impl CmdMethods for CmdEndpoint {
         Ok(status)
     }
 
+    async fn sign_in_with_apple(&self) -> Result<AuthStatus, String> {
+        let app_handle = crate::app_handle()?;
+        let status = app_handle
+            .state::<LuxAccount>()
+            .sign_in_with_apple(&app_handle)
+            .await?;
+        emit_auth_changed(&app_handle, status.clone())?;
+        // Same post-sign-in tail as the SRP path: pull the account's setups,
+        // then listen for change nudges from their other devices.
+        crate::cloud::schedule_sync(&app_handle);
+        crate::nudge::start(&app_handle);
+        Ok(status)
+    }
+
     fn sign_out(&self, app_handle: AppHandle) -> Result<AuthStatus, String> {
         let status = app_handle.state::<LuxAccount>().sign_out();
         crate::nudge::stop(&app_handle);
@@ -403,6 +424,10 @@ impl CmdMethods for CmdEndpoint {
     }
 
     fn delete_account(&self, app_handle: AppHandle) -> Result<AuthStatus, String> {
+        // Revoke the Apple-side grant first (required when an Apple link
+        // exists; a quiet no-op otherwise) — best-effort, never blocks the
+        // deletion itself.
+        app_handle.state::<LuxAccount>().revoke_apple_link();
         // Wipe the cloud data while the tokens still authenticate, then remove
         // the Cognito user; a failure at either step leaves the account intact
         // and the whole flow retryable.

--- a/apps/desktop/src-tauri/src/endpoints.rs
+++ b/apps/desktop/src-tauri/src/endpoints.rs
@@ -30,6 +30,11 @@ pub struct Endpoints {
     pub cognito_app_client_id: String,
     pub sync_url: String,
     pub nudge_endpoint: String,
+    /// Base URL of the lux-apple-auth Function URL (Sign in with Apple).
+    /// Absent until the first release after the service's Terraform applied —
+    /// the endpoints file only carries outputs that exist in applied state —
+    /// and empty means the feature stays dark.
+    pub apple_auth_url: String,
     /// Dev-machine remote control (device identity + mTLS material); only ever
     /// present in `endpoints.local.json` — the generated prod file never
     /// carries it, so plain installs have no remote-control surface.
@@ -108,6 +113,7 @@ fn overlay(base: &mut Endpoints, local: Endpoints) {
     take(&mut base.cognito_app_client_id, local.cognito_app_client_id);
     take(&mut base.sync_url, local.sync_url);
     take(&mut base.nudge_endpoint, local.nudge_endpoint);
+    take(&mut base.apple_auth_url, local.apple_auth_url);
     take(&mut base.sacn_interface, local.sacn_interface);
     if local.remote_control.is_some() {
         base.remote_control = local.remote_control;
@@ -130,6 +136,9 @@ mod tests {
         assert!(!endpoints.cognito_app_client_id.is_empty());
         assert!(!endpoints.sync_url.is_empty());
         assert!(!endpoints.nudge_endpoint.is_empty());
+        // `apple_auth_url` is deliberately NOT asserted populated: the key only
+        // enters the generated file once the Function URL exists in applied
+        // Terraform state, and an absent/empty value means "feature dark".
         assert!(endpoints.remote_control.is_none(), "prod never configures remote control");
     }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -30,6 +30,19 @@ use sync::*;
 use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
+/// The app handle for the few paths that cannot be handed one: today only the
+/// async `sign_in_with_apple` procedure (ttipc async procedures take no
+/// injected parameters). Set once in setup; everything else keeps taking the
+/// handle explicitly.
+static APP_HANDLE: std::sync::OnceLock<tauri::AppHandle> = std::sync::OnceLock::new();
+
+pub(crate) fn app_handle() -> Result<tauri::AppHandle, String> {
+    APP_HANDLE
+        .get()
+        .cloned()
+        .ok_or_else(|| "app handle not initialized yet".to_string())
+}
+
 pub async fn run() {
     // rustls 0.23 (pulled by rumqttc + reqwest) needs a process-level crypto
     // provider installed before any TLS use, or it panics. Install ring explicitly.
@@ -52,6 +65,7 @@ pub async fn run() {
         // restore below reads from it.
         account::init_keychain();
         app.manage(account::LuxAccount::load());
+        let _ = APP_HANDLE.set(app.handle().clone());
         account::restore_on_startup(app.handle());
         remote::connect(app.handle());
         #[cfg(desktop)]

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -125,6 +125,11 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  sign_in_with_apple(): Promise<AuthStatus> {
+    return invoke("cmd.sign_in_with_apple");
+  },
+
+  /** @throws {string} */
   sign_out(): Promise<AuthStatus> {
     return invoke("cmd.sign_out");
   },
@@ -222,6 +227,13 @@ export type AuthStatus = {
 	configured: boolean,
 	signedIn: boolean,
 	email: string | null,
+	/**  How the signed-in session was established; `None` when signed out. */
+	provider: Provider | null,
+	/**
+	 *  Whether native Sign in with Apple is available in this build (platform
+	 *  carries the entitlement AND the backend URL is configured).
+	 */
+	apple: boolean,
 };
 
 export type Channel = {
@@ -279,6 +291,13 @@ export type LuxChannels = {
 export type LuxLabelColor = "Red" | "Green" | "Blue" | "Amber" | "White" | "Brightness" | 
 /**  Raw universe channels (7..=512) with no fixed colour role. */
 "Generic";
+
+/**
+ *  How the current session was established. Password sessions can change
+ *  their password and re-auth by SRP; Apple sessions re-auth by sheet. Stored
+ *  with the session so a restart keeps the distinction.
+ */
+export type Provider = "password" | "apple";
 
 /**
  *  One of the user's other signed-in devices, as the UI sees it (a thinned

--- a/apps/desktop/src/components/account-menu.tsx
+++ b/apps/desktop/src/components/account-menu.tsx
@@ -103,6 +103,11 @@ export default function AccountMenu() {
           <DropdownMenuContent align="end" className="w-56">
             <DropdownMenuLabel className="truncate font-normal text-muted-foreground">
               {status.email}
+              {status.provider === "apple" ? (
+                <span className="block text-xs opacity-70">
+                  Signed in with Apple
+                </span>
+              ) : null}
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuItem onSelect={signOut} className="gap-2">
@@ -159,6 +164,20 @@ export default function AccountMenu() {
   const onOpenChange = (next: boolean) => {
     setOpen(next);
     if (next) go("signIn");
+  };
+
+  const signInWithApple = async () => {
+    setPending(true);
+    try {
+      await cmd().sign_in_with_apple();
+      await refreshAuth();
+      setOpen(false);
+    } catch (err) {
+      // Dismissing the sheet rejects with the literal "canceled" — not an error.
+      if (String(err) !== "canceled") toast.error(String(err));
+    } finally {
+      setPending(false);
+    }
   };
 
   const submit = async (e: React.FormEvent) => {
@@ -260,6 +279,33 @@ export default function AccountMenu() {
             {pending ? "…" : cta}
           </Button>
         </form>
+
+        {status.apple && mode !== "confirm" ? (
+          <>
+            <div className="flex items-center gap-3 text-xs text-muted-foreground">
+              <div className="h-px flex-1 bg-border" />
+              or
+              <div className="h-px flex-1 bg-border" />
+            </div>
+            {/* Per the Sign in with Apple HIG: the white style on dark UI,
+                left-aligned Apple logo, the exact "Sign in with Apple" label. */}
+            <Button
+              type="button"
+              onClick={signInWithApple}
+              disabled={pending}
+              className="min-h-11 gap-2 bg-white text-black hover:bg-white/90"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+                className="size-4 fill-current"
+              >
+                <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701" />
+              </svg>
+              Sign in with Apple
+            </Button>
+          </>
+        ) : null}
 
         <div className="text-center text-xs text-muted-foreground">
           {mode === "signIn" ? (

--- a/crates/lux-apple-id/Cargo.toml
+++ b/crates/lux-apple-id/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "lux-apple-id"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# The native Sign in with Apple sheet (ASAuthorizationController) behind a
+# plain-Rust callback API, for macOS and iOS; a stub that errors everywhere
+# else. Deliberately OUTSIDE the workspace lint policy: the workspace forbids
+# `unsafe_code`, and Objective-C interop is exactly the kind of FFI that policy
+# wants fenced into one small, reviewable leaf crate — nothing else in the
+# workspace may write `unsafe`. The rest of the shared policy is restated here.
+
+[lints.rust]
+unsafe_code = "allow"
+
+[lints.clippy]
+unwrap_used = "deny"
+panic = "warn"
+todo = "warn"
+unimplemented = "warn"
+
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = [
+    "NSArray",
+    "NSData",
+    "NSError",
+    "NSPersonNameComponents",
+    "NSString",
+] }
+objc2-authentication-services = { version = "0.3", features = [
+    "ASAuthorization",
+    "ASAuthorizationAppleIDCredential",
+    "ASAuthorizationAppleIDProvider",
+    "ASAuthorizationAppleIDRequest",
+    "ASAuthorizationController",
+    "ASAuthorizationCredential",
+    "ASAuthorizationOpenIDRequest",
+    "ASAuthorizationRequest",
+    "ASFoundation",
+] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3", features = [
+    "NSApplication",
+    "NSResponder",
+    "NSWindow",
+] }

--- a/crates/lux-apple-id/src/lib.rs
+++ b/crates/lux-apple-id/src/lib.rs
@@ -1,0 +1,240 @@
+//! The native Sign in with Apple sheet, as a callback.
+//!
+//! [`authorize`] must be called on the main thread (Tauri:
+//! `app.run_on_main_thread`); the completion fires later on the main run loop
+//! with the sheet's outcome. The caller supplies the SHA-256 (hex) of a raw
+//! nonce it keeps: Apple embeds that digest in the identity token's `nonce`
+//! claim, and the backend re-hashes the raw value to bind token and sheet run.
+//!
+//! Platform reality: real on macOS and iOS (the entitlement decides whether
+//! the sheet actually works at runtime); a compile-clean stub that errors
+//! immediately everywhere else, so callers need no cfg of their own.
+
+/// What a completed sheet hands back. `email`/`full_name` are only present on
+/// the FIRST authorization for this Apple ID — forward them to the backend,
+/// which persists them then or never.
+#[derive(Debug)]
+pub struct Authorization {
+    /// Apple's identity token (a JWT), UTF-8.
+    pub identity_token: String,
+    /// The single-use, ~5-minute authorization code, UTF-8.
+    pub authorization_code: String,
+    pub email: Option<String>,
+    pub full_name: Option<String>,
+}
+
+/// The user dismissed the sheet. Matched by callers to stay quiet about it.
+pub const CANCELED: &str = "canceled";
+
+pub type OnDone = Box<dyn FnOnce(Result<Authorization, String>) + Send>;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub use platform::authorize;
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+pub fn authorize(_hashed_nonce: &str, on_done: OnDone) {
+    on_done(Err(
+        "sign in with apple is not available on this platform".into()
+    ));
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod platform {
+    use std::cell::RefCell;
+
+    use objc2::rc::Retained;
+    use objc2::runtime::{AnyObject, ProtocolObject};
+    use objc2::{
+        define_class, msg_send, AnyThread, ClassType, DefinedClass, MainThreadMarker,
+        MainThreadOnly,
+    };
+    #[cfg(target_os = "macos")]
+    use objc2_authentication_services::ASAuthorizationControllerPresentationContextProviding;
+    use objc2_authentication_services::{
+        ASAuthorization, ASAuthorizationAppleIDCredential, ASAuthorizationAppleIDProvider,
+        ASAuthorizationController, ASAuthorizationControllerDelegate, ASAuthorizationScopeEmail,
+        ASAuthorizationScopeFullName,
+    };
+    use objc2_foundation::{NSArray, NSError, NSObject, NSObjectProtocol, NSString};
+
+    use super::{Authorization, OnDone, CANCELED};
+
+    // The one in-flight (delegate, controller) pair. The controller keeps
+    // itself alive during the flow, but its `delegate` property is WEAK — this
+    // slot is what keeps the delegate reachable until its callback runs. A new
+    // authorization replaces (and thereby releases) the previous pair; main
+    // thread only, hence `thread_local`.
+    thread_local! {
+        static IN_FLIGHT: RefCell<Option<(Retained<Delegate>, Retained<ASAuthorizationController>)>> =
+            const { RefCell::new(None) };
+    }
+
+    struct Ivars {
+        /// Taken by whichever completion callback fires first.
+        on_done: RefCell<Option<OnDone>>,
+    }
+
+    define_class!(
+        #[unsafe(super(NSObject))]
+        #[thread_kind = MainThreadOnly]
+        #[name = "LuxAppleIDDelegate"]
+        #[ivars = Ivars]
+        struct Delegate;
+
+        unsafe impl NSObjectProtocol for Delegate {}
+
+        unsafe impl ASAuthorizationControllerDelegate for Delegate {
+            #[unsafe(method(authorizationController:didCompleteWithAuthorization:))]
+            fn did_complete_with_authorization(
+                &self,
+                _controller: &ASAuthorizationController,
+                authorization: &ASAuthorization,
+            ) {
+                self.finish(extract(authorization));
+            }
+
+            #[unsafe(method(authorizationController:didCompleteWithError:))]
+            fn did_complete_with_error(
+                &self,
+                _controller: &ASAuthorizationController,
+                error: &NSError,
+            ) {
+                // ASAuthorizationError code 1001 is the user closing the sheet.
+                let message = if error.code() == 1001 {
+                    CANCELED.to_owned()
+                } else {
+                    format!(
+                        "apple authorization failed ({}): {}",
+                        error.code(),
+                        error.localizedDescription()
+                    )
+                };
+                self.finish(Err(message));
+            }
+        }
+
+        // macOS wants told where to hang the sheet; on iOS the system uses the
+        // key window when no provider is set (the generated binding only
+        // carries this method on macOS).
+        #[cfg(target_os = "macos")]
+        unsafe impl ASAuthorizationControllerPresentationContextProviding for Delegate {
+            #[unsafe(method_id(presentationAnchorForAuthorizationController:))]
+            fn presentation_anchor(
+                &self,
+                _controller: &ASAuthorizationController,
+            ) -> Retained<NSObject> {
+                anchor_window()
+            }
+        }
+    );
+
+    impl Delegate {
+        fn new(mtm: MainThreadMarker, on_done: OnDone) -> Retained<Self> {
+            let this = Self::alloc(mtm).set_ivars(Ivars {
+                on_done: RefCell::new(Some(on_done)),
+            });
+            // SAFETY: plain NSObject init on a freshly allocated instance.
+            unsafe { msg_send![super(this), init] }
+        }
+
+        fn finish(&self, result: Result<Authorization, String>) {
+            if let Some(on_done) = self.ivars().on_done.borrow_mut().take() {
+                on_done(result);
+            }
+        }
+    }
+
+    /// Present the sheet. Main thread only (checked; errors rather than UB).
+    pub fn authorize(hashed_nonce: &str, on_done: OnDone) {
+        let Some(mtm) = MainThreadMarker::new() else {
+            on_done(Err("authorize must be called on the main thread".into()));
+            return;
+        };
+
+        let delegate = Delegate::new(mtm, on_done);
+
+        // SAFETY: all main-thread (mtm in scope); the request is configured
+        // before the controller starts, and both objects live in IN_FLIGHT
+        // until the delegate callback has fired.
+        unsafe {
+            let provider = ASAuthorizationAppleIDProvider::new();
+            let request = provider.createRequest();
+            request.setRequestedScopes(Some(&NSArray::from_slice(&[
+                ASAuthorizationScopeFullName,
+                ASAuthorizationScopeEmail,
+            ])));
+            request.setNonce(Some(&NSString::from_str(hashed_nonce)));
+
+            let controller = ASAuthorizationController::initWithAuthorizationRequests(
+                ASAuthorizationController::alloc(),
+                &NSArray::from_slice(&[request.as_super().as_super()]),
+            );
+            controller.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+            #[cfg(target_os = "macos")]
+            controller.setPresentationContextProvider(Some(ProtocolObject::from_ref(&*delegate)));
+
+            controller.performRequests();
+            IN_FLIGHT.with(|slot| *slot.borrow_mut() = Some((delegate, controller)));
+        }
+    }
+
+    /// Copy everything out of the credential immediately — nothing
+    /// Objective-C-flavored escapes the callback.
+    fn extract(authorization: &ASAuthorization) -> Result<Authorization, String> {
+        // SAFETY: read-only accessors on the delivered credential, still on
+        // the main thread inside the delegate callback.
+        unsafe {
+            let credential = authorization.credential();
+            let credential: &AnyObject = (*credential).as_ref();
+            let Some(credential) = credential.downcast_ref::<ASAuthorizationAppleIDCredential>()
+            else {
+                return Err("authorization returned a non-Apple-ID credential".into());
+            };
+            let token = credential
+                .identityToken()
+                .ok_or("authorization carried no identity token")?;
+            let code = credential
+                .authorizationCode()
+                .ok_or("authorization carried no authorization code")?;
+            let full_name = credential.fullName().and_then(|components| {
+                let mut parts: Vec<String> = Vec::new();
+                if let Some(given) = components.givenName() {
+                    parts.push(given.to_string());
+                }
+                if let Some(family) = components.familyName() {
+                    parts.push(family.to_string());
+                }
+                (!parts.is_empty()).then(|| parts.join(" "))
+            });
+            Ok(Authorization {
+                identity_token: utf8(&token.to_vec(), "identity token")?,
+                authorization_code: utf8(&code.to_vec(), "authorization code")?,
+                email: credential.email().map(|e| e.to_string()),
+                full_name,
+            })
+        }
+    }
+
+    fn utf8(bytes: &[u8], what: &str) -> Result<String, String> {
+        String::from_utf8(bytes.to_vec()).map_err(|_| format!("{what} was not UTF-8"))
+    }
+
+    /// The window the macOS sheet attaches to: the key window, else the main
+    /// window, else a bare NSObject (the sheet then fails visibly — better
+    /// than never calling back).
+    #[cfg(target_os = "macos")]
+    fn anchor_window() -> Retained<NSObject> {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return NSObject::new();
+        };
+        let app = objc2_app_kit::NSApplication::sharedApplication(mtm);
+        let window = app.keyWindow().or_else(|| app.mainWindow());
+        match window {
+            Some(window) => {
+                let responder = Retained::into_super(window);
+                Retained::into_super(responder)
+            }
+            None => NSObject::new(),
+        }
+    }
+}

--- a/services/apple-auth/src/cognito.rs
+++ b/services/apple-auth/src/cognito.rs
@@ -30,6 +30,24 @@ pub struct Tokens {
     pub expires_in: i32,
 }
 
+/// Auth-flow failures the caller distinguishes: a missing user means a stale
+/// link (the account was deleted out from under it) and is self-healable;
+/// everything else is internal.
+#[derive(Debug)]
+pub enum AuthError {
+    UserNotFound,
+    Other(String),
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthError::UserNotFound => write!(f, "user not found"),
+            AuthError::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
 pub async fn find_user_by_email(ctx: &Ctx, email: &str) -> Result<Option<User>, String> {
     find_one(ctx, "email", email).await
 }
@@ -135,7 +153,11 @@ fn discarded_password() -> Result<String, String> {
 /// with the Apple identity token. The VerifyAuthChallenge trigger (this same
 /// binary) re-verifies the token and its link to exactly this user, so these
 /// admin calls add reach, not trust.
-pub async fn custom_auth(ctx: &Ctx, username: &str, identity_token: &str) -> Result<Tokens, String> {
+pub async fn custom_auth(
+    ctx: &Ctx,
+    username: &str,
+    identity_token: &str,
+) -> Result<Tokens, AuthError> {
     let start = ctx
         .cognito
         .admin_initiate_auth()
@@ -145,15 +167,20 @@ pub async fn custom_auth(ctx: &Ctx, username: &str, identity_token: &str) -> Res
         .auth_parameters("USERNAME", username)
         .send()
         .await
-        .map_err(|e| format!("auth initiate failed: {e}"))?;
+        .map_err(|e| match e.as_service_error() {
+            Some(se) if se.is_user_not_found_exception() => AuthError::UserNotFound,
+            _ => AuthError::Other(format!("auth initiate failed: {e}")),
+        })?;
 
     if start.challenge_name() != Some(&ChallengeNameType::CustomChallenge) {
-        return Err(format!(
+        return Err(AuthError::Other(format!(
             "expected CUSTOM_CHALLENGE, got {:?}",
             start.challenge_name()
-        ));
+        )));
     }
-    let session = start.session().ok_or("auth initiate returned no session")?;
+    let session = start
+        .session()
+        .ok_or(AuthError::Other("auth initiate returned no session".into()))?;
 
     let done = ctx
         .cognito
@@ -166,14 +193,17 @@ pub async fn custom_auth(ctx: &Ctx, username: &str, identity_token: &str) -> Res
         .challenge_responses("ANSWER", identity_token)
         .send()
         .await
-        .map_err(|e| format!("challenge response failed: {e}"))?;
+        .map_err(|e| match e.as_service_error() {
+            Some(se) if se.is_user_not_found_exception() => AuthError::UserNotFound,
+            _ => AuthError::Other(format!("challenge response failed: {e}")),
+        })?;
 
     let result = done
         .authentication_result()
-        .ok_or("challenge did not issue tokens")?;
-    let s = |v: Option<&str>, what: &str| -> Result<String, String> {
+        .ok_or(AuthError::Other("challenge did not issue tokens".into()))?;
+    let s = |v: Option<&str>, what: &str| -> Result<String, AuthError> {
         v.map(str::to_owned)
-            .ok_or_else(|| format!("auth result missing {what}"))
+            .ok_or_else(|| AuthError::Other(format!("auth result missing {what}")))
     };
     Ok(Tokens {
         id_token: s(result.id_token(), "id token")?,

--- a/services/apple-auth/src/http.rs
+++ b/services/apple-auth/src/http.rs
@@ -90,12 +90,15 @@ async fn sign_in(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
         }
     };
 
-    let (username, created) = match store::get_link(ctx, &identity.sub).await {
+    let existing = match store::get_link(ctx, &identity.sub).await {
         Err(e) => {
             tracing::error!("link lookup failed: {e}");
             return reply(500, &error("internal"));
         }
-        Ok(Some(link)) => {
+        Ok(link) => link,
+    };
+    let (mut username, mut created) = match &existing {
+        Some(link) => {
             // Known Apple user. Refresh the stored (revocable) Apple token
             // best-effort — the sign-in itself must not depend on Apple's
             // token endpoint being reachable once a link exists.
@@ -103,15 +106,31 @@ async fn sign_in(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
                 Ok(()) => {}
                 Err(e) => tracing::warn!("apple refresh-token update skipped: {e}"),
             }
-            (link.username, false)
+            (link.username.clone(), false)
         }
-        Ok(None) => match first_sign_in(ctx, &identity, &req).await {
+        None => match first_sign_in(ctx, &identity, &req).await {
             Ok(x) => x,
             Err(e) => return Ok(e),
         },
     };
 
-    let tokens = match cognito::custom_auth(ctx, &username, &req.identity_token).await {
+    let mut attempt = cognito::custom_auth(ctx, &username, &req.identity_token).await;
+    if let (Err(cognito::AuthError::UserNotFound), Some(link)) = (&attempt, &existing) {
+        // The linked user is gone — an account deletion whose Apple-side
+        // revoke never landed. Self-heal: drop the stale link and run this as
+        // a first sign-in (the same credential simply creates or relinks).
+        tracing::warn!("apple link points at a deleted user; relinking");
+        if let Err(e) = store::delete_link(ctx, &identity.sub, &link.sub).await {
+            tracing::error!("stale link cleanup failed: {e}");
+            return reply(500, &error("internal"));
+        }
+        (username, created) = match first_sign_in(ctx, &identity, &req).await {
+            Ok(x) => x,
+            Err(e) => return Ok(e),
+        };
+        attempt = cognito::custom_auth(ctx, &username, &req.identity_token).await;
+    }
+    let tokens = match attempt {
         Ok(t) => t,
         Err(e) => {
             tracing::error!("custom auth failed for linked user: {e}");


### PR DESCRIPTION
The client half of Sign in with Apple, on top of the `lux-apple-auth` backend (#199). Ships dark until the endpoints file carries `appleAuthUrl` — see the rollout order below.

## What's here

- **`crates/lux-apple-id`** — the native `ASAuthorizationController` sheet behind a plain-Rust callback, for macOS and iOS (compile-clean stub elsewhere). Deliberately the workspace's one `unsafe`-FFI leaf: the workspace forbids `unsafe_code`, so the Objective-C interop is fenced here with the shared lint policy restated locally. The delegate is retained in a thread-local slot for the flow's duration (`ASAuthorizationController.delegate` is a weak property — the classic sheet-appears-nothing-returns failure), cancel comes back as the literal `"canceled"`, and the iOS build skips the presentation-context provider (the system uses the key window; the binding only carries the anchor method on macOS).
- **`account.rs`** — `sign_in_with_apple()`: mint a raw nonce, hand the sheet its SHA-256, post the resulting identity token + code to `/auth/apple`, store the returned user-pool tokens through the existing keychain path. Sessions now carry a `provider` (`password | apple`), persisted and defaulted for keychain items written by older builds. `AuthStatus` reports the provider plus an `apple` capability flag: backend URL configured AND the build entitled — iOS and the MAS flavor today; the Developer ID .dmg stays hidden until it embeds a provisioning profile with the entitlement. Account deletion now revokes the Apple-side grant first (best-effort, never blocks the deletion).
- **The procedure is async on purpose** — the sheet is user-paced and its callbacks arrive on the main thread, exactly where a sync procedure would block. ttipc async procedures take no injected parameters, so the impl reaches the app handle through a process-global set once in setup (the only consumer).
- **UI** — the HIG white-style Apple button on the sign-in dialog (the app runs a dark theme), quiet on cancel; the account menu notes "Signed in with Apple".
- **Entitlements** — `com.apple.developer.applesignin` in `lux_iOS.entitlements` and `Entitlements.mas.plist`. The App ID capability is already enabled, so cloud signing regenerates profiles on the next build.
- **Backend hardening (same change)** — custom-auth errors are typed, and a link pointing at a deleted user (a deletion whose Apple revoke never landed) self-heals: the stale link is dropped and sign-in proceeds as a first use instead of failing forever.

## Rollout order

1. A release applies the #199 Terraform and deploys `lux-apple-auth` (both already on main).
2. A follow-up micro-PR adds `apple_auth_url` to `scripts/gen-endpoints` and the regenerated `endpoints.prod.json` — only possible once the Function URL exists in applied state; both drift gates stay green through the transition because an absent/empty field means "feature dark" by contract (`endpoints.rs`).
3. The next release after that ships builds with the button live. Before it: create the Sign in with Apple key in the developer portal and store it as the `lux/siwa-key` secret (`{"key_id","team_id","private_key"}`) — the sheet works without it, but the sign-in's code exchange fails loud until it exists.

## Verification

`cargo test --workspace --locked` green (backend 13, wire 18, desktop incl. the bindings drift guard); clippy `-D warnings` clean; `lux-apple-id` compiles for `aarch64-apple-ios`; front-end build, typecheck, and lint clean. On-device proof (TestFlight, after rollout step 3): fresh Apple sign-in, relaunch persistence, sync pull, then delete-account end-to-end — revoke, partition wipe, and the lux grant gone from Settings → Sign in with Apple.