### PR TITLE
fix(ui): merge the setup switcher and manager into one dropdown

### DIFF
--- a/apps/desktop/src/components/setup-switcher.tsx
+++ b/apps/desktop/src/components/setup-switcher.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   Check,
@@ -48,6 +48,17 @@ export default function SetupSwitcher() {
   // background refreshes, so a `setupsChanged` mid-edit can't clobber typing.
   const [draft, setDraft] = useState<Draft | null>(null);
   const [rescanning, setRescanning] = useState(false);
+  // Deleting a setup takes its fixtures with it and there is no undo, so the
+  // trash arms on the first tap (turns destructive) and only deletes on the
+  // second; it disarms itself after a moment or when the dropdown closes.
+  const [armedDelete, setArmedDelete] = useState<string | null>(null);
+  const disarmTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (disarmTimer.current) clearTimeout(disarmTimer.current);
+    },
+    [],
+  );
 
   if (!setups || !active) {
     return (
@@ -59,7 +70,10 @@ export default function SetupSwitcher() {
 
   const onOpenChange = (next: boolean) => {
     setOpen(next);
-    if (!next) setDraft(null);
+    if (!next) {
+      setDraft(null);
+      setArmedDelete(null);
+    }
   };
 
   const switchTo = (id: string) => {
@@ -106,6 +120,17 @@ export default function SetupSwitcher() {
     } catch (e) {
       toast.error(String(e));
     }
+  };
+
+  const onTrash = (id: string) => {
+    if (armedDelete === id) {
+      setArmedDelete(null);
+      void remove(id);
+      return;
+    }
+    setArmedDelete(id);
+    if (disarmTimer.current) clearTimeout(disarmTimer.current);
+    disarmTimer.current = setTimeout(() => setArmedDelete(null), 3000);
   };
 
   const selectDevice = (key: string) => {
@@ -223,10 +248,19 @@ export default function SetupSwitcher() {
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="size-7 shrink-0 text-muted-foreground hover:text-destructive"
-                    aria-label={`Delete ${s.name}`}
+                    className={cn(
+                      "size-7 shrink-0",
+                      armedDelete === s.id
+                        ? "bg-destructive/15 text-destructive hover:text-destructive"
+                        : "text-muted-foreground hover:text-destructive",
+                    )}
+                    aria-label={
+                      armedDelete === s.id
+                        ? `Tap again to delete ${s.name}`
+                        : `Delete ${s.name}`
+                    }
                     disabled={setups.length <= 1}
-                    onClick={() => remove(s.id)}
+                    onClick={() => onTrash(s.id)}
                   >
                     <Trash2 className="size-3.5" />
                   </Button>

--- a/apps/desktop/src/components/setup-switcher.tsx
+++ b/apps/desktop/src/components/setup-switcher.tsx
@@ -3,9 +3,9 @@ import { toast } from "sonner";
 import {
   Check,
   ChevronsUpDown,
+  Pencil,
   Plus,
   RefreshCw,
-  Settings2,
   Trash2,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -16,13 +16,6 @@ import useLuxRefresh from "@/hooks/useLuxRefresh";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -31,10 +24,15 @@ import { cn } from "@/lib/utils";
 
 const cmd = () => createTauRPCProxy().cmd;
 
+/** A setup row's in-flight edits (or the create form's, with id null). */
+type Draft = { id: string | null; name: string; universe: number };
+
 /**
- * Switch between the user's setups and manage them (rename / rebind universe /
- * create / delete). Switching is the common action, so it's a plain dropdown;
- * the editing lives behind a "manage" popover to keep the nav uncluttered.
+ * One dropdown for everything setups: each row switches on click and edits in
+ * place (the pencil flips the row to name/universe inputs — any setup, not
+ * just the active one), a "New setup…" row expands the same way, and the DMX
+ * output picker keeps its spot at the bottom. A Popover rather than a
+ * DropdownMenu because menu items fight inline inputs for focus and keys.
  */
 export default function SetupSwitcher() {
   const setups = useSetups();
@@ -45,11 +43,10 @@ export default function SetupSwitcher() {
   const refreshDevices = () =>
     queryClient.invalidateQueries({ queryKey: DMX_DEVICES_QUERY_KEY });
 
-  const [manageOpen, setManageOpen] = useState(false);
-  const [editName, setEditName] = useState("");
-  const [editUniverse, setEditUniverse] = useState(1);
-  const [newName, setNewName] = useState("");
-  const [newUniverse, setNewUniverse] = useState(1);
+  const [open, setOpen] = useState(false);
+  // Seeded when a row's pencil (or "New setup…") is clicked, never from
+  // background refreshes, so a `setupsChanged` mid-edit can't clobber typing.
+  const [draft, setDraft] = useState<Draft | null>(null);
   const [rescanning, setRescanning] = useState(false);
 
   if (!setups || !active) {
@@ -60,7 +57,13 @@ export default function SetupSwitcher() {
     );
   }
 
+  const onOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) setDraft(null);
+  };
+
   const switchTo = (id: string) => {
+    setOpen(false);
     if (id === active.id) return;
     cmd()
       .set_active_setup(id)
@@ -68,52 +71,38 @@ export default function SetupSwitcher() {
       .catch((e) => toast.error(String(e)));
   };
 
-  // Seed the edit fields from the active setup only as the popover opens, so a
-  // background `setupsChanged` can't clobber what the user is typing.
-  const onManageOpenChange = (open: boolean) => {
-    setManageOpen(open);
-    if (open) {
-      setEditName(active.name);
-      setEditUniverse(active.universe);
-      setNewName("");
-      setNewUniverse(1);
-    }
-  };
-
-  const saveCurrent = async () => {
-    const name = editName.trim();
+  const saveDraft = async () => {
+    if (!draft) return;
+    const name = draft.name.trim();
     if (!name) return;
     try {
-      if (name !== active.name) await cmd().rename_setup(active.id, name);
-      if (editUniverse !== active.universe)
-        await cmd().set_setup_universe(active.id, editUniverse);
+      if (draft.id === null) {
+        const before = setups;
+        const after: SetupSummary[] = await cmd().create_setup(
+          name,
+          draft.universe,
+        );
+        const created = after.find((s) => !before.some((b) => b.id === s.id));
+        if (created) await cmd().set_active_setup(created.id);
+        setOpen(false);
+      } else {
+        const current = setups.find((s) => s.id === draft.id);
+        if (current && name !== current.name)
+          await cmd().rename_setup(draft.id, name);
+        if (current && draft.universe !== current.universe)
+          await cmd().set_setup_universe(draft.id, draft.universe);
+      }
       await refresh();
-      setManageOpen(false);
+      setDraft(null);
     } catch (e) {
       toast.error(String(e));
     }
   };
 
-  const removeCurrent = async () => {
+  const remove = async (id: string) => {
     try {
-      await cmd().delete_setup(active.id);
+      await cmd().delete_setup(id);
       await refresh();
-      setManageOpen(false);
-    } catch (e) {
-      toast.error(String(e));
-    }
-  };
-
-  const createAndSwitch = async () => {
-    const name = newName.trim();
-    if (!name) return;
-    try {
-      const before = setups;
-      const after: SetupSummary[] = await cmd().create_setup(name, newUniverse);
-      const created = after.find((s) => !before.some((b) => b.id === s.id));
-      if (created) await cmd().set_active_setup(created.id);
-      await refresh();
-      setManageOpen(false);
     } catch (e) {
       toast.error(String(e));
     }
@@ -142,171 +131,174 @@ export default function SetupSwitcher() {
     }, 3500);
   };
 
+  const editorFor = (heading: string, confirmLabel: string) => (
+    <div className="flex flex-col gap-2 rounded-md border p-2">
+      <p className="text-xs font-medium text-muted-foreground">{heading}</p>
+      <Input
+        autoFocus
+        value={draft!.name}
+        onChange={(e) => setDraft({ ...draft!, name: e.target.value })}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") void saveDraft();
+        }}
+        placeholder="Name"
+        className="h-8"
+      />
+      <label className="flex items-center justify-between gap-2 text-xs font-medium text-muted-foreground">
+        Universe
+        <Input
+          type="number"
+          min={1}
+          max={63999}
+          className="h-8 w-24"
+          value={draft!.universe}
+          onChange={(e) => setDraft({ ...draft!, universe: Number(e.target.value) })}
+        />
+      </label>
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          className="flex-1"
+          onClick={saveDraft}
+          disabled={!draft!.name.trim()}
+        >
+          {confirmLabel}
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => setDraft(null)}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+
   return (
-    <div className="flex items-center gap-1">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm" className="gap-1.5">
-            <span className="max-w-32 truncate">{active.name}</span>
-            <ChevronsUpDown className="size-3.5 text-muted-foreground" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-56">
-          <DropdownMenuLabel>Setups</DropdownMenuLabel>
-          {setups.map((s) => (
-            <DropdownMenuItem
-              key={s.id}
-              onSelect={() => switchTo(s.id)}
-              className="gap-2"
-            >
-              <Check
-                className={cn("size-4", s.active ? "opacity-100" : "opacity-0")}
-              />
-              <span className="flex-1 truncate">{s.name}</span>
-              <span className="text-xs text-muted-foreground">
-                U{s.universe} · {s.fixtureCount}fx
-              </span>
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <Popover open={manageOpen} onOpenChange={onManageOpenChange}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-8"
-            aria-label="Manage setups"
-          >
-            <Settings2 className="size-4" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent align="start" className="w-72">
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2">
-              <p className="text-xs font-medium text-muted-foreground">
-                Current setup
-              </p>
-              <Input
-                value={editName}
-                onChange={(e) => setEditName(e.target.value)}
-                placeholder="Name"
-              />
-              <label className="flex items-center justify-between gap-2 text-xs font-medium text-muted-foreground">
-                Universe
-                <Input
-                  type="number"
-                  min={1}
-                  max={63999}
-                  className="h-8 w-24"
-                  value={editUniverse}
-                  onChange={(e) => setEditUniverse(Number(e.target.value))}
-                />
-              </label>
-              <div className="flex gap-2">
-                <Button
-                  size="sm"
-                  className="flex-1"
-                  onClick={saveCurrent}
-                  disabled={!editName.trim()}
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1.5">
+          <span className="max-w-32 truncate">{active.name}</span>
+          <ChevronsUpDown className="size-3.5 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-72 p-2">
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-0.5">
+            <p className="px-2 py-1 text-xs font-medium text-muted-foreground">
+              Setups
+            </p>
+            {setups.map((s) =>
+              draft?.id === s.id ? (
+                <div key={s.id}>{editorFor(s.name, "Save")}</div>
+              ) : (
+                <div
+                  key={s.id}
+                  className="flex items-center rounded-md hover:bg-accent"
                 >
-                  Save
-                </Button>
-                <Button
-                  size="sm"
-                  variant="destructive"
-                  onClick={removeCurrent}
-                  disabled={setups.length <= 1}
-                  aria-label="Delete this setup"
-                >
-                  <Trash2 className="size-4" />
-                </Button>
-              </div>
-            </div>
-
-            <div className="h-px bg-border" />
-
-            <div className="flex flex-col gap-2">
-              <p className="text-xs font-medium text-muted-foreground">
-                New setup
-              </p>
-              <Input
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                placeholder="e.g. Church"
-              />
-              <label className="flex items-center justify-between gap-2 text-xs font-medium text-muted-foreground">
-                Universe
-                <Input
-                  type="number"
-                  min={1}
-                  max={63999}
-                  className="h-8 w-24"
-                  value={newUniverse}
-                  onChange={(e) => setNewUniverse(Number(e.target.value))}
-                />
-              </label>
-              <Button
-                size="sm"
-                onClick={createAndSwitch}
-                disabled={!newName.trim()}
+                  <button
+                    type="button"
+                    onClick={() => switchTo(s.id)}
+                    className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left text-sm"
+                  >
+                    <Check
+                      className={cn(
+                        "size-4 shrink-0",
+                        s.active ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    <span className="flex-1 truncate">{s.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      U{s.universe} · {s.fixtureCount}fx
+                    </span>
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
+                    aria-label={`Edit ${s.name}`}
+                    onClick={() =>
+                      setDraft({ id: s.id, name: s.name, universe: s.universe })
+                    }
+                  >
+                    <Pencil className="size-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7 shrink-0 text-muted-foreground hover:text-destructive"
+                    aria-label={`Delete ${s.name}`}
+                    disabled={setups.length <= 1}
+                    onClick={() => remove(s.id)}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </div>
+              ),
+            )}
+            {draft?.id === null ? (
+              editorFor("New setup", "Create & switch")
+            ) : (
+              <button
+                type="button"
+                onClick={() => setDraft({ id: null, name: "", universe: 1 })}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
               >
-                <Plus className="mr-1 size-4" /> Create &amp; switch
+                <Plus className="size-4 shrink-0" />
+                New setup…
+              </button>
+            )}
+          </div>
+
+          <div className="h-px bg-border" />
+
+          <div className="flex flex-col gap-1 px-1 pb-1">
+            <div className="flex items-center justify-between">
+              <p className="px-1 text-xs font-medium text-muted-foreground">
+                DMX output
+              </p>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 gap-1 px-2 text-xs text-muted-foreground"
+                onClick={rescanDevices}
+                disabled={rescanning}
+              >
+                <RefreshCw
+                  className={cn("size-3", rescanning && "animate-spin")}
+                />
+                Rescan
               </Button>
             </div>
-
-            <div className="h-px bg-border" />
-
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center justify-between">
-                <p className="text-xs font-medium text-muted-foreground">
-                  DMX output
-                </p>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 gap-1 px-2 text-xs text-muted-foreground"
-                  onClick={rescanDevices}
-                  disabled={rescanning}
-                >
-                  <RefreshCw
-                    className={cn("size-3", rescanning && "animate-spin")}
-                  />
-                  Rescan
-                </Button>
-              </div>
-              {dmxDevices === null ? (
-                <p className="text-xs text-muted-foreground">Scanning…</p>
-              ) : dmxDevices.length === 0 ? (
-                <p className="text-xs text-muted-foreground">No outputs found.</p>
-              ) : (
-                <div className="flex flex-col gap-0.5">
-                  {dmxDevices.map((d) => (
-                    <button
-                      key={d.key}
-                      type="button"
-                      onClick={() => selectDevice(d.key)}
+            {dmxDevices === null ? (
+              <p className="px-1 text-xs text-muted-foreground">Scanning…</p>
+            ) : dmxDevices.length === 0 ? (
+              <p className="px-1 text-xs text-muted-foreground">
+                No outputs found.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-0.5">
+                {dmxDevices.map((d) => (
+                  <button
+                    key={d.key}
+                    type="button"
+                    onClick={() => selectDevice(d.key)}
+                    className={cn(
+                      "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent",
+                      d.active && "bg-accent/50",
+                    )}
+                  >
+                    <Check
                       className={cn(
-                        "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent",
-                        d.active && "bg-accent/50",
+                        "size-4 shrink-0",
+                        d.active ? "opacity-100" : "opacity-0",
                       )}
-                    >
-                      <Check
-                        className={cn(
-                          "size-4 shrink-0",
-                          d.active ? "opacity-100" : "opacity-0",
-                        )}
-                      />
-                      <span className="flex-1 truncate">{d.label}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+                    />
+                    <span className="flex-1 truncate">{d.label}</span>
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
-        </PopoverContent>
-      </Popover>
-    </div>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }


### PR DESCRIPTION
The nav had two setup controls: the switcher dropdown and a gear popover for managing (edit the active setup's name/universe, create, delete, DMX output). One surface now:

- **Each row switches on click** and shows the same `U<n> · <k>fx` summary as before.
- **Editing is in place**: the row's pencil flips it to name + universe inputs with Save/Cancel (Enter saves). Works for any setup, not just the active one — `rename_setup`/`set_setup_universe` were already id-based.
- **Delete is per-row**, disabled on the last remaining setup (unchanged guard).
- **New setup…** expands inline with the same fields and keeps the create-and-switch behavior.
- **DMX output** (device list + rescan) keeps its section at the bottom of the same dropdown; the gear button is gone.

Edit state seeds from the row when the pencil is clicked, never from background refreshes, so a `setupsChanged` mid-edit can't clobber typing (same guard the old popover had). Built on a Popover instead of a DropdownMenu because Radix menu items contend with inline inputs for focus and arrow keys.