### PR TITLE
fix(ui): make presets toggle and restore the frame they replaced

### DIFF
--- a/apps/desktop/src/components/button-row.tsx
+++ b/apps/desktop/src/components/button-row.tsx
@@ -1,58 +1,61 @@
 import { Button } from "@/components/ui/button";
-import { debug, trace } from "@tauri-apps/plugin-log";
-import { createTauRPCProxy } from "@/bindings";
+import { trace } from "@tauri-apps/plugin-log";
 import { toast } from "sonner";
+import useBuffer from "@/hooks/useBuffer";
+import {
+  togglePreset,
+  useActivePresetId,
+  usePresetReconcile,
+} from "@/lib/preset-toggle";
 
-export function setBuffer(buffer: number[]) {
-  const taurpc = createTauRPCProxy();
-  taurpc.cmd
-    .set_buffer(buffer)
-    .then(() => {
-      // Debug-only: logged at debug level, not surfaced as a toast.
-      debug(`buffer set [${buffer}]`);
-    })
-    .catch((e) => toast.error(String(e)));
-}
-
-// A full 512-channel frame at one level overrides the whole universe.
-const universe = (level: number) => Array(512).fill(level);
+/** A full 512-channel frame at one level overrides the whole universe. */
+const universeWrites = (level: number) =>
+  new Map(Array.from({ length: 512 }, (_, i) => [i + 1, level] as const));
 
 // The two built-in presets. User-defined presets (saved scenes) are the
 // planned next residents of this row.
-const buttons = [
+const presets = [
   {
+    id: "blackout",
     children: "⚫️ Blackout",
-    onClick: () => setBuffer(universe(0)),
+    writes: () => universeWrites(0),
   },
   {
+    id: "full-bright",
     children: "💡 Full Bright",
-    onClick: () => setBuffer(universe(255)),
+    writes: () => universeWrites(255),
   },
 ];
 
-function ControlButton({
-  children,
-  onClick,
-}: {
-  children: string;
-  onClick: () => void;
-}) {
-  const handleClick = () => {
-    trace(`frontend sending ${children}`);
-    onClick();
-  };
-  return (
-    <Button key={children} onClick={handleClick} variant="link" size="sm">
-      {children}
-    </Button>
-  );
-}
-
-/** The preset row, shown on both control surfaces (fixtures + universe). */
+/**
+ * The preset row, shown on both control surfaces (fixtures + universe).
+ * Presets toggle: engaging one remembers the frame it replaced, pressing it
+ * again restores that frame (see lib/preset-toggle).
+ */
 function ButtonRow() {
+  const buffer = useBuffer();
+  usePresetReconcile(buffer);
+  const activeId = useActivePresetId();
   return (
     <div className="flex shrink-0 justify-center gap-2 py-2">
-      {buttons.map(ControlButton)}
+      {presets.map(({ id, children, writes }) => {
+        const active = activeId === id;
+        return (
+          <Button
+            key={id}
+            variant={active ? "secondary" : "link"}
+            size="sm"
+            aria-pressed={active}
+            disabled={!buffer}
+            onClick={() => {
+              trace(`frontend toggling ${children}`);
+              togglePreset(id, writes()).catch((e) => toast.error(String(e)));
+            }}
+          >
+            {children}
+          </Button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -8,6 +8,7 @@ import ColorTrigger from "@/components/color-picker/color-trigger";
 import useThrottle from "@/hooks/useThrottle";
 import { setChannelValue } from "@/lib/actions";
 import { emittersToRgb, mixToEmitters } from "@/lib/color-mix";
+import { togglePreset, useActivePresetId } from "@/lib/preset-toggle";
 
 /**
  * Reading light: tungsten/amber at full, master at 40%. Expressed as a picker
@@ -63,12 +64,13 @@ export default function FixtureColor({
     setColor({ ...rgb, a: dimmer ? at(dimmer) / 255 : 1 });
   }, [buffer, r, g, b, amber, white, dimmer]);
 
-  const send = useThrottle((next: RgbaColor) => {
+  /** The per-address writes that render `next` on this fixture's emitters. */
+  const emitterWrites = (next: RgbaColor): Array<[number | null, number]> => {
     const mix = mixToEmitters(next.r, next.g, next.b, {
       amber: amber !== null,
       white: white !== null,
     });
-    const writes: Array<[number | null, number]> = [
+    return [
       [r, mix.r],
       [g, mix.g],
       [b, mix.b],
@@ -76,7 +78,10 @@ export default function FixtureColor({
       [white, mix.w],
       [dimmer, Math.round(next.a * 255)],
     ];
-    for (const [addr, value] of writes) {
+  };
+
+  const send = useThrottle((next: RgbaColor) => {
+    for (const [addr, value] of emitterWrites(next)) {
       if (addr) setChannelValue({ channelNumber: addr, value }).catch(() => {});
     }
   }, 40);
@@ -84,6 +89,20 @@ export default function FixtureColor({
   const onChange = (next: RgbaColor) => {
     setColor(next);
     send(next);
+  };
+
+  // Reading light toggles: engaging snapshots the frame it replaces, pressing
+  // again restores it. Applied as one buffer write (not through the throttled
+  // wheel path) so the toggle store can track exactly what it set; the swatch
+  // and wheel follow via the buffer round-trip like any out-of-band change.
+  const presetId = `reading-light-${fixture.id}`;
+  const readingLightActive = useActivePresetId() === presetId;
+  const onReadingLight = () => {
+    const writes = new Map<number, number>();
+    for (const [addr, value] of emitterWrites(READING_LIGHT)) {
+      if (addr) writes.set(addr, value);
+    }
+    togglePreset(presetId, writes).catch(() => {});
   };
 
   // Glow tracks the dimmer when present, else the brightest color channel.
@@ -103,10 +122,12 @@ export default function FixtureColor({
         <RgbaColorPicker className="mx-auto" color={color} onChange={onChange} />
         <div className="mt-3">
           <Button
-            variant="outline"
+            variant={readingLightActive ? "default" : "outline"}
             size="sm"
             className="w-full gap-2"
-            onClick={() => onChange(READING_LIGHT)}
+            aria-pressed={readingLightActive}
+            disabled={!buffer}
+            onClick={onReadingLight}
           >
             <LampDesk className="size-4" /> Reading light
           </Button>

--- a/apps/desktop/src/lib/preset-toggle.ts
+++ b/apps/desktop/src/lib/preset-toggle.ts
@@ -1,0 +1,105 @@
+import { useEffect, useSyncExternalStore } from "react";
+import { createTauRPCProxy } from "@/bindings";
+import { queryClient } from "@/lib/query-client";
+import { BUFFER_QUERY_KEY } from "@/hooks/useBuffer";
+
+/**
+ * Presets are momentary looks, not destinations: engaging one remembers the
+ * channels it replaces, and toggling it off puts them back. The active preset
+ * is a UI-side notion — the backend only ever sees buffer writes — so the
+ * store also watches the live buffer and quietly drops the active state when
+ * anything else (a fader, the wheel, a remote command) moves a channel the
+ * preset set, rather than offering a restore that would clobber it.
+ *
+ * Snapshots are sparse (only the addresses the preset wrote) and every toggle
+ * starts from a fresh backend read, so concurrent changes to unrelated
+ * channels — another surface, the Discord bot — survive both engage and
+ * restore.
+ */
+type ActivePreset = {
+  id: string;
+  /** Prior value of each address the preset wrote (restore target). */
+  snapshot: Map<number, number>;
+  /** What the preset wrote (1-based address → value); divergence deactivates. */
+  expected: Map<number, number>;
+};
+
+let active: ActivePreset | null = null;
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Write a full frame and land the committed buffer in the query cache — the
+ * same cache-through pattern as lib/actions, because the `bufferSet` event
+ * never reaches the webview on iOS.
+ */
+async function applyBuffer(frame: number[]) {
+  const committed = await createTauRPCProxy().cmd.set_buffer(frame);
+  await queryClient.cancelQueries({ queryKey: BUFFER_QUERY_KEY });
+  queryClient.setQueryData(BUFFER_QUERY_KEY, committed.buffer);
+}
+
+/**
+ * Engage the preset `id`, or toggle it off if it is already the active one.
+ *
+ * Either way the outgoing preset (if any) is undone first, so switching
+ * directly between presets composes undo + engage into a single frame:
+ * toggling off always returns to a state the user actually set, never to
+ * another preset's output. The active mark is only set once the backend
+ * commits, so a failed write leaves both the lights and the toggle untouched.
+ */
+export async function togglePreset(id: string, writes: Map<number, number>) {
+  const previous = active;
+  const base = (await createTauRPCProxy().sync.sync_buffer()).buffer.slice();
+  for (const [address, value] of previous?.snapshot ?? []) {
+    base[address - 1] = value;
+  }
+  if (previous?.id === id) {
+    active = null;
+    notify();
+    await applyBuffer(base);
+    return;
+  }
+  const snapshot = new Map<number, number>();
+  for (const address of writes.keys()) {
+    snapshot.set(address, base[address - 1] ?? 0);
+  }
+  const frame = base.slice();
+  for (const [address, value] of writes) frame[address - 1] = value;
+  await applyBuffer(frame);
+  active = { id, snapshot, expected: writes };
+  notify();
+}
+
+/** The id of the engaged preset, or null. Re-renders on engage/clear. */
+export function useActivePresetId(): string | null {
+  return useSyncExternalStore(subscribe, () => active?.id ?? null);
+}
+
+/**
+ * Drop the active preset when the live buffer no longer matches what it
+ * wrote. Mount next to a `useBuffer()` read (ButtonRow does, on both
+ * surfaces) — running it from several components is harmless.
+ */
+export function usePresetReconcile(buffer: number[] | null) {
+  useEffect(() => {
+    if (!active || !buffer) return;
+    for (const [address, value] of active.expected) {
+      if (buffer[address - 1] !== value) {
+        active = null;
+        notify();
+        return;
+      }
+    }
+  }, [buffer]);
+}


### PR DESCRIPTION
Selecting a preset (Blackout, Full Bright, or a fixture's Reading light) now toggles: engaging it remembers the channels it overwrites, pressing it again puts them back. The engaged preset renders pressed (`aria-pressed`, filled variant).

Semantics, decided for multi-surface safety:

- **Sparse snapshots + fresh reads.** A snapshot holds only the addresses the preset wrote, and every toggle starts from a fresh `sync_buffer` read — concurrent changes to unrelated channels (another surface, the Discord bot) survive both engage and restore.
- **Divergence deactivates.** If anything else moves a channel the preset set — a fader, the wheel, a remote command — the toggle quietly clears instead of later restoring over someone's changes.
- **Switching composes.** Going straight from one preset to another undoes the outgoing preset and engages the incoming one in a single frame, so toggling off always returns to a state the user actually set, never to another preset's output.
- **Failed writes change nothing.** The active mark is only set after the backend commits.

The preset row also cache-throughs the committed buffer the way `lib/actions` does (the `bufferSet` event never reaches the iOS webview), fixing its stale buffer view there.

The store is `src/lib/preset-toggle.ts`; user-defined scenes can ride the same mechanism when they land.