### PR TITLE
feat(auth): the device-pairing grant — routes, trigger path, device mint

### DIFF
--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -223,6 +223,138 @@ pub mod apple {
     }
 }
 
+pub mod device {
+    //! Headless device pairing: lux-node ↔ auth service wire
+    //! (docs/claim-code-pairing.md).
+    //!
+    //! An unpaired node registers and polls over plain HTTPS; the owner
+    //! approves from the app, which sees only pending devices that share its
+    //! NAT egress (same public IP). Approval binds the device to the owner's
+    //! account and a setup; the node's next poll returns an ordinary Cognito
+    //! refresh token minted on the device app client.
+    //!
+    //! Routes (on the auth service's Function URL):
+    //! - `POST /auth/device/authorize` — device: register, get a code pair
+    //! - `POST /auth/device/token`     — device: poll for the grant
+    //! - `GET  /auth/device/pending`   — bearer-authed: same-egress pending list
+    //! - `POST /auth/device/approve`   — bearer-authed: approve one device
+
+    use serde::{Deserialize, Serialize};
+
+    /// Path segments under [`super::apple::AUTH_SEGMENT`]:
+    /// `/auth/device/{authorize|token|pending|approve}`.
+    pub const DEVICE_SEGMENT: &str = "device";
+    pub const AUTHORIZE_SEGMENT: &str = "authorize";
+    pub const TOKEN_SEGMENT: &str = "token";
+    pub const PENDING_SEGMENT: &str = "pending";
+    pub const APPROVE_SEGMENT: &str = "approve";
+
+    /// Body for `POST /auth/device/authorize`. Everything here is display
+    /// metadata for the approve screen — identity is established by approval,
+    /// never claimed by the device.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct AuthorizeRequest {
+        /// The node's stable self-generated id (uuid, persisted in its state
+        /// dir). Lets a re-registering node supersede its own earlier codes.
+        pub device_id: String,
+        pub hostname: String,
+        /// Last 4 hex digits of the primary MAC — matches the sticker/port
+        /// label, the approve screen's physical cross-check.
+        pub mac_tail: String,
+        pub version: String,
+        pub arch: String,
+    }
+
+    /// Response to `POST /auth/device/authorize` (RFC 8628 §3.2 shape).
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct AuthorizeResponse {
+        /// The device's secret — polls `/token` with it. Never shown to humans.
+        pub device_code: String,
+        /// Short display code (`LUX-XXXX`) — shown in the app and the node's
+        /// journal for the human cross-check. Never typed anywhere.
+        pub user_code: String,
+        /// Seconds between `/token` polls.
+        pub interval: u32,
+        /// Seconds until this code pair expires and the node re-registers.
+        pub expires_in: u32,
+    }
+
+    /// Body for `POST /auth/device/token`.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct TokenRequest {
+        pub device_code: String,
+    }
+
+    /// Response to `POST /auth/device/token`. `status` follows RFC 8628 §3.5
+    /// (`authorization_pending`, `slow_down`, `expired_token`, `access_denied`)
+    /// plus `granted`, which carries the session fields.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct TokenResponse {
+        pub status: String,
+        /// On `granted`: what the node writes into session.json …
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub email: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub refresh_token: Option<String>,
+        /// … and the setup binding the approver chose.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub setup_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub universe: Option<u16>,
+    }
+
+    /// One pending device on the approve screen (`GET /auth/device/pending`).
+    /// `pair_ref` is an opaque handle for `/approve` — the app never sees the
+    /// device code itself.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct PendingDevice {
+        pub pair_ref: String,
+        pub user_code: String,
+        pub hostname: String,
+        pub mac_tail: String,
+        pub version: String,
+        pub arch: String,
+        /// Epoch millis of the registration (server clock).
+        pub first_seen: i64,
+    }
+
+    /// Response to `GET /auth/device/pending`.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct PendingResponse {
+        pub devices: Vec<PendingDevice>,
+    }
+
+    /// Body for `POST /auth/device/approve`.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ApproveRequest {
+        /// [`PendingDevice::pair_ref`] from the pending list.
+        pub pair_ref: String,
+        /// The setup this node will drive (the picker replaces `lux-node
+        /// install`'s interactive list for appliances).
+        pub setup_id: String,
+        /// sACN universe; defaults to 1.
+        #[serde(default)]
+        pub universe: Option<u16>,
+        /// Display name for the device registry; defaults to the hostname.
+        #[serde(default)]
+        pub name: Option<String>,
+    }
+
+    /// Response to a successful `POST /auth/device/approve`.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ApproveResponse {
+        pub approved: bool,
+    }
+}
+
 pub mod nudge {
     //! The change-nudge channel: tiny events, opaque to clients.
     //!
@@ -691,6 +823,83 @@ mod tests {
         );
         assert_eq!(apple::LINK_SEGMENT, "link");
         assert_eq!(apple::REVOKE_SEGMENT, "revoke");
+    }
+
+    #[test]
+    fn device_authorize_shapes() {
+        let req = device::AuthorizeRequest {
+            device_id: "d-1".into(),
+            hostname: "venue-node".into(),
+            mac_tail: "2dae".into(),
+            version: "1.5.0".into(),
+            arch: "aarch64".into(),
+        };
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            r#"{"deviceId":"d-1","hostname":"venue-node","macTail":"2dae","version":"1.5.0","arch":"aarch64"}"#
+        );
+        let resp = device::AuthorizeResponse {
+            device_code: "secret".into(),
+            user_code: "LUX-7QK2".into(),
+            interval: 5,
+            expires_in: 900,
+        };
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            r#"{"deviceCode":"secret","userCode":"LUX-7QK2","interval":5,"expiresIn":900}"#
+        );
+    }
+
+    #[test]
+    fn device_token_shapes() {
+        // Pending: bare status, no nulls on the wire.
+        let pending = device::TokenResponse {
+            status: "authorization_pending".into(),
+            email: None,
+            refresh_token: None,
+            setup_id: None,
+            universe: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&pending).unwrap(),
+            r#"{"status":"authorization_pending"}"#
+        );
+        let granted = device::TokenResponse {
+            status: "granted".into(),
+            email: Some("a@b.c".into()),
+            refresh_token: Some("re".into()),
+            setup_id: Some("s-1".into()),
+            universe: Some(1),
+        };
+        assert_eq!(
+            serde_json::to_string(&granted).unwrap(),
+            r#"{"status":"granted","email":"a@b.c","refreshToken":"re","setupId":"s-1","universe":1}"#
+        );
+    }
+
+    #[test]
+    fn device_approve_defaults() {
+        // An approve without universe/name (the app's minimal form) parses.
+        let req: device::ApproveRequest =
+            serde_json::from_str(r#"{"pairRef":"abc","setupId":"s-1"}"#).unwrap();
+        assert_eq!(req.universe, None);
+        assert_eq!(req.name, None);
+    }
+
+    #[test]
+    fn device_segments() {
+        assert_eq!(
+            format!(
+                "/{}/{}/{}",
+                apple::AUTH_SEGMENT,
+                device::DEVICE_SEGMENT,
+                device::AUTHORIZE_SEGMENT
+            ),
+            "/auth/device/authorize"
+        );
+        assert_eq!(device::TOKEN_SEGMENT, "token");
+        assert_eq!(device::PENDING_SEGMENT, "pending");
+        assert_eq!(device::APPROVE_SEGMENT, "approve");
     }
 
     #[test]

--- a/infra/accounts.tf
+++ b/infra/accounts.tf
@@ -81,9 +81,6 @@ resource "aws_cognito_user_pool_client" "lux_app" {
 # Public client for paired headless devices (lux-node appliances) — see
 # docs/claim-code-pairing.md. Sessions here are appliance-grade (10-year
 # refresh) and revocable without touching interactive logins on lux-app.
-# Deliberately refresh-only for now: ALLOW_CUSTOM_AUTH joins in the pairing
-# PR together with the Verify-trigger discrimination — until then a client
-# that can only refresh tokens nobody has minted is inert.
 resource "aws_cognito_user_pool_client" "lux_node_device" {
   name         = "lux-node-device"
   user_pool_id = aws_cognito_user_pool.lux.id
@@ -91,6 +88,12 @@ resource "aws_cognito_user_pool_client" "lux_node_device" {
   generate_secret = false
   explicit_auth_flows = [
     "ALLOW_REFRESH_TOKEN_AUTH", # the paired node's only day-to-day flow
+    # The pairing grant (lux-apple-auth drives it via AdminInitiateAuth). Safe
+    # against direct public-client calls for the same reason as lux-app's: the
+    # Verify trigger pins this client to the device-code answer kind, and only
+    # a live, approved, just-redeemed code bound to exactly the authenticating
+    # user passes.
+    "ALLOW_CUSTOM_AUTH",
   ]
 
   access_token_validity  = 1

--- a/infra/apple-auth.tf
+++ b/infra/apple-auth.tf
@@ -46,6 +46,8 @@ resource "aws_iam_role_policy" "lux_apple_auth_ddb" {
         "dynamodb:UpdateItem",
         "dynamodb:DeleteItem",
         "dynamodb:ConditionCheckItem",
+        # The pairing approve screen's same-egress pending list (PAIRIP#).
+        "dynamodb:Query",
       ]
       Resource = aws_dynamodb_table.lux_sync.arn
       Condition = {
@@ -133,8 +135,12 @@ resource "aws_lambda_function" "lux_apple_auth" {
     variables = {
       COGNITO_USER_POOL_ID  = aws_cognito_user_pool.lux.id
       COGNITO_APP_CLIENT_ID = aws_cognito_user_pool_client.lux_app.id
-      COGNITO_REGION        = data.aws_region.current.region
-      DYNAMODB_TABLE        = aws_dynamodb_table.lux_sync.name
+      # Single ids on purpose (they feed AdminInitiateAuth, not just the
+      # verifier): the interactive client above, the device-pairing client
+      # here. The trigger pins each answer kind to its client.
+      COGNITO_DEVICE_CLIENT_ID = aws_cognito_user_pool_client.lux_node_device.id
+      COGNITO_REGION           = data.aws_region.current.region
+      DYNAMODB_TABLE           = aws_dynamodb_table.lux_sync.name
       # Product identity, not environment: the bundle id is the token audience
       # and Apple client_id for native flows.
       APPLE_BUNDLE_ID = "com.johncarmack.lux"

--- a/services/apple-auth/src/cognito.rs
+++ b/services/apple-auth/src/cognito.rs
@@ -149,20 +149,23 @@ fn discarded_password() -> Result<String, String> {
     Ok(format!("A{hex}"))
 }
 
-/// Run the pool's CUSTOM_AUTH flow for `username`, answering the challenge
-/// with the Apple identity token. The VerifyAuthChallenge trigger (this same
-/// binary) re-verifies the token and its link to exactly this user, so these
-/// admin calls add reach, not trust.
+/// Run the pool's CUSTOM_AUTH flow for `username` on the given app client,
+/// answering the challenge with `answer` — the Apple identity token on the
+/// interactive client, the device code on the device client. The
+/// VerifyAuthChallenge trigger (this same binary) re-verifies the answer and
+/// its binding to exactly this user and client, so these admin calls add
+/// reach, not trust.
 pub async fn custom_auth(
     ctx: &Ctx,
+    client_id: &str,
     username: &str,
-    identity_token: &str,
+    answer: &str,
 ) -> Result<Tokens, AuthError> {
     let start = ctx
         .cognito
         .admin_initiate_auth()
         .user_pool_id(&ctx.pool_id)
-        .client_id(&ctx.client_id)
+        .client_id(client_id)
         .auth_flow(AuthFlowType::CustomAuth)
         .auth_parameters("USERNAME", username)
         .send()
@@ -186,11 +189,11 @@ pub async fn custom_auth(
         .cognito
         .admin_respond_to_auth_challenge()
         .user_pool_id(&ctx.pool_id)
-        .client_id(&ctx.client_id)
+        .client_id(client_id)
         .challenge_name(ChallengeNameType::CustomChallenge)
         .session(session)
         .challenge_responses("USERNAME", username)
-        .challenge_responses("ANSWER", identity_token)
+        .challenge_responses("ANSWER", answer)
         .send()
         .await
         .map_err(|e| match e.as_service_error() {

--- a/services/apple-auth/src/device.rs
+++ b/services/apple-auth/src/device.rs
@@ -1,0 +1,377 @@
+//! Headless device pairing — the RFC 8628-shaped grant from
+//! docs/claim-code-pairing.md, served next to the Apple routes because the
+//! trust machinery is the same: the pool's CUSTOM_AUTH triggers (this binary)
+//! are the verifier, these routes only add reach.
+//!
+//! The rendezvous is same-public-egress: an unpaired box registers over plain
+//! HTTPS and the approve screen only ever lists registrations that arrived
+//! from the caller's own public IP — phone on the venue WiFi sees the box on
+//! the venue ethernet, and nobody else sees either. Identity is never claimed
+//! by the device; it is granted by the approving account, and the mint runs
+//! on the device app client so appliance sessions stay segregated from
+//! interactive ones.
+//!
+//! Every route (and the trigger's device path) fails closed unless
+//! `COGNITO_DEVICE_CLIENT_ID` is configured.
+
+use std::sync::Arc;
+
+use lambda_runtime::Error;
+use lux_wire::device::{
+    ApproveRequest, ApproveResponse, AuthorizeRequest, AuthorizeResponse, PendingDevice,
+    PendingResponse, TokenRequest, TokenResponse,
+};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::http::{caller, error, parse_body, reply, UrlEvent};
+use crate::{cognito, store, Ctx};
+
+/// RFC 8628 §3.2: how often the node may poll `/token`.
+const INTERVAL_SECS: u32 = 5;
+/// Code-pair lifetime; an unclaimed node re-registers after this.
+const EXPIRES_SECS: u32 = 900;
+/// How long a redeemed grant stays mintable — covers exactly the token call
+/// in flight, nothing more.
+const REDEEM_WINDOW_MILLIS: i64 = 60_000;
+
+/// Display-code alphabet: no vowels (no words), no 0/O/1/I/L/S lookalikes.
+const USER_CODE_ALPHABET: &[u8] = b"23456789CDFGHJKMNPQRTVWXZ";
+const USER_CODE_LEN: usize = 4;
+
+/// `POST /auth/device/authorize` — an unpaired node registers and receives its
+/// code pair. Unauthenticated by design; everything in the body is display
+/// metadata, and the reply grants nothing.
+pub async fn authorize(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
+    if ctx.device_client_id.is_none() {
+        return reply(503, &error("device pairing is not enabled"));
+    }
+    let req: AuthorizeRequest = match parse_body(event) {
+        Ok(b) => b,
+        Err(e) => return reply(400, &error(&e)),
+    };
+    let pub_ip = event.source_ip();
+    if pub_ip.is_empty() {
+        return reply(400, &error("no source address"));
+    }
+
+    let device_code = match random_hex::<32>() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("{e}");
+            return reply(500, &error("internal"));
+        }
+    };
+    let user_code = match user_code() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("{e}");
+            return reply(500, &error("internal"));
+        }
+    };
+
+    if let Err(e) = store::create_pair(
+        ctx,
+        &pair_ref(&device_code),
+        &user_code,
+        &req.device_id,
+        &req.hostname,
+        &req.mac_tail,
+        &req.version,
+        &req.arch,
+        pub_ip,
+        EXPIRES_SECS as i64,
+    )
+    .await
+    {
+        tracing::error!("pair create failed: {e}");
+        return reply(500, &error("internal"));
+    }
+
+    reply(
+        200,
+        &AuthorizeResponse {
+            device_code,
+            user_code,
+            interval: INTERVAL_SECS,
+            expires_in: EXPIRES_SECS,
+        },
+    )
+}
+
+/// `POST /auth/device/token` — the node's poll. Unknown, expired, denied, and
+/// already-redeemed codes all collapse to `access_denied`: the caller learns
+/// nothing a legitimate device wouldn't already know.
+pub async fn token(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
+    let Some(device_client_id) = ctx.device_client_id.as_deref() else {
+        return reply(503, &error("device pairing is not enabled"));
+    };
+    let req: TokenRequest = match parse_body(event) {
+        Ok(b) => b,
+        Err(e) => return reply(400, &error(&e)),
+    };
+
+    let pair = match store::get_pair(ctx, &pair_ref(&req.device_code)).await {
+        Err(e) => {
+            tracing::error!("pair get failed: {e}");
+            return reply(500, &error("internal"));
+        }
+        Ok(None) => return status(400, "access_denied"),
+        Ok(Some(p)) => p,
+    };
+
+    match pair.status.as_str() {
+        "pending" if pair.expired() => status(400, "expired_token"),
+        "pending" => status(200, "authorization_pending"),
+        "approved" => grant(ctx, device_client_id, &req.device_code, pair).await,
+        _ => status(400, "access_denied"),
+    }
+}
+
+/// The approved poll: claim the single-use flip, then mint on the device
+/// client. The Verify trigger (this binary) independently re-checks the code
+/// against the store, so a direct-to-Cognito caller gets nothing extra.
+async fn grant(
+    ctx: &Arc<Ctx>,
+    device_client_id: &str,
+    device_code: &str,
+    pair: store::Pair,
+) -> Result<Value, Error> {
+    let (Some(username), Some(setup_id)) = (pair.bound_username.clone(), pair.setup_id.clone())
+    else {
+        tracing::error!("approved pair missing binding");
+        return reply(500, &error("internal"));
+    };
+
+    // Exactly one poll wins this; a failure after it burns the code and the
+    // node re-registers (safety over convenience).
+    if let Err(e) = store::redeem_pair(ctx, &pair_ref(device_code)).await {
+        tracing::warn!("redeem race lost or stale: {e}");
+        return status(400, "access_denied");
+    }
+
+    let tokens = match cognito::custom_auth(ctx, device_client_id, &username, device_code).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!("device mint failed: {e}");
+            return reply(500, &error("internal"));
+        }
+    };
+
+    reply(
+        200,
+        &TokenResponse {
+            status: "granted".into(),
+            // The pool's usernames are emails; the node stores this beside the
+            // refresh token exactly as `lux-node login` does.
+            email: Some(username),
+            refresh_token: Some(tokens.refresh_token),
+            setup_id: Some(setup_id),
+            universe: Some(pair.universe.unwrap_or(1)),
+        },
+    )
+}
+
+/// `GET /auth/device/pending` — bearer-authed: unexpired registrations that
+/// arrived from the caller's own public egress, oldest first.
+pub async fn pending(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
+    if ctx.device_client_id.is_none() {
+        return reply(503, &error("device pairing is not enabled"));
+    }
+    if caller(ctx, event).is_none() {
+        return reply(401, &error("invalid or missing token"));
+    }
+    let rows = match store::list_pending(ctx, event.source_ip()).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("pending list failed: {e}");
+            return reply(500, &error("internal"));
+        }
+    };
+    let devices: Vec<PendingDevice> = rows
+        .iter()
+        .filter_map(|item| {
+            let s = |k: &str| item.get(k)?.as_s().ok().cloned();
+            Some(PendingDevice {
+                pair_ref: s("pairRef")?,
+                user_code: s("userCode")?,
+                hostname: s("hostname")?,
+                mac_tail: s("macTail")?,
+                version: s("version")?,
+                arch: s("arch")?,
+                first_seen: item
+                    .get("createdAt")
+                    .and_then(|v| v.as_n().ok())
+                    .and_then(|v| v.parse().ok())?,
+            })
+        })
+        .collect();
+    reply(200, &PendingResponse { devices })
+}
+
+/// `POST /auth/device/approve` — bearer-authed. The same-egress check runs
+/// again here (not just on the listing): an approval must come from the same
+/// public IP the box registered from.
+pub async fn approve(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
+    if ctx.device_client_id.is_none() {
+        return reply(503, &error("device pairing is not enabled"));
+    }
+    let Some(caller_sub) = caller(ctx, event) else {
+        return reply(401, &error("invalid or missing token"));
+    };
+    let req: ApproveRequest = match parse_body(event) {
+        Ok(b) => b,
+        Err(e) => return reply(400, &error(&e)),
+    };
+
+    let pair = match store::get_pair(ctx, &req.pair_ref).await {
+        Err(e) => {
+            tracing::error!("pair get failed: {e}");
+            return reply(500, &error("internal"));
+        }
+        Ok(None) => return reply(404, &error("no such pending device")),
+        Ok(Some(p)) => p,
+    };
+    if pair.status != "pending" || pair.expired() {
+        return reply(409, &error("device is no longer pending"));
+    }
+    if pair.pub_ip != event.source_ip() {
+        tracing::warn!("approve egress mismatch");
+        return reply(403, &error("approve from the device's network"));
+    }
+
+    let user = match cognito::find_user_by_sub(ctx, &caller_sub).await {
+        Ok(Some(u)) => u,
+        Ok(None) => return reply(404, &error("account not found")),
+        Err(e) => {
+            tracing::error!("user lookup failed: {e}");
+            return reply(500, &error("internal"));
+        }
+    };
+
+    let universe = req.universe.unwrap_or(1);
+    let name = req.name.as_deref().unwrap_or(&pair.hostname);
+    if let Err(e) = store::approve_pair(
+        ctx,
+        &req.pair_ref,
+        &pair,
+        &user.username,
+        &user.sub,
+        &req.setup_id,
+        universe,
+        name,
+    )
+    .await
+    {
+        // A concurrent approve (or expiry) losing the condition is a 409, not
+        // an internal error — but we can't tell them apart cheaply; log both.
+        tracing::warn!("pair approve rejected: {e}");
+        return reply(409, &error("device is no longer pending"));
+    }
+
+    reply(200, &ApproveResponse { approved: true })
+}
+
+/// Is this challenge answer a live, just-redeemed device code bound to exactly
+/// this user? The trigger's device path — the actual trust anchor of the mint.
+pub async fn answer_is_correct(ctx: &Ctx, answer: &str, user_sub: &str) -> bool {
+    let pair = match store::get_pair(ctx, &pair_ref(answer)).await {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            tracing::warn!("device challenge answer matches no pair");
+            return false;
+        }
+        Err(e) => {
+            tracing::error!("pair lookup failed during verify: {e}");
+            return false;
+        }
+    };
+    let fresh = pair
+        .redeemed_at
+        .is_some_and(|at| now_millis().saturating_sub(at) < REDEEM_WINDOW_MILLIS);
+    pair.status == "redeemed" && fresh && pair.bound_sub.as_deref() == Some(user_sub)
+}
+
+// --- codes ----------------------------------------------------------------------
+
+/// The at-rest key for a device code: its hex sha256. The secret itself never
+/// touches the table.
+fn pair_ref(device_code: &str) -> String {
+    hex(&Sha256::digest(device_code.as_bytes()))
+}
+
+/// `LUX-XXXX` from the confusion-free alphabet. Display-only (never typed, is
+/// no authority), so the tiny modulo bias is irrelevant.
+fn user_code() -> Result<String, String> {
+    let bytes = random::<USER_CODE_LEN>()?;
+    let code: String = bytes
+        .iter()
+        .map(|b| USER_CODE_ALPHABET[*b as usize % USER_CODE_ALPHABET.len()] as char)
+        .collect();
+    Ok(format!("LUX-{code}"))
+}
+
+fn random_hex<const N: usize>() -> Result<String, String> {
+    Ok(hex(&random::<N>()?))
+}
+
+fn random<const N: usize>() -> Result<[u8; N], String> {
+    use std::io::Read;
+    let mut bytes = [0u8; N];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut f| f.read_exact(&mut bytes))
+        .map_err(|e| format!("no OS randomness: {e}"))?;
+    Ok(bytes)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().fold(String::new(), |mut acc, b| {
+        use std::fmt::Write;
+        let _ = write!(acc, "{b:02x}");
+        acc
+    })
+}
+
+fn now_millis() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn status(code: u16, s: &str) -> Result<Value, Error> {
+    reply(
+        code,
+        &TokenResponse {
+            status: s.into(),
+            email: None,
+            refresh_token: None,
+            setup_id: None,
+            universe: None,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_codes_use_the_display_alphabet() {
+        let code = user_code().unwrap();
+        assert!(code.starts_with("LUX-"));
+        let tail = &code["LUX-".len()..];
+        assert_eq!(tail.len(), USER_CODE_LEN);
+        assert!(tail.bytes().all(|b| USER_CODE_ALPHABET.contains(&b)));
+    }
+
+    #[test]
+    fn pair_ref_is_a_stable_hash_not_the_secret() {
+        let secret = "aaaaaaaa";
+        let r = pair_ref(secret);
+        assert_eq!(r.len(), 64);
+        assert_eq!(r, pair_ref(secret));
+        assert!(!r.contains(secret));
+    }
+}

--- a/services/apple-auth/src/http.rs
+++ b/services/apple-auth/src/http.rs
@@ -21,12 +21,20 @@ use crate::{apple, cognito, store, Ctx};
 /// The slice of a Function URL (payload format 2.0) event we route on.
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
-struct UrlEvent {
+pub(crate) struct UrlEvent {
     raw_path: String,
     headers: HashMap<String, String>,
     body: Option<String>,
     is_base64_encoded: bool,
     request_context: RequestContext,
+}
+
+impl UrlEvent {
+    /// The caller's public IP as the Function URL saw it — the pairing flow's
+    /// same-egress rendezvous key.
+    pub(crate) fn source_ip(&self) -> &str {
+        &self.request_context.http.source_ip
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -36,9 +44,10 @@ struct RequestContext {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(default)]
+#[serde(rename_all = "camelCase", default)]
 struct HttpContext {
     method: String,
+    source_ip: String,
 }
 
 pub async fn handle(ctx: &Arc<Ctx>, payload: Value) -> Result<Value, Error> {
@@ -54,6 +63,10 @@ pub async fn handle(ctx: &Arc<Ctx>, payload: Value) -> Result<Value, Error> {
     let path = event.raw_path.clone();
     let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
 
+    use lux_wire::device::{
+        APPROVE_SEGMENT, AUTHORIZE_SEGMENT, DEVICE_SEGMENT, PENDING_SEGMENT, TOKEN_SEGMENT,
+    };
+
     match (method, segments.as_slice()) {
         ("POST", [a, b]) if *a == AUTH_SEGMENT && *b == APPLE_SEGMENT => {
             sign_in(ctx, &event).await
@@ -65,6 +78,26 @@ pub async fn handle(ctx: &Arc<Ctx>, payload: Value) -> Result<Value, Error> {
             if *a == AUTH_SEGMENT && *b == APPLE_SEGMENT && *c == REVOKE_SEGMENT =>
         {
             revoke(ctx, &event).await
+        }
+        ("POST", [a, b, c])
+            if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == AUTHORIZE_SEGMENT =>
+        {
+            crate::device::authorize(ctx, &event).await
+        }
+        ("POST", [a, b, c])
+            if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == TOKEN_SEGMENT =>
+        {
+            crate::device::token(ctx, &event).await
+        }
+        ("GET", [a, b, c])
+            if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == PENDING_SEGMENT =>
+        {
+            crate::device::pending(ctx, &event).await
+        }
+        ("POST", [a, b, c])
+            if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == APPROVE_SEGMENT =>
+        {
+            crate::device::approve(ctx, &event).await
         }
         _ => reply(404, &error("not found")),
     }
@@ -114,7 +147,7 @@ async fn sign_in(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
         },
     };
 
-    let mut attempt = cognito::custom_auth(ctx, &username, &req.identity_token).await;
+    let mut attempt = cognito::custom_auth(ctx, &ctx.client_id, &username, &req.identity_token).await;
     if let (Err(cognito::AuthError::UserNotFound), Some(link)) = (&attempt, &existing) {
         // The linked user is gone — an account deletion whose Apple-side
         // revoke never landed. Self-heal: drop the stale link and run this as
@@ -128,7 +161,7 @@ async fn sign_in(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
             Ok(x) => x,
             Err(e) => return Ok(e),
         };
-        attempt = cognito::custom_auth(ctx, &username, &req.identity_token).await;
+        attempt = cognito::custom_auth(ctx, &ctx.client_id, &username, &req.identity_token).await;
     }
     let tokens = match attempt {
         Ok(t) => t,
@@ -365,7 +398,7 @@ async fn refresh_apple_token(ctx: &Arc<Ctx>, apple_sub: &str, code: &str) -> Res
 // --- request/response helpers -------------------------------------------------
 
 /// The verified caller (`sub`) from the bearer token, if any.
-fn caller(ctx: &Ctx, event: &UrlEvent) -> Option<String> {
+pub(crate) fn caller(ctx: &Ctx, event: &UrlEvent) -> Option<String> {
     let token = event
         .headers
         .get("authorization")?
@@ -373,7 +406,7 @@ fn caller(ctx: &Ctx, event: &UrlEvent) -> Option<String> {
     ctx.verifier.verify(token).ok().map(|c| c.sub)
 }
 
-fn parse_body<T: for<'de> Deserialize<'de>>(event: &UrlEvent) -> Result<T, String> {
+pub(crate) fn parse_body<T: for<'de> Deserialize<'de>>(event: &UrlEvent) -> Result<T, String> {
     let raw = event.body.as_deref().unwrap_or_default();
     let bytes = if event.is_base64_encoded {
         BASE64
@@ -385,14 +418,14 @@ fn parse_body<T: for<'de> Deserialize<'de>>(event: &UrlEvent) -> Result<T, Strin
     serde_json::from_slice(&bytes).map_err(|e| format!("bad body: {e}"))
 }
 
-fn error(message: &str) -> ErrorResponse {
+pub(crate) fn error(message: &str) -> ErrorResponse {
     ErrorResponse {
         error: message.to_owned(),
     }
 }
 
 /// A Function URL (payload v2) response.
-fn reply<T: serde::Serialize>(status: u16, body: &T) -> Result<Value, Error> {
+pub(crate) fn reply<T: serde::Serialize>(status: u16, body: &T) -> Result<Value, Error> {
     Ok(json!({
         "statusCode": status,
         "headers": { "content-type": "application/json" },

--- a/services/apple-auth/src/main.rs
+++ b/services/apple-auth/src/main.rs
@@ -27,6 +27,7 @@
 
 mod apple;
 mod cognito;
+mod device;
 mod http;
 mod store;
 mod triggers;
@@ -47,6 +48,10 @@ pub(crate) struct Ctx {
     pub siwa_key: tokio::sync::OnceCell<apple::SiwaKey>,
     pub pool_id: String,
     pub client_id: String,
+    /// The device app client (`lux-node-device`) the pairing grant mints on.
+    /// Absent until the infra ships it — the `/auth/device/*` routes and the
+    /// device trigger path stay disabled (fail closed) without it.
+    pub device_client_id: Option<String>,
     pub table: String,
     pub siwa_secret_id: String,
 }
@@ -89,6 +94,7 @@ async fn main() -> Result<(), Error> {
 
     let pool_id = env("COGNITO_USER_POOL_ID")?;
     let client_id = env("COGNITO_APP_CLIENT_ID")?;
+    let device_client_id = std::env::var("COGNITO_DEVICE_CLIENT_ID").ok();
     let region = env("COGNITO_REGION")?;
     let table = env("DYNAMODB_TABLE")?;
     let bundle_id = env("APPLE_BUNDLE_ID")?;
@@ -109,6 +115,7 @@ async fn main() -> Result<(), Error> {
         siwa_key: tokio::sync::OnceCell::new(),
         pool_id,
         client_id,
+        device_client_id,
         table,
         siwa_secret_id,
     });

--- a/services/apple-auth/src/store.rs
+++ b/services/apple-auth/src/store.rs
@@ -190,3 +190,295 @@ fn now_millis() -> i64 {
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0)
 }
+
+// --- Device pairing (docs/claim-code-pairing.md) -------------------------------
+//
+// Three more disjoint partitions, same LeadingKeys discipline as the links:
+// - `pk = PAIR#<sha256(device_code)>, sk = PAIR` — one grant attempt, keyed by
+//   the hash so the secret itself is never at rest.
+// - `pk = PAIRIP#<public_ip>, sk = <createdAt>#<device_id>` — the approve
+//   screen's same-egress pending list.
+// - `pk = DEVICE#<sub>, sk = <device_id>` — the owner's paired-device registry.
+// PAIR/PAIRIP items carry `ttl` (epoch seconds) and self-expire; DEVICE items
+// don't.
+
+/// One pairing grant, as read back from the `PAIR#` item.
+#[derive(Debug)]
+pub struct Pair {
+    pub status: String,
+    pub device_id: String,
+    pub hostname: String,
+    pub user_code: String,
+    /// Set on approve.
+    pub bound_username: Option<String>,
+    pub bound_sub: Option<String>,
+    pub setup_id: Option<String>,
+    pub universe: Option<u16>,
+    pub device_name: Option<String>,
+    /// Epoch millis.
+    pub created_at: i64,
+    pub expires_at: i64,
+    pub redeemed_at: Option<i64>,
+    pub pub_ip: String,
+}
+
+impl Pair {
+    pub fn expired(&self) -> bool {
+        now_millis() >= self.expires_at
+    }
+}
+
+fn pair_pk(pair_ref: &str) -> String {
+    format!("PAIR#{pair_ref}")
+}
+
+fn pair_ip_pk(pub_ip: &str) -> String {
+    format!("PAIRIP#{pub_ip}")
+}
+
+fn device_pk(sub: &str) -> String {
+    format!("DEVICE#{sub}")
+}
+
+const PAIR_SK: &str = "PAIR";
+
+/// Register a grant attempt: the `PAIR#` item and its `PAIRIP#` pending-list
+/// row, transactionally. `pair_ref` is the hex sha256 of the device code.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_pair(
+    ctx: &Ctx,
+    pair_ref: &str,
+    user_code: &str,
+    device_id: &str,
+    hostname: &str,
+    mac_tail: &str,
+    version: &str,
+    arch: &str,
+    pub_ip: &str,
+    expires_in_secs: i64,
+) -> Result<(), String> {
+    let created_at = now_millis();
+    let expires_at = created_at + expires_in_secs * 1000;
+    // DynamoDB TTL is epoch seconds; keep expired rows a day for debugging.
+    let ttl = expires_at / 1000 + 86_400;
+
+    let s = |v: &str| AttributeValue::S(v.into());
+    let n = |v: i64| AttributeValue::N(v.to_string());
+
+    let pair: HashMap<String, AttributeValue> = HashMap::from([
+        ("pk".into(), s(&pair_pk(pair_ref))),
+        ("sk".into(), s(PAIR_SK)),
+        ("status".into(), s("pending")),
+        ("userCode".into(), s(user_code)),
+        ("deviceId".into(), s(device_id)),
+        ("hostname".into(), s(hostname)),
+        ("macTail".into(), s(mac_tail)),
+        ("version".into(), s(version)),
+        ("arch".into(), s(arch)),
+        ("pubIp".into(), s(pub_ip)),
+        ("createdAt".into(), n(created_at)),
+        ("expiresAt".into(), n(expires_at)),
+        ("ttl".into(), n(ttl)),
+    ]);
+    let row: HashMap<String, AttributeValue> = HashMap::from([
+        ("pk".into(), s(&pair_ip_pk(pub_ip))),
+        ("sk".into(), s(&format!("{created_at}#{device_id}"))),
+        ("pairRef".into(), s(pair_ref)),
+        ("userCode".into(), s(user_code)),
+        ("hostname".into(), s(hostname)),
+        ("macTail".into(), s(mac_tail)),
+        ("version".into(), s(version)),
+        ("arch".into(), s(arch)),
+        ("createdAt".into(), n(created_at)),
+        ("expiresAt".into(), n(expires_at)),
+        ("ttl".into(), n(ttl)),
+    ]);
+
+    let put = |item| {
+        Put::builder()
+            .table_name(&ctx.table)
+            .set_item(Some(item))
+            .condition_expression("attribute_not_exists(pk)")
+            .build()
+            .map_err(|e| format!("pair put malformed: {e}"))
+    };
+    ctx.ddb
+        .transact_write_items()
+        .transact_items(TransactWriteItem::builder().put(put(pair)?).build())
+        .transact_items(TransactWriteItem::builder().put(put(row)?).build())
+        .send()
+        .await
+        .map_err(|e| format!("pair write failed: {e}"))?;
+    Ok(())
+}
+
+pub async fn get_pair(ctx: &Ctx, pair_ref: &str) -> Result<Option<Pair>, String> {
+    let out = ctx
+        .ddb
+        .get_item()
+        .table_name(&ctx.table)
+        .key("pk", AttributeValue::S(pair_pk(pair_ref)))
+        .key("sk", AttributeValue::S(PAIR_SK.into()))
+        .send()
+        .await
+        .map_err(|e| format!("pair get failed: {e}"))?;
+    let Some(item) = out.item else {
+        return Ok(None);
+    };
+    let s = |k: &str| -> Result<String, String> {
+        item.get(k)
+            .and_then(|v| v.as_s().ok())
+            .cloned()
+            .ok_or_else(|| format!("pair item missing {k}"))
+    };
+    let opt_s = |k: &str| item.get(k).and_then(|v| v.as_s().ok()).cloned();
+    let num = |k: &str| -> Result<i64, String> {
+        item.get(k)
+            .and_then(|v| v.as_n().ok())
+            .and_then(|v| v.parse().ok())
+            .ok_or_else(|| format!("pair item missing {k}"))
+    };
+    let opt_n = |k: &str| {
+        item.get(k)
+            .and_then(|v| v.as_n().ok())
+            .and_then(|v| v.parse::<i64>().ok())
+    };
+    Ok(Some(Pair {
+        status: s("status")?,
+        device_id: s("deviceId")?,
+        hostname: s("hostname")?,
+        user_code: s("userCode")?,
+        bound_username: opt_s("boundUsername"),
+        bound_sub: opt_s("boundSub"),
+        setup_id: opt_s("setupId"),
+        universe: opt_n("universe").map(|v| v as u16),
+        device_name: opt_s("deviceName"),
+        created_at: num("createdAt")?,
+        expires_at: num("expiresAt")?,
+        redeemed_at: opt_n("redeemedAt"),
+        pub_ip: s("pubIp")?,
+    }))
+}
+
+/// Unexpired pending-list rows for one public IP, oldest first. Approval
+/// deletes its row, so what's here is (at most a TTL-lag away from) pending.
+pub async fn list_pending(
+    ctx: &Ctx,
+    pub_ip: &str,
+) -> Result<Vec<HashMap<String, AttributeValue>>, String> {
+    let out = ctx
+        .ddb
+        .query()
+        .table_name(&ctx.table)
+        .key_condition_expression("pk = :pk")
+        .expression_attribute_values(":pk", AttributeValue::S(pair_ip_pk(pub_ip)))
+        .send()
+        .await
+        .map_err(|e| format!("pending query failed: {e}"))?;
+    let now = now_millis();
+    Ok(out
+        .items
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|item| {
+            item.get("expiresAt")
+                .and_then(|v| v.as_n().ok())
+                .and_then(|v| v.parse::<i64>().ok())
+                .is_some_and(|exp| exp > now)
+        })
+        .collect())
+}
+
+/// Approve a pending grant: bind it to the approver and the chosen setup,
+/// retire its pending-list row, and record the device in the owner's registry
+/// — one transaction. Fails (condition) if the grant isn't pending anymore.
+#[allow(clippy::too_many_arguments)]
+pub async fn approve_pair(
+    ctx: &Ctx,
+    pair_ref: &str,
+    pair: &Pair,
+    username: &str,
+    sub: &str,
+    setup_id: &str,
+    universe: u16,
+    device_name: &str,
+) -> Result<(), String> {
+    let now = now_millis();
+    let s = |v: &str| AttributeValue::S(v.into());
+    let n = |v: i64| AttributeValue::N(v.to_string());
+
+    let update = aws_sdk_dynamodb::types::Update::builder()
+        .table_name(&ctx.table)
+        .key("pk", s(&pair_pk(pair_ref)))
+        .key("sk", s(PAIR_SK))
+        .update_expression(
+            "SET #st = :approved, boundUsername = :u, boundSub = :sub, \
+             setupId = :setup, universe = :uni, deviceName = :name, approvedAt = :now",
+        )
+        .condition_expression("#st = :pending AND expiresAt > :now")
+        .expression_attribute_names("#st", "status")
+        .expression_attribute_values(":approved", s("approved"))
+        .expression_attribute_values(":pending", s("pending"))
+        .expression_attribute_values(":u", s(username))
+        .expression_attribute_values(":sub", s(sub))
+        .expression_attribute_values(":setup", s(setup_id))
+        .expression_attribute_values(":uni", n(universe as i64))
+        .expression_attribute_values(":name", s(device_name))
+        .expression_attribute_values(":now", n(now))
+        .build()
+        .map_err(|e| format!("pair approve malformed: {e}"))?;
+
+    let drop_row = Delete::builder()
+        .table_name(&ctx.table)
+        .key("pk", s(&pair_ip_pk(&pair.pub_ip)))
+        .key("sk", s(&format!("{}#{}", pair.created_at, pair.device_id)))
+        .build()
+        .map_err(|e| format!("pending-row delete malformed: {e}"))?;
+
+    let registry: HashMap<String, AttributeValue> = HashMap::from([
+        ("pk".into(), s(&device_pk(sub))),
+        ("sk".into(), s(&pair.device_id)),
+        ("name".into(), s(device_name)),
+        ("hostname".into(), s(&pair.hostname)),
+        ("setupId".into(), s(setup_id)),
+        ("universe".into(), n(universe as i64)),
+        ("pairedAt".into(), n(now)),
+    ]);
+    let put_registry = Put::builder()
+        .table_name(&ctx.table)
+        .set_item(Some(registry))
+        .build()
+        .map_err(|e| format!("device registry put malformed: {e}"))?;
+
+    ctx.ddb
+        .transact_write_items()
+        .transact_items(TransactWriteItem::builder().update(update).build())
+        .transact_items(TransactWriteItem::builder().delete(drop_row).build())
+        .transact_items(TransactWriteItem::builder().put(put_registry).build())
+        .send()
+        .await
+        .map_err(|e| format!("pair approve failed: {e}"))?;
+    Ok(())
+}
+
+/// Claim an approved grant for redemption — the single-use gate. Exactly one
+/// caller wins the `approved → redeemed` flip; everyone else hits the
+/// condition. (If the mint after this fails, the code is burned and the node
+/// simply re-registers — safety over convenience.)
+pub async fn redeem_pair(ctx: &Ctx, pair_ref: &str) -> Result<(), String> {
+    ctx.ddb
+        .update_item()
+        .table_name(&ctx.table)
+        .key("pk", AttributeValue::S(pair_pk(pair_ref)))
+        .key("sk", AttributeValue::S(PAIR_SK.into()))
+        .update_expression("SET #st = :redeemed, redeemedAt = :now")
+        .condition_expression("#st = :approved")
+        .expression_attribute_names("#st", "status")
+        .expression_attribute_values(":redeemed", AttributeValue::S("redeemed".into()))
+        .expression_attribute_values(":approved", AttributeValue::S("approved".into()))
+        .expression_attribute_values(":now", AttributeValue::N(now_millis().to_string()))
+        .send()
+        .await
+        .map_err(|e| format!("pair redeem failed: {e}"))?;
+    Ok(())
+}

--- a/services/apple-auth/src/store.rs
+++ b/services/apple-auth/src/store.rs
@@ -202,19 +202,18 @@ fn now_millis() -> i64 {
 // PAIR/PAIRIP items carry `ttl` (epoch seconds) and self-expire; DEVICE items
 // don't.
 
-/// One pairing grant, as read back from the `PAIR#` item.
+/// One pairing grant, as read back from the `PAIR#` item. (The item carries
+/// more — userCode, deviceName — surfaced here only once something reads them.)
 #[derive(Debug)]
 pub struct Pair {
     pub status: String,
     pub device_id: String,
     pub hostname: String,
-    pub user_code: String,
     /// Set on approve.
     pub bound_username: Option<String>,
     pub bound_sub: Option<String>,
     pub setup_id: Option<String>,
     pub universe: Option<u16>,
-    pub device_name: Option<String>,
     /// Epoch millis.
     pub created_at: i64,
     pub expires_at: i64,
@@ -347,12 +346,10 @@ pub async fn get_pair(ctx: &Ctx, pair_ref: &str) -> Result<Option<Pair>, String>
         status: s("status")?,
         device_id: s("deviceId")?,
         hostname: s("hostname")?,
-        user_code: s("userCode")?,
         bound_username: opt_s("boundUsername"),
         bound_sub: opt_s("boundSub"),
         setup_id: opt_s("setupId"),
         universe: opt_n("universe").map(|v| v as u16),
-        device_name: opt_s("deviceName"),
         created_at: num("createdAt")?,
         expires_at: num("expiresAt")?,
         redeemed_at: opt_n("redeemedAt"),

--- a/services/apple-auth/src/triggers.rs
+++ b/services/apple-auth/src/triggers.rs
@@ -75,6 +75,12 @@ fn create(event: &mut Value) {
 /// A bad token, an unlinked credential, or a link to a different user are all
 /// the same outcome: `answerCorrect = false`. Only infrastructure failures
 /// (the link store erroring) surface as invoke errors.
+///
+/// The answer kind is pinned to the calling app client: the interactive
+/// client answers with an Apple identity token, the device client with a
+/// just-redeemed pairing code (`crate::device`). Pinning both directions means
+/// neither credential can ever mint on the other client — an Apple token
+/// can't open a 10-year device session, a device code can't sign into the app.
 async fn verify(ctx: &Ctx, event: &mut Value) {
     let answer = event
         .pointer("/request/challengeAnswer")
@@ -86,15 +92,26 @@ async fn verify(ctx: &Ctx, event: &mut Value) {
         .and_then(Value::as_str)
         .unwrap_or_default()
         .to_owned();
+    let client_id = event
+        .pointer("/callerContext/clientId")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
 
-    let correct = answer_is_correct(ctx, &answer, &user_sub).await;
+    let correct = if answer.is_empty() || user_sub.is_empty() {
+        false
+    } else if ctx.device_client_id.as_deref() == Some(client_id.as_str()) {
+        crate::device::answer_is_correct(ctx, &answer, &user_sub).await
+    } else if client_id == ctx.client_id {
+        apple_answer_is_correct(ctx, &answer, &user_sub).await
+    } else {
+        tracing::warn!("challenge answer from unknown app client");
+        false
+    };
     event["response"]["answerCorrect"] = json!(correct);
 }
 
-async fn answer_is_correct(ctx: &Ctx, answer: &str, user_sub: &str) -> bool {
-    if answer.is_empty() || user_sub.is_empty() {
-        return false;
-    }
+async fn apple_answer_is_correct(ctx: &Ctx, answer: &str, user_sub: &str) -> bool {
     let claims = match ctx.apple.verify_token(answer).await {
         Ok(c) => c,
         Err(e) => {


### PR DESCRIPTION
Phase 2 of docs/claim-code-pairing.md: an unpaired lux-node can now be
claimed from the app with no shell and no password.

- lux-wire: `device` module — /auth/device/{authorize,token,pending,
  approve} shapes, RFC 8628-style statuses, golden tests.
- apple-auth: device.rs implements the grant. Same-public-egress
  rendezvous (register and approve must share a NAT egress), display
  code LUX-XXXX from a confusion-free alphabet, device codes stored
  only as sha256, single-use via a conditional approved→redeemed flip,
  approve binds owner + setup + universe and writes the DEVICE#
  registry row in one transaction.
- Verify trigger now pins each answer kind to its app client: Apple
  identity tokens mint only on lux-app, device codes only on
  lux-node-device (fresh-redeem window, bound-user match). This also
  closes the pre-existing gap where any linked Apple token could have
  minted on any client.
- infra: ALLOW_CUSTOM_AUTH joins the device client (safe under the
  trigger pinning), the lambda learns COGNITO_DEVICE_CLIENT_ID, and
  the role gains dynamodb:Query for the pending list.

Everything fails closed until the infra applies (release-gated); the
routes 503 without the device client id. Node state machine (phase 3)
and the app's Add-device screen (phase 4) ride on this.
