### PR TITLE
ci(release): run node builds beside the other builds, attach assets with the publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1020,11 +1020,11 @@ jobs:
 
   # The node binary becomes a public release asset, so installing on a Linux
   # box is a curl of releases/latest + `sudo ./lux-node install` — no Actions
-  # login to fetch an artifact. Runs after build-macos on purpose: the
-  # assetless-release resolver treats "release has assets" as "finished", so
-  # nothing may attach assets before the macOS publish does.
-  node-release:
-    needs: [release, build-macos]
+  # login to fetch an artifact. This job only builds and stages: attaching to
+  # the release is node-publish's, so the musl builds run in parallel with the
+  # other build legs instead of trailing build-macos.
+  node-build:
+    needs: [release, ci]
     if: ${{ needs.release.outputs.release_created == 'true' }}
     strategy:
       matrix:
@@ -1040,7 +1040,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
-      contents: write # upload the release asset
+      contents: read
     env:
       TAG: ${{ needs.release.outputs.tag_name }}
       RUSTC_WRAPPER: sccache
@@ -1069,10 +1069,38 @@ jobs:
       - name: Build (static musl)
         run: cargo build --release --target ${{ matrix.target }} -p lux-node
 
-      - name: Upload as a release asset
+      - name: Stage the binary
+        run: cp "target/${{ matrix.target }}/release/lux-node" "${{ matrix.asset }}"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.asset }}
+          path: ${{ matrix.asset }}
+          retention-days: 1
+
+  # The node sibling of publish-ios/publish-mas: the binaries already exist,
+  # "publishing" is attaching them as release assets. Behind build-macos on
+  # purpose: the assetless-release resolver treats "release has assets" as
+  # "finished", so nothing may attach assets before the macOS publish does.
+  node-publish:
+    needs: [release, node-build, build-macos]
+    if: ${{ needs.release.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # upload the release assets
+    env:
+      TAG: ${{ needs.release.outputs.tag_name }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: lux-node-*
+          merge-multiple: true
+
+      - name: Upload as release assets
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          cp "target/${{ matrix.target }}/release/lux-node" "${{ matrix.asset }}"
-          gh release upload "$TAG" "${{ matrix.asset }}" --clobber
-          echo "uploaded ${{ matrix.asset }} to $TAG"
+          gh release upload "$TAG" lux-node-x86_64-linux lux-node-aarch64-linux \
+            --clobber -R "$GITHUB_REPOSITORY"
+          echo "uploaded node binaries to $TAG"


### PR DESCRIPTION
The `node-release` matrix job built the musl binaries **and** attached them as release assets, gated behind `build-macos` — so the builds trailed the whole pipeline even though only the asset attachment needs the gate (the assetless-release resolver treats "release has assets" as "finished"; nothing may attach assets before the macOS publish does).

Split it along the same build/publish seam as the Apple legs:

- **`node-build`** (matrix, unchanged build steps): `needs: [release, ci]` like `build-ios`, so both musl builds start as soon as the test gate clears and run in parallel with `build-ios`/`build-mas`/`build-macos`. Stages the binaries as 1-day artifacts; `contents: read`.
- **`node-publish`**: `needs: [release, node-build, build-macos]`, in parallel with `publish-ios`/`publish-mas`. Downloads the staged artifacts and `gh release upload`s both assets — the asset-ordering invariant holds exactly as before, the uploads just no longer wait on a fresh compile.

Failure semantics are unchanged: no `always()` on either job, so a failed `ci` skips `node-build`, and a failed `build-macos` (or node build) skips `node-publish` — assets never attach ahead of a broken macOS publish. Dispatch re-runs skip the node legs exactly as they did before.

actionlint: clean apart from the pre-existing SC2034 warning on main.