### PR TITLE
fix(ui): drop the dialog slide-in/out utilities that skewed the open animation

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -44,7 +44,6 @@
     "react-hook-form": "^7.80.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -70,7 +70,11 @@ const DialogContent = React.forwardRef<
         ...style,
       }}
       className={cn(
-        "fixed left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        // No slide-in/out utilities here: with Tailwind v4 the static centering
+        // rides the `translate` property while the animate keyframes drive
+        // `transform`, so the two compose and the dialog would fly in
+        // diagonally from the top-left instead of zooming in place.
+        "fixed left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className,
       )}
       {...props}

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "apps/desktop": {
       "name": "lux",
-      "version": "1.1.0",
+      "version": "1.5.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@hookform/resolvers": "^5.4.0",
@@ -44,7 +44,6 @@
         "react-hook-form": "^7.80.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
-        "tailwindcss-animate": "^1.0.7",
         "tw-animate-css": "^1.4.0",
       },
       "devDependencies": {
@@ -836,8 +835,6 @@
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
-
-    "tailwindcss-animate": ["tailwindcss-animate@1.0.7", "", { "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders" } }, "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 


### PR DESCRIPTION
Every dialog (sign-in, delete-account confirm) entered from the top-left corner on a 45° diagonal and exited the same way instead of zooming in place.

**Cause:** a Tailwind v3 → v4 composition hazard. v4 emits the static centering utilities (`translate-x-[-50%]` / `translate-y-[-50%]`) on the modern `translate` CSS property, while the `tw-animate-css` enter/exit keyframes animate `transform` (`translate3d(...) scale3d(...)`). The two properties compose rather than override, so the shadcn-v3-era `slide-in-from-left-1/2` / `slide-in-from-top-[48%]` classes — which under v3 *reproduced* the centering inside the keyframe — now stack on top of it: the first frame starts a full half-dialog up-left of center and slides diagonally into place.

**Fix:** remove the four slide-in/out utilities and keep the fade + zoom pair, matching upstream shadcn's current (v4) dialog. Verified in the compiled CSS that the dialog no longer references the half-size slide offsets; the remaining `slide-in-from-*-2` classes are the intentional side-nudges on dropdown/popover surfaces, which carry no conflicting static translate.

Also removes `tailwindcss-animate` (v3 plugin): unreferenced since the v4 CSS-first migration — `globals.css` imports `tw-animate-css`, and no tailwind.config exists to load the JS plugin.