### PR TITLE
feat(node): claim-code pairing — unpaired-boot state machine and `pair`

### DIFF
--- a/apps/desktop/src-tauri/endpoints.prod.json
+++ b/apps/desktop/src-tauri/endpoints.prod.json
@@ -1,6 +1,7 @@
 {
   "appleAuthUrl": "https://z3z752gt7cz6sd4a55xzu53bgi0cfsrm.lambda-url.us-west-1.on.aws/",
   "cognitoAppClientId": "2t2l4fn537ttb3vul39olt3of3",
+  "cognitoDeviceClientId": "l6ocppn3jr96bulq87mvg7qem",
   "cognitoRegion": "us-west-1",
   "cognitoUserPoolId": "us-west-1_jV7esPwmi",
   "nudgeEndpoint": "a3ql2117uqly38-ats.iot.us-west-1.amazonaws.com",

--- a/apps/desktop/src-tauri/src/endpoints.rs
+++ b/apps/desktop/src-tauri/src/endpoints.rs
@@ -28,6 +28,11 @@ pub struct Endpoints {
     pub cognito_region: String,
     pub cognito_user_pool_id: String,
     pub cognito_app_client_id: String,
+    /// The `lux-node-device` app client the headless pairing grant mints on.
+    /// Present from the first release after that client's Terraform applied;
+    /// only lux-node refreshes against it, but the app carries it so the
+    /// generated endpoints file stays one shape across both embedders.
+    pub cognito_device_client_id: String,
     pub sync_url: String,
     pub nudge_endpoint: String,
     /// Base URL of the lux-apple-auth Function URL (Sign in with Apple).
@@ -111,6 +116,10 @@ fn overlay(base: &mut Endpoints, local: Endpoints) {
     take(&mut base.cognito_region, local.cognito_region);
     take(&mut base.cognito_user_pool_id, local.cognito_user_pool_id);
     take(&mut base.cognito_app_client_id, local.cognito_app_client_id);
+    take(
+        &mut base.cognito_device_client_id,
+        local.cognito_device_client_id,
+    );
     take(&mut base.sync_url, local.sync_url);
     take(&mut base.nudge_endpoint, local.nudge_endpoint);
     take(&mut base.apple_auth_url, local.apple_auth_url);
@@ -134,6 +143,7 @@ mod tests {
         assert!(!endpoints.cognito_region.is_empty());
         assert!(!endpoints.cognito_user_pool_id.is_empty());
         assert!(!endpoints.cognito_app_client_id.is_empty());
+        assert!(!endpoints.cognito_device_client_id.is_empty());
         assert!(!endpoints.sync_url.is_empty());
         assert!(!endpoints.nudge_endpoint.is_empty());
         assert!(!endpoints.apple_auth_url.is_empty());

--- a/apps/node/src/config.rs
+++ b/apps/node/src/config.rs
@@ -20,6 +20,12 @@ pub struct Endpoints {
     pub cognito_app_client_id: String,
     pub nudge_endpoint: String,
     pub sync_url: String,
+    /// Base URL of the auth service (Sign in with Apple + `/auth/device/*`) —
+    /// the node's pairing endpoint.
+    pub apple_auth_url: String,
+    /// The `lux-node-device` Cognito app client the pairing grant mints on;
+    /// the node refreshes against it (recorded in [`StoredSession::client_id`]).
+    pub cognito_device_client_id: String,
 }
 
 pub fn endpoints() -> Result<Endpoints, String> {
@@ -85,8 +91,71 @@ pub fn session_path() -> Result<PathBuf, String> {
     Ok(config_dir()?.join("session.json"))
 }
 
-pub fn default_config_path() -> Result<PathBuf, String> {
-    Ok(config_dir()?.join("config.json"))
+/// Is a session already stored? An absent session is the trigger for the
+/// unpaired-boot state machine — `run` waits to be claimed instead of dying.
+pub fn session_exists() -> Result<bool, String> {
+    Ok(session_path()?.exists())
+}
+
+/// The paired setup binding lives here, not in the root-owned
+/// `/etc/lux-node/config.json`: the service runs as `lux-node` under
+/// `ProtectSystem=full`, so the approve step's choice lands in the state dir.
+/// `run`'s precedence: explicit `--config` file → this → unpaired-wait.
+pub fn node_binding_path() -> Result<PathBuf, String> {
+    Ok(config_dir()?.join("node.json"))
+}
+
+/// Which setup-binding source `run` uses. Pure, so the precedence is unit-tested
+/// (`--config` file → paired state-dir `node.json` → none).
+#[derive(Debug, PartialEq, Eq)]
+pub enum Binding {
+    /// An explicit `--config <file>` that exists on disk (today's installs).
+    Explicit,
+    /// The paired state-dir `node.json` (the approve step's choice).
+    StateDir,
+    /// No binding at all — the box must pair (or be given `--config`) first.
+    None,
+}
+
+pub fn binding_choice(explicit_config_exists: bool, node_json_exists: bool) -> Binding {
+    if explicit_config_exists {
+        Binding::Explicit
+    } else if node_json_exists {
+        Binding::StateDir
+    } else {
+        Binding::None
+    }
+}
+
+/// Persist the setup binding the approver chose (`{setupId, universe}`), the
+/// same minimal shape `install` writes to `/etc/lux-node/config.json`;
+/// `interface`/`priority` stay at their [`NodeConfig`] defaults.
+pub fn save_node_binding(setup_id: &str, universe: u16) -> Result<(), String> {
+    let path = node_binding_path()?;
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;
+    }
+    let json = serde_json::json!({ "setupId": setup_id, "universe": universe });
+    fs::write(&path, format!("{json:#}\n")).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+/// The node's stable self-generated id (a uuid), persisted in the state dir so
+/// a re-registering node supersedes its own earlier pairing codes rather than
+/// piling up new pending entries. Created on first read.
+pub fn load_or_create_device_id() -> Result<String, String> {
+    let path = config_dir()?.join("device_id");
+    if let Ok(existing) = fs::read_to_string(&path) {
+        let id = existing.trim();
+        if !id.is_empty() {
+            return Ok(id.to_owned());
+        }
+    }
+    let id = uuid::Uuid::new_v4().to_string();
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;
+    }
+    fs::write(&path, format!("{id}\n")).map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(id)
 }
 
 pub fn load_session() -> Result<StoredSession, String> {
@@ -139,6 +208,8 @@ mod tests {
         assert!(!e.cognito_region.is_empty());
         assert!(!e.nudge_endpoint.is_empty());
         assert!(e.sync_url.starts_with("https://"));
+        assert!(e.apple_auth_url.starts_with("https://"));
+        assert!(!e.cognito_device_client_id.is_empty());
     }
 
     #[test]
@@ -147,5 +218,33 @@ mod tests {
             serde_json::from_str(r#"{"setupId":"s-1","universe":1}"#).expect("parses");
         assert_eq!(cfg.priority, 90);
         assert!(cfg.interface.is_none());
+    }
+
+    #[test]
+    fn binding_precedence_explicit_over_state_over_none() {
+        // An existing --config wins even when a paired binding is present.
+        assert_eq!(binding_choice(true, true), Binding::Explicit);
+        assert_eq!(binding_choice(true, false), Binding::Explicit);
+        // No usable --config: fall back to the paired state-dir binding.
+        assert_eq!(binding_choice(false, true), Binding::StateDir);
+        // Neither: the box hasn't been paired and wasn't given a config.
+        assert_eq!(binding_choice(false, false), Binding::None);
+    }
+
+    #[test]
+    fn node_binding_round_trips_through_load_node_config() {
+        // What `save_node_binding` writes must parse back with the run loop's
+        // loader and pick up the priority/interface defaults.
+        let dir = std::env::temp_dir().join(format!("lux-node-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("node.json");
+        let json = serde_json::json!({ "setupId": "s-42", "universe": 7u16 });
+        std::fs::write(&path, format!("{json:#}\n")).expect("write");
+        let cfg = load_node_config(&path).expect("parses");
+        assert_eq!(cfg.setup_id, "s-42");
+        assert_eq!(cfg.universe, 7);
+        assert_eq!(cfg.priority, 90);
+        assert!(cfg.interface.is_none());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/apps/node/src/main.rs
+++ b/apps/node/src/main.rs
@@ -4,7 +4,10 @@
 //!                              login, enable (idempotent; --keep-sleep to
 //!                              skip masking suspend)
 //!   lux-node login <email>     sign in once; stores the refresh token (0600)
-//!   lux-node run [--config P]  hold the user channel and drive the rig
+//!   lux-node pair              claim a headless box from the lux app — prints
+//!                              a code, blocks until approved (no password)
+//!   lux-node run [--config P]  hold the user channel and drive the rig; an
+//!                              unpaired box waits to be claimed instead of dying
 //!
 //! Config file (default ~/.config/lux-node/config.json):
 //!   { "setupId": "<uuid>", "universe": 1, "interface": null, "priority": 90 }
@@ -13,6 +16,7 @@ mod auth;
 mod config;
 mod install;
 mod node;
+mod pairing;
 mod setups;
 
 use std::net::Ipv4Addr;
@@ -43,9 +47,10 @@ fn dispatch() -> Result<(), String> {
             let opts = install::Options::parse(&login_args(&args[1..]))?;
             login(opts)
         }
-        Some("run") | None => run(config_path(&args)?),
+        Some("pair") => pair(),
+        Some("run") | None => run(explicit_config(&args[..])?),
         Some(other) => Err(format!(
-            "unknown command {other}; usage: lux-node install | lux-node login [<email>] | lux-node run [--config <path>]"
+            "unknown command {other}; usage: lux-node install | lux-node login [<email>] | lux-node pair | lux-node run [--config <path>]"
         )),
     }
 }
@@ -63,14 +68,17 @@ fn login_args(args: &[String]) -> Vec<String> {
     }
 }
 
-fn config_path(args: &[String]) -> Result<PathBuf, String> {
-    if let Some(i) = args.iter().position(|a| a == "--config") {
-        return args
+/// The `--config <path>` the operator passed, if any. `None` (no flag) is
+/// distinct from a flag pointing at a missing file: only an explicit,
+/// *existing* file outranks the paired state-dir binding in `run`.
+fn explicit_config(args: &[String]) -> Result<Option<PathBuf>, String> {
+    match args.iter().position(|a| a == "--config") {
+        Some(i) => args
             .get(i + 1)
-            .map(PathBuf::from)
-            .ok_or("--config needs a path".to_owned());
+            .map(|p| Some(PathBuf::from(p)))
+            .ok_or("--config needs a path".to_owned()),
+        None => Ok(None),
     }
-    config::default_config_path()
 }
 
 fn login(opts: install::Options) -> Result<(), String> {
@@ -95,10 +103,69 @@ fn login(opts: install::Options) -> Result<(), String> {
     Ok(())
 }
 
-fn run(config_file: PathBuf) -> Result<(), String> {
+/// `lux-node pair` — the human-with-a-shell path: register, print the code,
+/// block until approved, and write the same files the unpaired-boot state
+/// machine writes. `run` then finds the session and binding and just works.
+fn pair() -> Result<(), String> {
     let env = config::endpoints()?;
+    let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+    if config::session_exists()? {
+        return Err(
+            "already paired (session.json exists); delete it to re-pair, or just run lux-node run"
+                .into(),
+        );
+    }
+    let granted = runtime.block_on(pairing::pair_wait(&env, pairing::stdout_announce))?;
+    config::save_session(&granted.session)?;
+    config::save_node_binding(&granted.setup_id, granted.universe)?;
+    println!(
+        "paired as {}; setup {} on universe {}. Next: lux-node run",
+        granted.session.email, granted.setup_id, granted.universe
+    );
+    Ok(())
+}
+
+fn run(explicit_config: Option<PathBuf>) -> Result<(), String> {
+    let env = config::endpoints()?;
+    let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+
+    // Unpaired boot: no session means wait to be claimed from the app rather
+    // than die. The grant persists exactly what `login` + `install` would.
+    let session = if config::session_exists()? {
+        config::load_session()?
+    } else {
+        log::info!("no stored session; waiting to be paired from the lux app");
+        let granted = runtime.block_on(pairing::pair_wait(&env, pairing::journal_announce))?;
+        config::save_session(&granted.session)?;
+        config::save_node_binding(&granted.setup_id, granted.universe)?;
+        log::info!(
+            "paired as {}; setup {} on universe {}",
+            granted.session.email,
+            granted.setup_id,
+            granted.universe
+        );
+        granted.session
+    };
+
+    // Setup-binding precedence: an explicit, existing `--config` (today's
+    // installs) → the paired state-dir `node.json` → nothing (a session with
+    // no binding, e.g. a bare `login` — surfaced as a clear error).
+    let node_json = config::node_binding_path()?;
+    let explicit_exists = explicit_config.as_ref().is_some_and(|p| p.exists());
+    let config_file = match config::binding_choice(explicit_exists, node_json.exists()) {
+        config::Binding::Explicit => {
+            explicit_config.ok_or("internal: explicit binding chosen without a path")?
+        }
+        config::Binding::StateDir => node_json,
+        config::Binding::None => {
+            return Err(format!(
+                "no setup binding: pass --config <file> or pair the device \
+                 (a paired binding is written to {})",
+                node_json.display()
+            ))
+        }
+    };
     let cfg = config::load_node_config(&config_file)?;
-    let session = config::load_session()?;
 
     let interface = match &cfg.interface {
         Some(ip) => Some(

--- a/apps/node/src/pairing.rs
+++ b/apps/node/src/pairing.rs
@@ -1,0 +1,405 @@
+//! The unpaired-boot state machine (docs/claim-code-pairing.md, "Box:
+//! first-boot state machine"). A factory-fresh headless box has no session and
+//! no TTY to type a password into, so instead of dying it registers over plain
+//! HTTPS and waits to be claimed from the lux app.
+//!
+//! Three legs, RFC 8628-shaped: register (`/auth/device/authorize`), poll
+//! (`/auth/device/token`), redeem (the poll that comes back `granted`). Boot is
+//! patient and never fatal — an unclaimed code simply expires and the box
+//! re-registers with fresh codes, forever, so a box can sit unpaired on a shelf
+//! and pair the moment someone opens Add-device on the same venue network.
+//!
+//! The reqwest + webpki idiom mirrors `setups.rs`: a headless box may not even
+//! have `ca-certificates` installed, so we trust the bundled roots.
+
+use std::time::{Duration, Instant};
+
+use lux_wire::apple::AUTH_SEGMENT;
+use lux_wire::device::{
+    AuthorizeRequest, AuthorizeResponse, TokenRequest, TokenResponse, AUTHORIZE_SEGMENT,
+    DEVICE_SEGMENT, TOKEN_SEGMENT,
+};
+
+use lux_engine::tls::webpki_pem_bundle;
+
+use crate::config::{Endpoints, StoredSession};
+
+/// Brief settle before re-registering after an expired/denied code, plus jitter
+/// so a fleet of boxes booted together don't re-register in lockstep.
+const REREGISTER_BASE: Duration = Duration::from_secs(2);
+const REREGISTER_JITTER_SECS: u64 = 3;
+/// Cap on the transient-error (network/5xx) backoff during registration.
+const NET_BACKOFF_CAP_SECS: u64 = 30;
+/// Ceiling on the poll interval after `slow_down` bumps.
+const MAX_INTERVAL_SECS: u64 = 60;
+
+/// A completed grant: everything the caller persists (`session.json` +
+/// `node.json`) before falling through to the normal connect path.
+pub struct Granted {
+    pub session: StoredSession,
+    pub setup_id: String,
+    pub universe: u16,
+}
+
+/// What a `/token` poll status means for the loop. Pure so the transitions are
+/// unit-tested without a network.
+#[derive(Debug, PartialEq, Eq)]
+enum PollAction {
+    /// `authorization_pending` — keep polling at the current interval.
+    KeepPolling,
+    /// `slow_down` (RFC 8628 §3.5) — widen the interval, keep polling.
+    SlowDown,
+    /// `expired_token` / `access_denied` / anything unexpected — drop the codes
+    /// and register afresh. The patient boot never gives up.
+    ReRegister,
+    /// `granted` — the poll carries the session fields.
+    Granted,
+}
+
+fn classify(status: &str) -> PollAction {
+    match status {
+        "authorization_pending" => PollAction::KeepPolling,
+        "slow_down" => PollAction::SlowDown,
+        "granted" => PollAction::Granted,
+        _ => PollAction::ReRegister,
+    }
+}
+
+/// Announce a fresh code to the journal — SSH-fallback parity with the app's
+/// display. Used by `run`'s unpaired path.
+pub fn journal_announce(auth: &AuthorizeResponse) {
+    log::info!(
+        "lux-node is unpaired: open the lux app (Settings > Devices > Add device) \
+         and confirm code {} to claim this box",
+        auth.user_code
+    );
+}
+
+/// Announce a fresh code to stdout — the `lux-node pair` CLI (a human with a
+/// shell). Journald also captures this, so parity is preserved either way.
+pub fn stdout_announce(auth: &AuthorizeResponse) {
+    println!();
+    println!("  lux-node is waiting to be paired.");
+    println!("  In the lux app: Settings > Devices > Add device, then confirm this code:");
+    println!();
+    println!("      {}", auth.user_code);
+    println!();
+    println!("  (waiting… the code refreshes automatically until you approve it)");
+    println!();
+}
+
+/// Register, then poll until claimed. Blocks (patiently) forever on the wait;
+/// only a completed grant or an unrecoverable local error returns.
+pub async fn pair_wait(
+    env: &Endpoints,
+    announce: impl Fn(&AuthorizeResponse),
+) -> Result<Granted, String> {
+    let device_id = crate::config::load_or_create_device_id()?;
+    let request = device_request(device_id);
+    let client = http_client()?;
+    let mut net_backoff = 1u64;
+
+    'register: loop {
+        let auth = match authorize(&client, env, &request).await {
+            Ok(auth) => {
+                net_backoff = 1;
+                auth
+            }
+            Err(e) => {
+                log::warn!("device register failed ({e}); retrying in {net_backoff}s");
+                sleep_secs(net_backoff, REREGISTER_JITTER_SECS).await;
+                net_backoff = (net_backoff * 2).min(NET_BACKOFF_CAP_SECS);
+                continue 'register;
+            }
+        };
+        announce(&auth);
+
+        let deadline = Instant::now() + Duration::from_secs(auth.expires_in as u64);
+        let mut interval = (auth.interval.max(1) as u64).min(MAX_INTERVAL_SECS);
+
+        loop {
+            tokio::time::sleep(Duration::from_secs(interval)).await;
+            if Instant::now() >= deadline {
+                log::info!("pairing code expired unclaimed; re-registering");
+                break;
+            }
+            match poll_once(&client, env, &auth.device_code).await {
+                Ok(resp) => match classify(&resp.status) {
+                    PollAction::KeepPolling => {}
+                    PollAction::SlowDown => interval = (interval + 5).min(MAX_INTERVAL_SECS),
+                    PollAction::ReRegister => {
+                        log::info!(
+                            "pairing grant no longer valid ({}); re-registering",
+                            resp.status
+                        );
+                        break;
+                    }
+                    PollAction::Granted => {
+                        return granted_from(resp, &env.cognito_device_client_id);
+                    }
+                },
+                // Transient (unreachable service / 5xx): keep polling. Never
+                // fatal — the box waits out the outage and pairs when it clears.
+                Err(e) => log::warn!("pairing poll failed ({e}); retrying"),
+            }
+        }
+
+        sleep_secs(REREGISTER_BASE.as_secs(), REREGISTER_JITTER_SECS).await;
+    }
+}
+
+/// Build the `AuthorizeRequest` display metadata once — it never changes for a
+/// given boot, so a re-registering node reuses it (same `device_id` supersedes
+/// its own earlier codes).
+fn device_request(device_id: String) -> AuthorizeRequest {
+    AuthorizeRequest {
+        device_id,
+        hostname: gethostname::gethostname().to_string_lossy().into_owned(),
+        mac_tail: mac_tail(),
+        version: env!("CARGO_PKG_VERSION").to_owned(),
+        arch: std::env::consts::ARCH.to_owned(),
+    }
+}
+
+/// Turn a `granted` poll into the persisted grant. Fails closed if the response
+/// is missing a field the node cannot invent.
+fn granted_from(resp: TokenResponse, device_client_id: &str) -> Result<Granted, String> {
+    let email = resp.email.ok_or("granted response missing email")?;
+    let refresh_token = resp
+        .refresh_token
+        .ok_or("granted response missing refreshToken")?;
+    let setup_id = resp.setup_id.ok_or("granted response missing setupId")?;
+    let universe = resp.universe.unwrap_or(1);
+    // The backend always names the minting (device) client; default to the
+    // configured one so a session is never written that would refresh against
+    // the wrong client and get rejected.
+    let client_id = resp.client_id.or_else(|| Some(device_client_id.to_owned()));
+    Ok(Granted {
+        session: StoredSession {
+            email,
+            refresh_token,
+            client_id,
+        },
+        setup_id,
+        universe,
+    })
+}
+
+async fn authorize(
+    client: &reqwest::Client,
+    env: &Endpoints,
+    request: &AuthorizeRequest,
+) -> Result<AuthorizeResponse, String> {
+    let resp = client
+        .post(device_url(env, AUTHORIZE_SEGMENT))
+        .json(request)
+        .send()
+        .await
+        .map_err(|e| format!("auth service unreachable: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("authorize answered {}", resp.status()));
+    }
+    resp.json()
+        .await
+        .map_err(|e| format!("bad authorize reply: {e}"))
+}
+
+/// One `/token` poll. The backend returns a `TokenResponse` body for the
+/// negative statuses too (`expired_token`/`access_denied` ride HTTP 400), so we
+/// parse the body regardless of status code and let [`classify`] decide.
+async fn poll_once(
+    client: &reqwest::Client,
+    env: &Endpoints,
+    device_code: &str,
+) -> Result<TokenResponse, String> {
+    let resp = client
+        .post(device_url(env, TOKEN_SEGMENT))
+        .json(&TokenRequest {
+            device_code: device_code.to_owned(),
+        })
+        .send()
+        .await
+        .map_err(|e| format!("auth service unreachable: {e}"))?;
+    let status = resp.status();
+    let body = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("token poll {status}: {e}"))?;
+    serde_json::from_slice(&body).map_err(|e| format!("token poll {status}: unreadable body: {e}"))
+}
+
+fn http_client() -> Result<reqwest::Client, String> {
+    let certs = reqwest::Certificate::from_pem_bundle(webpki_pem_bundle())
+        .map_err(|e| format!("webpki bundle: {e}"))?;
+    reqwest::Client::builder()
+        .tls_certs_only(certs)
+        .build()
+        .map_err(|e| e.to_string())
+}
+
+/// `<appleAuthUrl>/auth/device/<segment>`.
+fn device_url(env: &Endpoints, segment: &str) -> String {
+    let base = env.apple_auth_url.trim_end_matches('/');
+    format!("{base}/{AUTH_SEGMENT}/{DEVICE_SEGMENT}/{segment}")
+}
+
+/// Sleep `base` seconds plus up to `jitter_secs` of jitter.
+async fn sleep_secs(base: u64, jitter_secs: u64) {
+    tokio::time::sleep(Duration::from_secs(base) + jitter(jitter_secs)).await;
+}
+
+/// A cheap, dependency-free jitter: the wall-clock sub-second, so a fleet that
+/// booted together doesn't re-register in lockstep. Precision is irrelevant.
+fn jitter(max_secs: u64) -> Duration {
+    if max_secs == 0 {
+        return Duration::ZERO;
+    }
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    Duration::from_millis(u64::from(nanos) % (max_secs * 1000))
+}
+
+/// Last four hex digits of the box's primary MAC — the approve screen's
+/// physical cross-check against the sticker/port label. Best-effort: an
+/// unreadable NIC set degrades to `0000` rather than blocking a boot.
+fn mac_tail() -> String {
+    let mac = read_primary_mac().unwrap_or_default();
+    let hex: String = mac
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .collect::<String>()
+        .to_lowercase();
+    if hex.len() >= 4 {
+        hex[hex.len() - 4..].to_owned()
+    } else {
+        "0000".to_owned()
+    }
+}
+
+/// Pick the box's primary MAC from sysfs: prefer wired (`en*`/`eth*`), then
+/// wireless (`wl*`), then anything else, tie-broken by name for a stable
+/// choice across boots. Loopback and all-zero addresses are skipped.
+#[cfg(target_os = "linux")]
+fn read_primary_mac() -> Option<String> {
+    let mut best: Option<(u8, String, String)> = None;
+    for entry in std::fs::read_dir("/sys/class/net").ok()?.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name == "lo" {
+            continue;
+        }
+        let Ok(raw) = std::fs::read_to_string(entry.path().join("address")) else {
+            continue;
+        };
+        let mac = raw.trim().to_owned();
+        if mac.is_empty() || mac.chars().all(|c| c == '0' || c == ':') {
+            continue;
+        }
+        let prio = if name.starts_with("en") || name.starts_with("eth") {
+            0
+        } else if name.starts_with("wl") {
+            1
+        } else {
+            2
+        };
+        let better = match &best {
+            None => true,
+            Some((bp, bn, _)) => prio < *bp || (prio == *bp && name < *bn),
+        };
+        if better {
+            best = Some((prio, name, mac));
+        }
+    }
+    best.map(|(_, _, mac)| mac)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_primary_mac() -> Option<String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poll_status_transitions() {
+        assert_eq!(classify("authorization_pending"), PollAction::KeepPolling);
+        assert_eq!(classify("slow_down"), PollAction::SlowDown);
+        assert_eq!(classify("expired_token"), PollAction::ReRegister);
+        assert_eq!(classify("access_denied"), PollAction::ReRegister);
+        assert_eq!(classify("granted"), PollAction::Granted);
+        // Anything the box doesn't recognise is treated as re-register, never
+        // as a fatal boot error.
+        assert_eq!(classify("something_new"), PollAction::ReRegister);
+    }
+
+    fn granted_response() -> TokenResponse {
+        TokenResponse {
+            status: "granted".into(),
+            email: Some("venue@example.com".into()),
+            refresh_token: Some("refresh-xyz".into()),
+            client_id: Some("device-client".into()),
+            setup_id: Some("setup-1".into()),
+            universe: Some(3),
+        }
+    }
+
+    #[test]
+    fn granted_maps_to_session_and_binding() {
+        let g = granted_from(granted_response(), "fallback-client").expect("granted maps");
+        assert_eq!(g.session.email, "venue@example.com");
+        assert_eq!(g.session.refresh_token, "refresh-xyz");
+        assert_eq!(g.session.client_id.as_deref(), Some("device-client"));
+        assert_eq!(g.setup_id, "setup-1");
+        assert_eq!(g.universe, 3);
+    }
+
+    #[test]
+    fn granted_defaults_universe_and_client() {
+        let resp = TokenResponse {
+            client_id: None,
+            universe: None,
+            ..granted_response()
+        };
+        let g = granted_from(resp, "fallback-client").expect("granted maps");
+        // Universe defaults to 1; the client falls back to the configured
+        // device client so refresh never targets the interactive client.
+        assert_eq!(g.universe, 1);
+        assert_eq!(g.session.client_id.as_deref(), Some("fallback-client"));
+    }
+
+    #[test]
+    fn granted_requires_the_session_fields() {
+        for missing in ["email", "refreshToken", "setupId"] {
+            let mut resp = granted_response();
+            match missing {
+                "email" => resp.email = None,
+                "refreshToken" => resp.refresh_token = None,
+                "setupId" => resp.setup_id = None,
+                _ => unreachable!(),
+            }
+            assert!(
+                granted_from(resp, "fallback-client").is_err(),
+                "a granted response without {missing} must fail closed"
+            );
+        }
+    }
+
+    #[test]
+    fn mac_tail_is_four_lowercase_hex() {
+        let tail = mac_tail();
+        assert_eq!(tail.len(), 4);
+        assert!(tail.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert_eq!(tail, tail.to_lowercase());
+    }
+
+    #[test]
+    fn device_url_joins_the_segments() {
+        let env = crate::config::endpoints().expect("endpoints");
+        let url = device_url(&env, AUTHORIZE_SEGMENT);
+        assert!(url.ends_with("/auth/device/authorize"), "got {url}");
+        assert!(!url.contains("//auth"), "no double slash: {url}");
+    }
+}

--- a/scripts/gen-endpoints
+++ b/scripts/gen-endpoints
@@ -15,19 +15,21 @@ cd "$(dirname "$0")/.."
 out() { terraform -chdir=infra output -raw "$1"; }
 
 jq -Sn \
-  --arg cognitoRegion      "$(out cognito_region)" \
-  --arg cognitoUserPoolId  "$(out cognito_user_pool_id)" \
-  --arg cognitoAppClientId "$(out cognito_app_client_id)" \
-  --arg syncUrl            "$(out lux_sync_url)" \
-  --arg nudgeEndpoint      "$(out iot_endpoint)" \
-  --arg appleAuthUrl       "$(out apple_auth_url)" \
+  --arg cognitoRegion         "$(out cognito_region)" \
+  --arg cognitoUserPoolId     "$(out cognito_user_pool_id)" \
+  --arg cognitoAppClientId    "$(out cognito_app_client_id)" \
+  --arg cognitoDeviceClientId "$(out cognito_device_client_id)" \
+  --arg syncUrl               "$(out lux_sync_url)" \
+  --arg nudgeEndpoint         "$(out iot_endpoint)" \
+  --arg appleAuthUrl          "$(out apple_auth_url)" \
   '{
-    cognitoRegion:      $cognitoRegion,
-    cognitoUserPoolId:  $cognitoUserPoolId,
-    cognitoAppClientId: $cognitoAppClientId,
-    syncUrl:            $syncUrl,
-    nudgeEndpoint:      $nudgeEndpoint,
-    appleAuthUrl:       $appleAuthUrl
+    cognitoRegion:         $cognitoRegion,
+    cognitoUserPoolId:     $cognitoUserPoolId,
+    cognitoAppClientId:    $cognitoAppClientId,
+    cognitoDeviceClientId: $cognitoDeviceClientId,
+    syncUrl:               $syncUrl,
+    nudgeEndpoint:         $nudgeEndpoint,
+    appleAuthUrl:          $appleAuthUrl
   }' > apps/desktop/src-tauri/endpoints.prod.json
 
 echo "wrote apps/desktop/src-tauri/endpoints.prod.json:"


### PR DESCRIPTION
Phase 3 of the claim-code pairing flow (docs/claim-code-pairing.md). Backend routes + verify-trigger (phases 1–2) are already live in prod; this is the node side.

## What this does
A factory-fresh headless box has no TTY to type a password into (and Sign in with Apple users have no password at all), so `lux-node run` gains an **unpaired state** instead of dying when `session.json` is absent:

1. Self-generate + persist a `device_id` (uuid) in the state dir.
2. `POST /auth/device/authorize` and log the `user_code` to the journal (SSH-fallback parity with the app display).
3. Poll `POST /auth/device/token` every `interval`s, honoring `slow_down`; on `expired_token`/`access_denied` re-register with fresh codes, forever, with jittered backoff. **Boot is patient, never fatal.**
4. On `granted`: write `session.json {email, refreshToken, clientId}` (0600, exactly as `login`) and the setup binding `node.json {setupId, universe}`, then fall through to the normal connect path — nothing downstream changes.

`lux-node pair` is the CLI equivalent for a human with a shell (prints the code to stdout, blocks until approved, writes the same files). `login` stays for dev.

**Setup-binding precedence** in `run`: explicit `--config` file → state-dir `node.json` → unpaired-wait. Existing `/etc/lux-node/config.json` installs keep working unchanged (the systemd unit's `--config` still wins when the file exists).

## Endpoints plumbing
- Node `Endpoints` gains `appleAuthUrl` + `cognitoDeviceClientId`; desktop `Endpoints` mirrors `cognitoDeviceClientId` (inert there — only the node refreshes against that client, but both embedders share one generated file shape).
- `scripts/gen-endpoints` emits `cognitoDeviceClientId` from terraform output `cognito_device_client_id`.
- `endpoints.prod.json` carries `l6ocppn3jr96bulq87mvg7qem`. **I can't reach terraform state from here, so I hand-wrote that value** — it is byte-identical to `jq -S`'s output, so CI's endpoints drift gate (re-runs `gen-endpoints` and byte-diffs on infra PRs and at release apply) stays green.

## Tests
Decision points are unit-tested: token-poll status transitions (`authorization_pending`/`slow_down`/`expired_token`/`access_denied`/`granted`), config-source precedence, and the session/binding file shapes + round-trip. `cargo test -p lux-node` and `cargo clippy -p lux-node -- -D warnings` are green locally.

## Not in this PR
The live end-to-end test (delete `session.json` on the real box, watch it register in the journal, approve from the app, see the presence card) runs on the home server afterward — **pending**. No new deps (Cargo.lock untouched). No infra changes. The app-side Add-device UI is phase 4 (separate PR).