### PR TITLE
fix(auth): pairing follow-ups — grant identity fields and a visible deletion blast radius

### DIFF
--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -363,6 +363,39 @@ impl LuxAccount {
         }
     }
 
+    /// The account's paired headless devices (lux-node boxes) from the auth
+    /// service's registry — the delete-account confirm's tally. No auth
+    /// service configured means no pairing anywhere: an empty list.
+    pub fn list_paired_devices(&self) -> Result<Vec<lux_wire::device::DeviceRecord>, String> {
+        let Some(base) = self.apple_auth_url.clone() else {
+            return Ok(Vec::new());
+        };
+        let Some(token) = self.current_id_token() else {
+            return Err("not signed in".into());
+        };
+        block_on(async move {
+            let response = reqwest::Client::new()
+                .get(format!(
+                    "{base}/{}/{}/{}",
+                    lux_wire::apple::AUTH_SEGMENT,
+                    lux_wire::device::DEVICE_SEGMENT,
+                    lux_wire::device::LIST_SEGMENT
+                ))
+                .bearer_auth(token)
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            if !response.status().is_success() {
+                return Err(format!("device list answered {}", response.status()));
+            }
+            response
+                .json::<lux_wire::device::ListResponse>()
+                .await
+                .map(|r| r.devices)
+                .map_err(|e| e.to_string())
+        })
+    }
+
     pub fn sign_out(&self) -> AuthStatus {
         clear_session();
         self.session.lock_or_recover().clear();

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -123,6 +123,9 @@ pub trait CmdMethods {
     // cards on the user channel. Backend-driven, so the UI polls it (events
     // don't reliably reach the webview on iOS).
     fn list_remote_peers(&self, app_handle: AppHandle) -> Result<Vec<RemotePeer>, String>;
+    // Paired headless devices (lux-node boxes) from the account's registry —
+    // the delete-account confirm shows them so the blast radius is visible.
+    fn list_paired_devices(&self, app_handle: AppHandle) -> Result<Vec<PairedDevice>, String>;
     // DMX output — the in-app device picker (the only output selector on mobile,
     // where there's no tray). Mirrors the desktop tray's device menu.
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String>;
@@ -133,6 +136,15 @@ pub trait CmdMethods {
     ) -> Result<Vec<DmxDeviceInfo>, String>;
     fn rescan_dmx_devices(&self, app_handle: AppHandle) -> Result<(), String>;
 }
+/// One paired headless device (a lux-node box) on the account, thinned from
+/// [`lux_wire::device::DeviceRecord`] to what the confirm dialog shows.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PairedDevice {
+    pub name: String,
+    pub hostname: String,
+}
+
 #[derive(ttipc::Event)]
 pub enum CmdEvent {
     ChannelDataSet {
@@ -451,6 +463,18 @@ impl CmdMethods for CmdEndpoint {
 
     fn list_remote_peers(&self, app_handle: AppHandle) -> Result<Vec<RemotePeer>, String> {
         Ok(app_handle.state::<crate::nudge::LuxNudge>().remote_peers())
+    }
+
+    fn list_paired_devices(&self, app_handle: AppHandle) -> Result<Vec<PairedDevice>, String> {
+        Ok(app_handle
+            .state::<LuxAccount>()
+            .list_paired_devices()?
+            .into_iter()
+            .map(|d| PairedDevice {
+                name: d.name,
+                hostname: d.hostname,
+            })
+            .collect())
     }
 
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String> {

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -155,6 +155,11 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  list_paired_devices(): Promise<PairedDevice[]> {
+    return invoke("cmd.list_paired_devices");
+  },
+
+  /** @throws {string} */
   list_dmx_devices(): Promise<DmxDeviceInfo[]> {
     return invoke("cmd.list_dmx_devices");
   },
@@ -308,6 +313,15 @@ export type RemotePeer = {
 	session: string,
 	setupId: string,
 	name: string,
+};
+
+/**
+ *  One paired headless device (a lux-node box) on the account, thinned from
+ *  [`lux_wire::device::DeviceRecord`] to what the confirm dialog shows.
+ */
+export type PairedDevice = {
+	name: string,
+	hostname: string,
 };
 
 /**

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -155,11 +155,6 @@ export const cmd = {
   },
 
   /** @throws {string} */
-  list_paired_devices(): Promise<PairedDevice[]> {
-    return invoke("cmd.list_paired_devices");
-  },
-
-  /** @throws {string} */
   list_dmx_devices(): Promise<DmxDeviceInfo[]> {
     return invoke("cmd.list_dmx_devices");
   },
@@ -313,15 +308,6 @@ export type RemotePeer = {
 	session: string,
 	setupId: string,
 	name: string,
-};
-
-/**
- *  One paired headless device (a lux-node box) on the account, thinned from
- *  [`lux_wire::device::DeviceRecord`] to what the confirm dialog shows.
- */
-export type PairedDevice = {
-	name: string,
-	hostname: string,
 };
 
 /**

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -155,6 +155,11 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  list_paired_devices(): Promise<PairedDevice[]> {
+    return invoke("cmd.list_paired_devices");
+  },
+
+  /** @throws {string} */
   list_dmx_devices(): Promise<DmxDeviceInfo[]> {
     return invoke("cmd.list_dmx_devices");
   },
@@ -291,6 +296,15 @@ export type LuxChannels = {
 export type LuxLabelColor = "Red" | "Green" | "Blue" | "Amber" | "White" | "Brightness" | 
 /**  Raw universe channels (7..=512) with no fixed colour role. */
 "Generic";
+
+/**
+ *  One paired headless device (a lux-node box) on the account, thinned from
+ *  [`lux_wire::device::DeviceRecord`] to what the confirm dialog shows.
+ */
+export type PairedDevice = {
+	name: string,
+	hostname: string,
+};
 
 /**
  *  How the current session was established. Password sessions can change

--- a/apps/desktop/src/components/account-menu.tsx
+++ b/apps/desktop/src/components/account-menu.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { toast } from "sonner";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { LogOut, Trash2, User as UserIcon } from "lucide-react";
 import { createTauRPCProxy } from "@/bindings";
 import useAuth, { AUTH_QUERY_KEY } from "@/hooks/useAuth";
+import useSetups from "@/hooks/useSetups";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -54,6 +55,14 @@ export default function AccountMenu() {
   const [pending, setPending] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  // Blast radius for the delete confirm: what the account will take with it.
+  const setups = useSetups();
+  const { data: pairedDevices } = useQuery({
+    queryKey: ["pairedDevices"],
+    queryFn: () => cmd().list_paired_devices(),
+    // Only worth a network round-trip while the confirm is actually open.
+    enabled: !!status?.signedIn && confirmDelete,
+  });
 
   // Accounts disabled (or status still loading) — render nothing.
   if (!status?.configured) return null;
@@ -128,9 +137,19 @@ export default function AccountMenu() {
             <DialogHeader>
               <DialogTitle>Delete account?</DialogTitle>
               <DialogDescription>
-                This permanently deletes your account and its cloud-synced
-                setups. Setups on this device stay on this device. This can't
-                be undone.
+                This permanently deletes {status.email ?? "your account"}
+                {setups
+                  ? ` and its ${setups.length} cloud-synced setup${
+                      setups.length === 1 ? "" : "s"
+                    }`
+                  : " and its cloud-synced setups"}
+                {pairedDevices?.length
+                  ? `, and unpairs ${pairedDevices.length} device${
+                      pairedDevices.length === 1 ? "" : "s"
+                    } (${pairedDevices.map((d) => d.name).join(", ")})`
+                  : ""}
+                . Setups on this device stay on this device. This can't be
+                undone.
               </DialogDescription>
             </DialogHeader>
             <div className="flex justify-end gap-2">

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -248,6 +248,7 @@ pub mod device {
     pub const TOKEN_SEGMENT: &str = "token";
     pub const PENDING_SEGMENT: &str = "pending";
     pub const APPROVE_SEGMENT: &str = "approve";
+    pub const LIST_SEGMENT: &str = "list";
 
     /// Body for `POST /auth/device/authorize`. Everything here is display
     /// metadata for the approve screen — identity is established by approval,
@@ -295,11 +296,16 @@ pub mod device {
     #[serde(rename_all = "camelCase")]
     pub struct TokenResponse {
         pub status: String,
-        /// On `granted`: what the node writes into session.json …
+        /// On `granted`: what the node writes into session.json (the account's
+        /// email attribute — usernames are UUIDs for Apple-created users) …
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub email: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub refresh_token: Option<String>,
+        /// The app client that minted the refresh token — the node refreshes
+        /// against this, never the interactive client.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub client_id: Option<String>,
         /// … and the setup binding the approver chose.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub setup_id: Option<String>,
@@ -352,6 +358,27 @@ pub mod device {
     #[serde(rename_all = "camelCase")]
     pub struct ApproveResponse {
         pub approved: bool,
+    }
+
+    /// One paired device in the owner's registry (`GET /auth/device/list`) —
+    /// the app's device list, and the account-deletion confirm's tally.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DeviceRecord {
+        pub device_id: String,
+        pub name: String,
+        pub hostname: String,
+        pub setup_id: String,
+        pub universe: u16,
+        /// Epoch millis (server clock).
+        pub paired_at: i64,
+    }
+
+    /// Response to `GET /auth/device/list`.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ListResponse {
+        pub devices: Vec<DeviceRecord>,
     }
 }
 
@@ -857,6 +884,7 @@ mod tests {
             status: "authorization_pending".into(),
             email: None,
             refresh_token: None,
+            client_id: None,
             setup_id: None,
             universe: None,
         };
@@ -868,12 +896,13 @@ mod tests {
             status: "granted".into(),
             email: Some("a@b.c".into()),
             refresh_token: Some("re".into()),
+            client_id: Some("dev-client".into()),
             setup_id: Some("s-1".into()),
             universe: Some(1),
         };
         assert_eq!(
             serde_json::to_string(&granted).unwrap(),
-            r#"{"status":"granted","email":"a@b.c","refreshToken":"re","setupId":"s-1","universe":1}"#
+            r#"{"status":"granted","email":"a@b.c","refreshToken":"re","clientId":"dev-client","setupId":"s-1","universe":1}"#
         );
     }
 

--- a/services/apple-auth/src/cognito.rs
+++ b/services/apple-auth/src/cognito.rs
@@ -121,6 +121,26 @@ pub async fn create_user(ctx: &Ctx, email: &str) -> Result<User, String> {
     })
 }
 
+/// The account's email attribute. Usernames are UUIDs for Apple-created
+/// users, so anything user-facing (or session-bound) wants this, not the
+/// username.
+pub async fn email_of(ctx: &Ctx, username: &str) -> Result<Option<String>, String> {
+    let out = ctx
+        .cognito
+        .admin_get_user()
+        .user_pool_id(&ctx.pool_id)
+        .username(username)
+        .send()
+        .await
+        .map_err(|e| format!("user get failed: {e}"))?;
+    Ok(out
+        .user_attributes()
+        .iter()
+        .find(|a| a.name() == "email")
+        .and_then(|a| a.value())
+        .map(str::to_owned))
+}
+
 /// Confirm a stalled self-signup (see [`User::unconfirmed`]).
 pub async fn confirm_user(ctx: &Ctx, username: &str) -> Result<(), String> {
     ctx.cognito

--- a/services/apple-auth/src/device.rs
+++ b/services/apple-auth/src/device.rs
@@ -391,6 +391,7 @@ fn status(code: u16, s: &str) -> Result<Value, Error> {
             status: s.into(),
             email: None,
             refresh_token: None,
+            client_id: None,
             setup_id: None,
             universe: None,
         },

--- a/services/apple-auth/src/device.rs
+++ b/services/apple-auth/src/device.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 
 use lambda_runtime::Error;
 use lux_wire::device::{
-    ApproveRequest, ApproveResponse, AuthorizeRequest, AuthorizeResponse, PendingDevice,
-    PendingResponse, TokenRequest, TokenResponse,
+    ApproveRequest, ApproveResponse, AuthorizeRequest, AuthorizeResponse, DeviceRecord,
+    ListResponse, PendingDevice, PendingResponse, TokenRequest, TokenResponse,
 };
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -158,18 +158,62 @@ async fn grant(
         }
     };
 
+    // The email attribute, not the username — Apple-created accounts have
+    // UUID usernames and the node stores/logs this as the account identity.
+    let email = match cognito::email_of(ctx, &username).await {
+        Ok(Some(e)) => e,
+        Ok(None) => username,
+        Err(e) => {
+            tracing::warn!("email lookup failed, falling back to username: {e}");
+            username
+        }
+    };
+
     reply(
         200,
         &TokenResponse {
             status: "granted".into(),
-            // The pool's usernames are emails; the node stores this beside the
-            // refresh token exactly as `lux-node login` does.
-            email: Some(username),
+            email: Some(email),
             refresh_token: Some(tokens.refresh_token),
+            client_id: Some(device_client_id.to_owned()),
             setup_id: Some(setup_id),
             universe: Some(pair.universe.unwrap_or(1)),
         },
     )
+}
+
+/// `GET /auth/device/list` — bearer-authed: the caller's paired devices.
+pub async fn list(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
+    let Some(caller_sub) = caller(ctx, event) else {
+        return reply(401, &error("invalid or missing token"));
+    };
+    let rows = match store::list_devices(ctx, &caller_sub).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("device list failed: {e}");
+            return reply(500, &error("internal"));
+        }
+    };
+    let devices: Vec<DeviceRecord> = rows
+        .iter()
+        .filter_map(|item| {
+            let s = |k: &str| item.get(k)?.as_s().ok().cloned();
+            let n = |k: &str| {
+                item.get(k)
+                    .and_then(|v| v.as_n().ok())
+                    .and_then(|v| v.parse::<i64>().ok())
+            };
+            Some(DeviceRecord {
+                device_id: item.get("sk")?.as_s().ok()?.clone(),
+                name: s("name")?,
+                hostname: s("hostname")?,
+                setup_id: s("setupId")?,
+                universe: n("universe")? as u16,
+                paired_at: n("pairedAt")?,
+            })
+        })
+        .collect();
+    reply(200, &ListResponse { devices })
 }
 
 /// `GET /auth/device/pending` — bearer-authed: unexpired registrations that

--- a/services/apple-auth/src/http.rs
+++ b/services/apple-auth/src/http.rs
@@ -64,7 +64,8 @@ pub async fn handle(ctx: &Arc<Ctx>, payload: Value) -> Result<Value, Error> {
     let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
 
     use lux_wire::device::{
-        APPROVE_SEGMENT, AUTHORIZE_SEGMENT, DEVICE_SEGMENT, PENDING_SEGMENT, TOKEN_SEGMENT,
+        APPROVE_SEGMENT, AUTHORIZE_SEGMENT, DEVICE_SEGMENT, LIST_SEGMENT, PENDING_SEGMENT,
+        TOKEN_SEGMENT,
     };
 
     match (method, segments.as_slice()) {
@@ -93,6 +94,9 @@ pub async fn handle(ctx: &Arc<Ctx>, payload: Value) -> Result<Value, Error> {
             if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == PENDING_SEGMENT =>
         {
             crate::device::pending(ctx, &event).await
+        }
+        ("GET", [a, b, c]) if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == LIST_SEGMENT => {
+            crate::device::list(ctx, &event).await
         }
         ("POST", [a, b, c])
             if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == APPROVE_SEGMENT =>

--- a/services/apple-auth/src/store.rs
+++ b/services/apple-auth/src/store.rs
@@ -386,6 +386,23 @@ pub async fn list_pending(
         .collect())
 }
 
+/// The owner's paired-device registry rows (`DEVICE#<sub>`), as stored.
+pub async fn list_devices(
+    ctx: &Ctx,
+    sub: &str,
+) -> Result<Vec<HashMap<String, AttributeValue>>, String> {
+    let out = ctx
+        .ddb
+        .query()
+        .table_name(&ctx.table)
+        .key_condition_expression("pk = :pk")
+        .expression_attribute_values(":pk", AttributeValue::S(device_pk(sub)))
+        .send()
+        .await
+        .map_err(|e| format!("device query failed: {e}"))?;
+    Ok(out.items.unwrap_or_default())
+}
+
 /// Approve a pending grant: bind it to the approver and the chosen setup,
 /// retire its pending-list row, and record the device in the owner's registry
 /// — one transaction. Fails (condition) if the grant isn't pending anymore.


### PR DESCRIPTION
Two 1.7.1 fixes out of tonight's account-deletion incident and first real device pairing:

- **Grant identity fields**: `/auth/device/token` now returns the account's **email attribute** (was: Cognito username, a UUID for Apple-created accounts) and the **minting client id**, so paired nodes write a complete, correct session without guessing (pairs with #210).
- **GET /auth/device/list**: the caller's paired-device registry — powers the app's future device list and, today, the deletion confirm.
- **Deletion blast radius**: the delete-account confirm now names the email, cloud-synced setup count, and paired devices before the destructive tap.