### PR TITLE
refactor(auth): drop the app-handle global for ttipc 0.1.6 injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1823,7 +1823,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2147,7 +2147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3056,7 +3056,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3997,7 +3997,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4471,7 +4471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5355,7 +5355,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5434,7 +5434,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6020,7 +6020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6629,9 +6629,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-typed-ipc"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "047d61982c23b8e281a5c3b0dadb5f0e0f82614853a7a8cedf8309ca1ea7d697"
+checksum = "bccc4bdfe2d4e6eac37c8f7578b3a4d98af4f63866590fa239811d668f269e1e"
 dependencies = [
  "serde",
  "serde_json",
@@ -6645,9 +6645,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-typed-ipc-macros"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587581fc029e1c7b9cc47b79d4a3f17a0a05f375797e633b06e2eefbcbbac172"
+checksum = "10513fcb8c2c9f59ba074d26439994118ed7e24d2fb6f03b016d403dd3ae1979"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -6717,7 +6717,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7153,7 +7153,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7201,7 +7201,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7625,7 +7625,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -110,10 +110,9 @@ pub trait CmdMethods {
     /// Run the native Sign in with Apple sheet and exchange its identity token
     /// for a session. Async: the sheet is user-paced and its callbacks arrive
     /// on the main thread, which must stay unblocked — a sync procedure would
-    /// run (and block) exactly there. No injected parameters (a ttipc async
-    /// limitation); the impl reaches the app handle through `crate::app_handle`.
-    /// Rejects with "canceled" (verbatim) when the user dismisses the sheet.
-    async fn sign_in_with_apple(&self) -> Result<AuthStatus, String>;
+    /// run (and block) exactly there. Rejects with "canceled" (verbatim) when
+    /// the user dismisses the sheet.
+    async fn sign_in_with_apple(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
     fn sign_out(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
     fn delete_account(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
     // Cloud sync — current status for the indicator, and a manual pull (fired on
@@ -402,8 +401,7 @@ impl CmdMethods for CmdEndpoint {
         Ok(status)
     }
 
-    async fn sign_in_with_apple(&self) -> Result<AuthStatus, String> {
-        let app_handle = crate::app_handle()?;
+    async fn sign_in_with_apple(&self, app_handle: AppHandle) -> Result<AuthStatus, String> {
         let status = app_handle
             .state::<LuxAccount>()
             .sign_in_with_apple(&app_handle)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -30,19 +30,6 @@ use sync::*;
 use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-/// The app handle for the few paths that cannot be handed one: today only the
-/// async `sign_in_with_apple` procedure (ttipc async procedures take no
-/// injected parameters). Set once in setup; everything else keeps taking the
-/// handle explicitly.
-static APP_HANDLE: std::sync::OnceLock<tauri::AppHandle> = std::sync::OnceLock::new();
-
-pub(crate) fn app_handle() -> Result<tauri::AppHandle, String> {
-    APP_HANDLE
-        .get()
-        .cloned()
-        .ok_or_else(|| "app handle not initialized yet".to_string())
-}
-
 pub async fn run() {
     // rustls 0.23 (pulled by rumqttc + reqwest) needs a process-level crypto
     // provider installed before any TLS use, or it panics. Install ring explicitly.
@@ -65,7 +52,6 @@ pub async fn run() {
         // restore below reads from it.
         account::init_keychain();
         app.manage(account::LuxAccount::load());
-        let _ = APP_HANDLE.set(app.handle().clone());
         account::restore_on_startup(app.handle());
         remote::connect(app.handle());
         #[cfg(desktop)]


### PR DESCRIPTION
tauri-typed-ipc 0.1.6 supports injected parameters on async procedures, so `sign_in_with_apple` takes its `AppHandle` like every other procedure and the process-global `OnceLock` workaround is deleted. Lockfile bumped 0.1.4 → 0.1.6; regenerated `bindings.ts` is byte-identical (injected parameters never ride the wire).