### PR TITLE
feat(auth): stage the device-pairing foundations

### DIFF
--- a/crates/lux-auth/src/lib.rs
+++ b/crates/lux-auth/src/lib.rs
@@ -17,11 +17,14 @@ use serde::Deserialize;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-/// Verifies Cognito ID tokens against a fixed user pool + app client.
+/// Verifies Cognito ID tokens against a fixed user pool and a set of app
+/// clients. Most deployments verify against one client; services that must
+/// also accept device-paired sessions (the IoT authorizer, the sync API) list
+/// the device client too.
 pub struct Verifier {
     keys: HashMap<String, DecodingKey>,
     issuer: String,
-    client_id: String,
+    client_ids: Vec<String>,
 }
 
 /// The ID-token claims we read. The library validates `iss`/`aud`/`exp` from the
@@ -48,7 +51,10 @@ struct Jwk {
 impl Verifier {
     /// Fetch the pool's JWKS and build a verifier. Done once per cold start;
     /// Cognito rotates signing keys rarely, and a recycled Lambda re-fetches.
-    pub async fn new(region: &str, pool_id: &str, client_id: &str) -> Result<Self, BoxError> {
+    ///
+    /// `client_ids` is one app client id, or several comma-separated — a token
+    /// is accepted when its `aud` matches any of them.
+    pub async fn new(region: &str, pool_id: &str, client_ids: &str) -> Result<Self, BoxError> {
         let issuer = format!("https://cognito-idp.{region}.amazonaws.com/{pool_id}");
         let jwks: Jwks = reqwest::get(format!("{issuer}/.well-known/jwks.json"))
             .await?
@@ -63,10 +69,19 @@ impl Verifier {
                     .map(|dk| (k.kid, dk))
             })
             .collect();
+        let client_ids: Vec<String> = client_ids
+            .split(',')
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(str::to_owned)
+            .collect();
+        if client_ids.is_empty() {
+            return Err("no app client id given".into());
+        }
         Ok(Self {
             keys,
             issuer,
-            client_id: client_id.to_owned(),
+            client_ids,
         })
     }
 
@@ -81,7 +96,7 @@ impl Verifier {
 
         let mut validation = Validation::new(Algorithm::RS256);
         validation.set_issuer(&[&self.issuer]);
-        validation.set_audience(&[&self.client_id]);
+        validation.set_audience(&self.client_ids);
 
         let data =
             decode::<Claims>(token, key, &validation).map_err(|e| format!("invalid token: {e}"))?;
@@ -155,15 +170,19 @@ LMiAU7FjLN24jRnbdq2+qgzWtx6LjwKbrjDy6TZu1tX78WexoIa5dnoSvUmMNT6C
         exp: usize,
     }
 
-    fn verifier() -> Verifier {
+    fn verifier_for(client_ids: &[&str]) -> Verifier {
         Verifier {
             keys: HashMap::from([(
                 KID.to_string(),
                 DecodingKey::from_rsa_pem(PUBLIC_PEM).unwrap(),
             )]),
             issuer: ISSUER.to_string(),
-            client_id: CLIENT_ID.to_string(),
+            client_ids: client_ids.iter().map(|id| id.to_string()).collect(),
         }
+    }
+
+    fn verifier() -> Verifier {
+        verifier_for(&[CLIENT_ID])
     }
 
     fn sign(token_use: &str) -> String {
@@ -199,5 +218,23 @@ LMiAU7FjLN24jRnbdq2+qgzWtx6LjwKbrjDy6TZu1tX78WexoIa5dnoSvUmMNT6C
     #[test]
     fn rejects_a_non_id_token() {
         assert!(verifier().verify(&sign("access")).is_err());
+    }
+
+    // A verifier listing several app clients accepts a token minted for any
+    // one of them — how the IoT authorizer and sync API admit device-paired
+    // sessions alongside interactive ones.
+    #[test]
+    fn accepts_any_listed_client_id() {
+        let claims = verifier_for(&["some-other-client", CLIENT_ID])
+            .verify(&sign("id"))
+            .expect("a token for the second listed client verifies");
+        assert_eq!(claims.sub, "user-123");
+    }
+
+    #[test]
+    fn rejects_an_unlisted_client_id() {
+        assert!(verifier_for(&["some-other-client"])
+            .verify(&sign("id"))
+            .is_err());
     }
 }

--- a/infra/accounts.tf
+++ b/infra/accounts.tf
@@ -78,6 +78,33 @@ resource "aws_cognito_user_pool_client" "lux_app" {
   prevent_user_existence_errors = "ENABLED"
 }
 
+# Public client for paired headless devices (lux-node appliances) — see
+# docs/claim-code-pairing.md. Sessions here are appliance-grade (10-year
+# refresh) and revocable without touching interactive logins on lux-app.
+# Deliberately refresh-only for now: ALLOW_CUSTOM_AUTH joins in the pairing
+# PR together with the Verify-trigger discrimination — until then a client
+# that can only refresh tokens nobody has minted is inert.
+resource "aws_cognito_user_pool_client" "lux_node_device" {
+  name         = "lux-node-device"
+  user_pool_id = aws_cognito_user_pool.lux.id
+
+  generate_secret = false
+  explicit_auth_flows = [
+    "ALLOW_REFRESH_TOKEN_AUTH", # the paired node's only day-to-day flow
+  ]
+
+  access_token_validity  = 1
+  id_token_validity      = 1
+  refresh_token_validity = 3650
+  token_validity_units {
+    access_token  = "hours"
+    id_token      = "hours"
+    refresh_token = "days"
+  }
+
+  prevent_user_existence_errors = "ENABLED"
+}
+
 # --- State: DynamoDB single table (one item per setup) ---
 
 resource "aws_dynamodb_table" "lux_sync" {
@@ -100,6 +127,14 @@ resource "aws_dynamodb_table" "lux_sync" {
   # window (it can be enabled live, no table rebuild).
   point_in_time_recovery {
     enabled = false
+  }
+
+  # Item expiry for the short-lived pairing records (PAIR#/PAIRIP# partitions,
+  # docs/claim-code-pairing.md). Items without a `ttl` attribute — everything
+  # else in the table — are untouched.
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
   }
 }
 
@@ -180,8 +215,10 @@ resource "aws_lambda_function" "lux_sync_api" {
 
   environment {
     variables = {
-      COGNITO_USER_POOL_ID  = aws_cognito_user_pool.lux.id
-      COGNITO_APP_CLIENT_ID = aws_cognito_user_pool_client.lux_app.id
+      COGNITO_USER_POOL_ID = aws_cognito_user_pool.lux.id
+      # Comma-separated: interactive sessions (lux-app) and paired devices
+      # (lux-node-device) both call this API with their own ID tokens.
+      COGNITO_APP_CLIENT_ID = "${aws_cognito_user_pool_client.lux_app.id},${aws_cognito_user_pool_client.lux_node_device.id}"
       COGNITO_REGION        = data.aws_region.current.region
       DYNAMODB_TABLE        = aws_dynamodb_table.lux_sync.name
       # Change nudges (nudge.tf): where to publish after a committed write.
@@ -215,6 +252,11 @@ output "cognito_user_pool_id" {
 output "cognito_app_client_id" {
   description = "COGNITO_APP_CLIENT_ID for the app (public client, no secret)."
   value       = aws_cognito_user_pool_client.lux_app.id
+}
+
+output "cognito_device_client_id" {
+  description = "App client id paired lux-node devices refresh against (endpoints.prod.json gains this when pairing ships)."
+  value       = aws_cognito_user_pool_client.lux_node_device.id
 }
 
 output "cognito_region" {

--- a/infra/apple-auth.tf
+++ b/infra/apple-auth.tf
@@ -50,7 +50,10 @@ resource "aws_iam_role_policy" "lux_apple_auth_ddb" {
       Resource = aws_dynamodb_table.lux_sync.arn
       Condition = {
         "ForAllValues:StringLike" = {
-          "dynamodb:LeadingKeys" = ["APPLE#*", "APPLELINK#*"]
+          # APPLE#/APPLELINK# = Sign in with Apple links; PAIR#/PAIRIP#/DEVICE#
+          # = device-pairing records (docs/claim-code-pairing.md — this service
+          # grows the /auth/device/* routes).
+          "dynamodb:LeadingKeys" = ["APPLE#*", "APPLELINK#*", "PAIR#*", "PAIRIP#*", "DEVICE#*"]
         }
       }
     }]

--- a/infra/nudge.tf
+++ b/infra/nudge.tf
@@ -60,8 +60,10 @@ resource "aws_lambda_function" "lux_iot_authorizer" {
 
   environment {
     variables = {
-      COGNITO_USER_POOL_ID  = aws_cognito_user_pool.lux.id
-      COGNITO_APP_CLIENT_ID = aws_cognito_user_pool_client.lux_app.id
+      COGNITO_USER_POOL_ID = aws_cognito_user_pool.lux.id
+      # Comma-separated: interactive sessions (lux-app) and paired devices
+      # (lux-node-device) both connect to the realtime channel.
+      COGNITO_APP_CLIENT_ID = "${aws_cognito_user_pool_client.lux_app.id},${aws_cognito_user_pool_client.lux_node_device.id}"
       COGNITO_REGION        = data.aws_region.current.region
     }
   }


### PR DESCRIPTION
Phase 1 of docs/claim-code-pairing.md — everything here is inert until
the pairing flow itself ships:

- lux-auth: Verifier accepts a comma-separated set of app client ids
  (aud matches any); the IoT authorizer and sync API must admit
  device-paired sessions alongside interactive ones or every token a
  paired node mints is rejected at the door.
- lux-node-device app client: 10-year refresh, refresh-only for now —
  ALLOW_CUSTOM_AUTH arrives with the Verify-trigger discrimination so
  no token can be minted against it until then.
- lux-sync gains TTL on `ttl` for the short-lived pairing records.
- apple-auth's LeadingKeys pin pre-adds PAIR#/PAIRIP#/DEVICE# for the
  coming /auth/device/* routes.

Wired into the authorizer and sync-api envs; apple-auth's env is
deliberately untouched (it feeds AdminInitiateAuth, which needs a
single client id).
