### PR TITLE
feat(auth): carry the apple auth endpoint

### DIFF
--- a/apps/desktop/src-tauri/endpoints.prod.json
+++ b/apps/desktop/src-tauri/endpoints.prod.json
@@ -1,4 +1,5 @@
 {
+  "appleAuthUrl": "https://z3z752gt7cz6sd4a55xzu53bgi0cfsrm.lambda-url.us-west-1.on.aws/",
   "cognitoAppClientId": "2t2l4fn537ttb3vul39olt3of3",
   "cognitoRegion": "us-west-1",
   "cognitoUserPoolId": "us-west-1_jV7esPwmi",

--- a/apps/desktop/src-tauri/src/endpoints.rs
+++ b/apps/desktop/src-tauri/src/endpoints.rs
@@ -136,9 +136,7 @@ mod tests {
         assert!(!endpoints.cognito_app_client_id.is_empty());
         assert!(!endpoints.sync_url.is_empty());
         assert!(!endpoints.nudge_endpoint.is_empty());
-        // `apple_auth_url` is deliberately NOT asserted populated: the key only
-        // enters the generated file once the Function URL exists in applied
-        // Terraform state, and an absent/empty value means "feature dark".
+        assert!(!endpoints.apple_auth_url.is_empty());
         assert!(endpoints.remote_control.is_none(), "prod never configures remote control");
     }
 

--- a/scripts/gen-endpoints
+++ b/scripts/gen-endpoints
@@ -20,12 +20,14 @@ jq -Sn \
   --arg cognitoAppClientId "$(out cognito_app_client_id)" \
   --arg syncUrl            "$(out lux_sync_url)" \
   --arg nudgeEndpoint      "$(out iot_endpoint)" \
+  --arg appleAuthUrl       "$(out apple_auth_url)" \
   '{
     cognitoRegion:      $cognitoRegion,
     cognitoUserPoolId:  $cognitoUserPoolId,
     cognitoAppClientId: $cognitoAppClientId,
     syncUrl:            $syncUrl,
-    nudgeEndpoint:      $nudgeEndpoint
+    nudgeEndpoint:      $nudgeEndpoint,
+    appleAuthUrl:       $appleAuthUrl
   }' > apps/desktop/src-tauri/endpoints.prod.json
 
 echo "wrote apps/desktop/src-tauri/endpoints.prod.json:"


### PR DESCRIPTION
The release apply for v1.4.0 put `apple_auth_url` in Terraform state, so `gen-endpoints` now reads it and the committed file carries it — builds from here show Sign in with Apple on entitled platforms. The PR plan job's drift gate regenerates from applied state and validates the committed value.