### PR TITLE
feat(node): sessions record the app client that minted them

### DIFF
--- a/apps/node/src/auth.rs
+++ b/apps/node/src/auth.rs
@@ -98,12 +98,18 @@ pub async fn sign_in(env: &Endpoints, email: &str, password: &str) -> Result<Tok
     tokens_from(resp.authentication_result())
 }
 
-pub async fn refresh(env: &Endpoints, refresh_token: &str) -> Result<Tokens, String> {
+/// `client_id` must be the client that minted the refresh token; `None` means
+/// the interactive client from the endpoints (pre-pairing sessions).
+pub async fn refresh(
+    env: &Endpoints,
+    client_id: Option<&str>,
+    refresh_token: &str,
+) -> Result<Tokens, String> {
     let client = cognito_client(&env.cognito_region).await;
     let out = client
         .initiate_auth()
         .auth_flow(AuthFlowType::RefreshTokenAuth)
-        .client_id(&env.cognito_app_client_id)
+        .client_id(client_id.unwrap_or(&env.cognito_app_client_id))
         .auth_parameters("REFRESH_TOKEN", refresh_token)
         .send()
         .await

--- a/apps/node/src/config.rs
+++ b/apps/node/src/config.rs
@@ -61,6 +61,12 @@ pub fn load_node_config(path: &Path) -> Result<NodeConfig, String> {
 pub struct StoredSession {
     pub email: String,
     pub refresh_token: String,
+    /// Which app client minted this session. Absent (password-era sessions)
+    /// means the interactive client from the embedded endpoints; device
+    /// pairing writes the device client here, and refresh must match the
+    /// minting client or Cognito rejects the token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
 }
 
 /// `$XDG_CONFIG_HOME/lux-node` (or `~/.config/lux-node`).

--- a/apps/node/src/install.rs
+++ b/apps/node/src/install.rs
@@ -124,7 +124,11 @@ pub fn install(opts: Options) -> Result<(), String> {
     let id_token = if Path::new(&session_file).exists() {
         let session = config::load_session()?;
         runtime
-            .block_on(auth::refresh(&env, &session.refresh_token))?
+            .block_on(auth::refresh(
+                &env,
+                session.client_id.as_deref(),
+                &session.refresh_token,
+            ))?
             .id
     } else {
         let email = value_or_prompt(opts.email.clone(), "lux account email", "--email")?;
@@ -138,6 +142,7 @@ pub fn install(opts: Options) -> Result<(), String> {
         config::save_session(&StoredSession {
             email: email.clone(),
             refresh_token: refresh,
+            client_id: None,
         })?;
         run("chown", &["-R", SERVICE_USER, STATE_DIR])?;
         println!("signed in as {email}");

--- a/apps/node/src/main.rs
+++ b/apps/node/src/main.rs
@@ -89,6 +89,7 @@ fn login(opts: install::Options) -> Result<(), String> {
     config::save_session(&config::StoredSession {
         email: email.clone(),
         refresh_token: refresh,
+        client_id: None,
     })?;
     println!("signed in as {email}; session stored. Next: lux-node run");
     Ok(())

--- a/apps/node/src/node.rs
+++ b/apps/node/src/node.rs
@@ -39,11 +39,12 @@ pub async fn run(
 ) -> Result<(), String> {
     let mut universe = Universe::default();
     let mut refresh_token = session.refresh_token;
+    let client_id = session.client_id;
     let mut backoff_secs = 1u64;
 
     loop {
         // Fresh ID token every attempt; Cognito may rotate the refresh token.
-        let tokens = match auth::refresh(&env, &refresh_token).await {
+        let tokens = match auth::refresh(&env, client_id.as_deref(), &refresh_token).await {
             Ok(tokens) => tokens,
             Err(e) => {
                 log::warn!("token refresh failed ({e}); retrying in {backoff_secs}s");


### PR DESCRIPTION
Device pairing mints refresh tokens on lux-node-device, but refresh was
pinned to the embedded interactive client id — a paired session died
with 'Refresh Token has different Client'. session.json gains an
optional clientId (absent = interactive client, so existing sessions
are untouched) and every refresh uses the minting client.
