### PR TITLE
feat(shares): grant a contact control of one setup (shared control, phase 1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -583,6 +583,31 @@ jobs:
           cat /tmp/body; echo
           test "$code" = "401" && grep -q '"error"' /tmp/body
 
+      # Shared control's routes answer the same typed 401, which is the cheapest
+      # proof that the shares module shipped and is gated: an unauthenticated
+      # claim must never reach the code lookup, and an unrouted path would 404.
+      - name: Smoke sync-api shares routes
+        run: |
+          url=$(aws lambda get-function-url-config --function-name lux-sync-api --query FunctionUrl --output text)
+          code=$(curl -s -o /tmp/shares-list -w '%{http_code}' "${url}shares")
+          cat /tmp/shares-list; echo
+          test "$code" = "401" && grep -q '"error"' /tmp/shares-list
+          code=$(curl -s -o /tmp/shares-claim -w '%{http_code}' -X POST \
+            -H 'content-type: application/json' -d '{"code":"LUX-SMOKE-TEST0"}' "${url}shares/claim")
+          cat /tmp/shares-claim; echo
+          test "$code" = "401" && grep -q '"error"' /tmp/shares-claim
+
+      # The authorizer reads grants from DynamoDB now, and a missing table is
+      # not an error there — it degrades to "no connection is ever widened",
+      # which would look exactly like shared control quietly not working. Assert
+      # the applied configuration rather than waiting to discover it.
+      - name: Assert authorizer grant lookup is configured
+        run: |
+          table=$(aws lambda get-function-configuration --function-name lux-iot-authorizer \
+            --query 'Environment.Variables.DYNAMODB_TABLE' --output text)
+          echo "authorizer grant table: $table"
+          test "$table" = "lux-sync"
+
       # A garbage identity token answering the typed 401 proves the new binary
       # cold-started (its init fetches the Cognito JWKS before serving), routes
       # /auth/apple, and rejects unverifiable tokens.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3840,6 +3840,8 @@ dependencies = [
 name = "lux-iot-authorizer"
 version = "0.1.0"
 dependencies = [
+ "aws-config",
+ "aws-sdk-dynamodb",
  "lambda_runtime",
  "lux-auth",
  "lux-wire",
@@ -3888,6 +3890,7 @@ dependencies = [
  "rustls 0.23.41",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 lambda_http = "1.2"
+sha2 = "0.11"
 
 # Small, optimized release binaries. Profiles must live at the workspace root, so
 # this now governs the Lambda services too — lto + opt-level "s" give them smaller,

--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -267,6 +267,52 @@ async fn delete_user_data(
     read_json(resp).await
 }
 
+async fn list_shares_req(
+    client: &Client,
+    base: &str,
+    token: String,
+) -> Result<lux_wire::shares::SharesResponse, SyncError> {
+    let resp = client
+        .get(format!("{base}/{}", lux_wire::shares::SHARES_SEGMENT))
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|e| SyncError::Other(e.to_string()))?;
+    read_json(resp).await
+}
+
+/// The caller's shared-control grants, both directions — what the
+/// delete-account confirm counts so the blast radius is visible before it
+/// happens (deleting an account revokes every share it is part of, in either
+/// direction, and the other people involved find out by their lists changing).
+///
+/// An account with cloud sync never configured has no shares at all, which is
+/// an empty answer rather than an error.
+pub fn list_shares(app: &AppHandle) -> Result<lux_wire::shares::SharesResponse, String> {
+    let (base, token) = {
+        let account = app.state::<LuxAccount>();
+        let Some(base) = account.sync_url() else {
+            return Ok(lux_wire::shares::SharesResponse {
+                granted: Vec::new(),
+                received: Vec::new(),
+                pending: Vec::new(),
+            });
+        };
+        let token = account.current_id_token().ok_or("not signed in")?;
+        (base, token)
+    };
+    let app = app.clone();
+    crate::account::block_on(async move {
+        let client = Client::new();
+        let mut result = list_shares_req(&client, &base, token).await;
+        if matches!(result, Err(SyncError::Unauthorized)) {
+            let fresh = refresh(&app).await.map_err(|e| e.to_string())?;
+            result = list_shares_req(&client, &base, fresh).await;
+        }
+        result.map_err(|e| format!("could not list shares: {e}"))
+    })
+}
+
 async fn read_json<T: DeserializeOwned>(resp: reqwest::Response) -> Result<T, SyncError> {
     match resp.status() {
         StatusCode::UNAUTHORIZED => Err(SyncError::Unauthorized),

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -139,6 +139,10 @@ pub trait CmdMethods {
         name: Option<String>,
     ) -> Result<(), String>;
     fn remove_device(&self, app_handle: AppHandle, device_id: String) -> Result<(), String>;
+    // Shared control in both directions, for the same confirm: deleting an
+    // account ends every share it is part of, including ones other people
+    // depend on.
+    fn list_shares(&self, app_handle: AppHandle) -> Result<ShareTally, String>;
     // DMX output — the in-app device picker (the only output selector on mobile,
     // where there's no tray). Mirrors the desktop tray's device menu.
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String>;
@@ -177,6 +181,19 @@ pub struct PendingDevice {
     pub version: String,
     pub arch: String,
     pub first_seen: f64,
+}
+
+/// Who the account's shared-control grants involve, thinned from
+/// [`lux_wire::shares::SharesResponse`] to the names a confirm dialog reads
+/// out. One person holding two of the caller's setups is one name here — the
+/// dialog counts *people*, because that is what the user is about to affect.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ShareTally {
+    /// People who can currently control one of the caller's setups.
+    pub granted_to: Vec<String>,
+    /// People whose setups the caller can currently control.
+    pub received_from: Vec<String>,
 }
 
 #[derive(ttipc::Event)]
@@ -547,6 +564,46 @@ impl CmdMethods for CmdEndpoint {
 
     fn remove_device(&self, app_handle: AppHandle, device_id: String) -> Result<(), String> {
         app_handle.state::<LuxAccount>().revoke_device(device_id)
+    }
+
+    fn list_shares(&self, app_handle: AppHandle) -> Result<ShareTally, String> {
+        let shares = crate::cloud::list_shares(&app_handle)?;
+        // One person can hold several of the caller's setups; the dialog is
+        // counting people, so fold by account and keep first-seen order.
+        let names = |mut seen: Vec<(String, String)>| -> Vec<String> {
+            seen.dedup_by(|a, b| a.0 == b.0);
+            seen.into_iter().map(|(_, label)| label).collect()
+        };
+        let label = |sub: &str, label: &str| {
+            // Every pool user has an email, but a token without the claim is
+            // still a valid token — name the account rather than show a blank.
+            if label.is_empty() {
+                format!("account {}", sub.chars().take(8).collect::<String>())
+            } else {
+                label.to_owned()
+            }
+        };
+        let mut granted: Vec<(String, String)> = shares
+            .granted
+            .iter()
+            .map(|g| {
+                (
+                    g.contact_sub.clone(),
+                    label(&g.contact_sub, &g.contact_label),
+                )
+            })
+            .collect();
+        granted.sort_by(|a, b| a.0.cmp(&b.0));
+        let mut received: Vec<(String, String)> = shares
+            .received
+            .iter()
+            .map(|g| (g.owner_sub.clone(), label(&g.owner_sub, &g.owner_label)))
+            .collect();
+        received.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(ShareTally {
+            granted_to: names(granted),
+            received_from: names(received),
+        })
     }
 
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String> {

--- a/apps/desktop/src-tauri/src/nudge.rs
+++ b/apps/desktop/src-tauri/src/nudge.rs
@@ -162,12 +162,16 @@ impl LuxNudge {
 
     /// The user's other live connections, stable-ordered for the UI poll.
     pub fn remote_peers(&self) -> Vec<RemotePeer> {
+        // `session` comes from the topic, not the card body: the topic is what
+        // the authorizer scoped, the body is whatever the publisher typed. They
+        // agree for a peer's own cards, and a shared-control guest could
+        // otherwise present itself under someone else's session id.
         let mut peers: Vec<RemotePeer> = self
             .peers
             .lock_or_recover()
-            .values()
-            .map(|card| RemotePeer {
-                session: card.session.clone(),
+            .iter()
+            .map(|(session, card)| RemotePeer {
+                session: session.clone(),
                 setup_id: card.setup_id.clone(),
                 name: card.name.clone(),
             })

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -175,6 +175,11 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  list_shares(): Promise<ShareTally> {
+    return invoke("cmd.list_shares");
+  },
+
+  /** @throws {string} */
   list_dmx_devices(): Promise<DmxDeviceInfo[]> {
     return invoke("cmd.list_dmx_devices");
   },
@@ -370,6 +375,19 @@ export type SetupSummary = {
 	universe: number,
 	fixtureCount: number,
 	active: boolean,
+};
+
+/**
+ *  Who the account's shared-control grants involve, thinned from
+ *  [`lux_wire::shares::SharesResponse`] to the names a confirm dialog reads
+ *  out. One person holding two of the caller's setups is one name here — the
+ *  dialog counts *people*, because that is what the user is about to affect.
+ */
+export type ShareTally = {
+	/**  People who can currently control one of the caller's setups. */
+	grantedTo: string[],
+	/**  People whose setups the caller can currently control. */
+	receivedFrom: string[],
 };
 
 /**

--- a/apps/desktop/src/components/account-menu.tsx
+++ b/apps/desktop/src/components/account-menu.tsx
@@ -39,6 +39,12 @@ type Mode = "signIn" | "signUp" | "confirm";
  * updates reactively from the `authChanged` event, so a successful sign-in or
  * deletion just closes its dialog.
  */
+/** Names for a confirm sentence: all of them up to three, then a tail count. */
+function peopleList(names: string[]) {
+  if (names.length <= 3) return names.join(", ");
+  return `${names.slice(0, 3).join(", ")} and ${names.length - 3} more`;
+}
+
 export default function AccountMenu() {
   const status = useAuth();
   const queryClient = useQueryClient();
@@ -61,6 +67,11 @@ export default function AccountMenu() {
     queryKey: ["pairedDevices"],
     queryFn: () => cmd().list_paired_devices(),
     // Only worth a network round-trip while the confirm is actually open.
+    enabled: !!status?.signedIn && confirmDelete,
+  });
+  const { data: shares } = useQuery({
+    queryKey: ["shares"],
+    queryFn: () => cmd().list_shares(),
     enabled: !!status?.signedIn && confirmDelete,
   });
 
@@ -148,8 +159,23 @@ export default function AccountMenu() {
                       pairedDevices.length === 1 ? "" : "s"
                     } (${pairedDevices.map((d) => d.name).join(", ")})`
                   : ""}
-                . Setups on this device stay on this device. This can't be
-                undone.
+                .
+                {/* The half of the blast radius that lands on other people —
+                    its own sentence, because it's the part a user is least
+                    likely to have in mind. */}
+                {shares?.grantedTo.length
+                  ? ` It ends control access for ${
+                      shares.grantedTo.length === 1
+                        ? "1 person"
+                        : `${shares.grantedTo.length} people`
+                    } you've shared with (${peopleList(shares.grantedTo)}).`
+                  : ""}
+                {shares?.receivedFrom.length
+                  ? ` You also lose access to setups shared with you by ${peopleList(
+                      shares.receivedFrom,
+                    )}.`
+                  : ""}{" "}
+                Setups on this device stay on this device. This can't be undone.
               </DialogDescription>
             </DialogHeader>
             <div className="flex justify-end gap-2">

--- a/crates/lux-auth/src/lib.rs
+++ b/crates/lux-auth/src/lib.rs
@@ -34,6 +34,13 @@ pub struct Verifier {
 pub struct Claims {
     pub sub: String,
     pub token_use: String,
+    /// The account's email, when the pool put one in the token. Display only —
+    /// it labels the other party in a shared-control grant, so a human can tell
+    /// who they shared with. Never an identity: `sub` alone authorizes, and a
+    /// token without this claim is perfectly valid (an appliance session's, for
+    /// one), so every reader needs a fallback.
+    #[serde(default)]
+    pub email: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -706,21 +706,22 @@ pub mod ctl {
     /// A shared-control guest's presence card in the **owner's** space, so the
     /// owner's desk can show who else is live on it.
     ///
-    /// The session segment is prefixed with the guest's own sub, which is what
-    /// lets the IoT authorizer grant them `presence/<contactSub>-*` instead of
-    /// the whole `presence/*`: a guest can leave a card, and can never overwrite
-    /// or clear the owner's card or another guest's. (Sub-prefixing is the same
-    /// trick the connection's own client-id prefix uses — the authorizer runs
-    /// before the session id exists, so a wildcard is unavoidable; the question
-    /// is only how narrow it can be made.)
-    pub fn guest_presence_topic(owner_sub: &str, contact_sub: &str, session: &str) -> String {
-        format!("{}/presence/{contact_sub}-{session}", user_prefix(owner_sub))
-    }
-
-    /// The wildcard covering exactly one guest's presence cards in an owner's
-    /// space — the authorizer's resource for [`guest_presence_topic`].
-    pub fn guest_presence_filter(owner_sub: &str, contact_sub: &str) -> String {
-        format!("{}/presence/{contact_sub}-*", user_prefix(owner_sub))
+    /// Deliberately keyed by the guest's sub and **not** by session, unlike
+    /// [`presence_topic`]. The authorizer runs during the WebSocket handshake,
+    /// before any session id exists, so a per-session topic could only be
+    /// authorized as a wildcard — and a wildcard over a topic namespace is an
+    /// unbounded retained-write primitive: a guest could retain messages on
+    /// arbitrarily many topics, the owner would replay every one of them on
+    /// each reconnect, and revoking the grant would remove the guest's ability
+    /// to clear them, making the mess permanent. An exact topic has no such
+    /// hazard and needs no wildcard at all.
+    ///
+    /// Per-session granularity buys nothing here anyway: a connection has one
+    /// Last Will and it stays on the guest's *own* presence topic, so cards in
+    /// the owner's space are explicit publish/clear either way. The cost is
+    /// that a guest signed in on two devices shows one card, last write wins.
+    pub fn guest_presence_topic(owner_sub: &str, contact_sub: &str) -> String {
+        format!("{}/presence/{contact_sub}", user_prefix(owner_sub))
     }
 
     /// One live control write. The two kinds mirror the command layer's two
@@ -1473,22 +1474,22 @@ mod tests {
             "lux/ctl/user/abc-123/presence/0a1b2c3d"
         );
 
-        // A guest's card lands in the owner's space, under the guest's own sub
-        // so the authorizer can wildcard exactly that guest and nothing else.
+        // A guest's card lands in the owner's space, keyed by the guest's sub —
+        // one exact topic, so the authorizer needs no wildcard to grant it.
         assert_eq!(
-            ctl::guest_presence_topic("owner-1", "contact-2", "0a1b2c3d"),
-            "lux/ctl/user/owner-1/presence/contact-2-0a1b2c3d"
+            ctl::guest_presence_topic("owner-1", "contact-2"),
+            "lux/ctl/user/owner-1/presence/contact-2"
         );
-        assert_eq!(
-            ctl::guest_presence_filter("owner-1", "contact-2"),
-            "lux/ctl/user/owner-1/presence/contact-2-*"
+        assert!(!ctl::guest_presence_topic("owner-1", "contact-2").contains('*'));
+        // Distinct guests, and guest vs owner, never collide.
+        assert_ne!(
+            ctl::guest_presence_topic("owner-1", "contact-2"),
+            ctl::guest_presence_topic("owner-1", "contact-3")
         );
-        // The filter must cover the topic and stop at the guest's own prefix.
-        let filter = ctl::guest_presence_filter("owner-1", "contact-2");
-        let stem = filter.trim_end_matches('*');
-        assert!(ctl::guest_presence_topic("owner-1", "contact-2", "s").starts_with(stem));
-        assert!(!ctl::presence_topic("owner-1", "owner-session").starts_with(stem));
-        assert!(!ctl::guest_presence_topic("owner-1", "contact-3", "s").starts_with(stem));
+        assert_ne!(
+            ctl::guest_presence_topic("owner-1", "contact-2"),
+            ctl::presence_topic("owner-1", "owner-session")
+        );
     }
 
     #[test]

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -405,6 +405,179 @@ pub mod device {
     }
 }
 
+pub mod shares {
+    //! Shared control: granting one contact the desk for one setup
+    //! (docs/shared-control.md).
+    //!
+    //! A grant is a triple — (owner, contact, setup). Nothing here shares an
+    //! *account*: the contact signs in as themselves, and the grant only widens
+    //! what their own identity may do on the owner's ctl space (publish frames
+    //! and a presence card; subscribe the applier's state and config). The
+    //! owner's applier stays the sole DMX authority, and guests never sync:
+    //! their surface renders from the retained [`super::ctl::Config`] alone.
+    //!
+    //! Invites are claim codes, not emails — the owner mints a short-lived
+    //! single-use code and sends it over their own channel (iMessage), so there
+    //! is no mail infrastructure and no deliverability surface, and contacts
+    //! using Hide My Email work by construction.
+    //!
+    //! Routes (on the sync API's Function URL, all bearer-authed):
+    //! - `POST   /shares/invite`                        — owner: mint a code
+    //! - `POST   /shares/claim`                         — contact: redeem one
+    //! - `GET    /shares`                               — both directions at once
+    //! - `DELETE /shares/granted/{contactSub}/{setupId}` — owner: revoke
+    //! - `DELETE /shares/received/{ownerSub}/{setupId}`  — contact: leave
+    //! - `DELETE /shares/invite/{codeRef}`               — owner: withdraw a code
+
+    use serde::{Deserialize, Serialize};
+
+    /// Path segments the sync API routes on (see the module docs).
+    pub const SHARES_SEGMENT: &str = "shares";
+    pub const INVITE_SEGMENT: &str = "invite";
+    pub const CLAIM_SEGMENT: &str = "claim";
+    pub const GRANTED_SEGMENT: &str = "granted";
+    pub const RECEIVED_SEGMENT: &str = "received";
+
+    /// Hard ceiling on the live grants **one contact** may hold, across all
+    /// owners. This is not a product limit dressed up as a safety limit: an IoT
+    /// custom authorizer may return at most 10 policy documents, the contact's
+    /// own space takes one, and each grant needs its own (a grant's six ARNs
+    /// run ~1 KB against the 2048-character per-document ceiling, so two grants
+    /// will not reliably share a document). Past this the authorizer would have
+    /// to silently drop grants; instead the claim route refuses loudly and the
+    /// authorizer truncates with an error log if it ever sees more.
+    pub const MAX_GRANTS_PER_CONTACT: usize = 9;
+
+    /// Outstanding (unclaimed, unexpired) invites one owner may hold at once.
+    /// Codes are bearer credentials, so a bounded number of them is a smaller
+    /// standing liability — and it keeps the pending list an honest UI.
+    pub const MAX_PENDING_INVITES: usize = 10;
+
+    /// Invite lifetime. Long enough to survive "I'll set this up tonight",
+    /// short enough that a screenshotted code in a chat log goes stale.
+    pub const INVITE_TTL_SECS: i64 = 48 * 60 * 60;
+
+    /// Body for `POST /shares/invite`.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct InviteRequest {
+        /// The setup this code will grant. Must be one of the caller's own.
+        pub setup_id: String,
+        /// The owner's private note for their manage list ("Chelsea"). Never
+        /// shown to the contact — it is a label *for* them, not *by* them.
+        #[serde(default)]
+        pub label: Option<String>,
+    }
+
+    /// Response to `POST /shares/invite`.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct InviteResponse {
+        /// The claim code, formatted for a human to send in a message. This is
+        /// the only time the server can produce it — only its hash is stored.
+        pub code: String,
+        /// Opaque handle for `DELETE /shares/invite/{codeRef}`, so the minting
+        /// app can withdraw the code without waiting for a list refresh.
+        pub code_ref: String,
+        /// Epoch millis (server clock).
+        pub expires_at: i64,
+    }
+
+    /// Body for `POST /shares/claim`.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ClaimRequest {
+        /// As typed or pasted; the server normalizes case and separators.
+        pub code: String,
+    }
+
+    /// Response to a successful `POST /shares/claim` — everything the guest
+    /// surface needs to start rendering, without a second round trip.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ClaimResponse {
+        /// The owner's Cognito sub: the ctl topic space this grant addresses.
+        pub owner_sub: String,
+        /// How the owner appears in the guest's "Shared with you" list (their
+        /// account email, recorded when the code was minted).
+        pub owner_label: String,
+        pub setup_id: String,
+        #[serde(default)]
+        pub setup_name: Option<String>,
+    }
+
+    /// One grant as the **owner** sees it (`granted` in [`SharesResponse`]).
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Grant {
+        /// The contact's Cognito sub — the revoke route's key, and what a
+        /// guest's presence card and frames are attributed to.
+        pub contact_sub: String,
+        /// The contact's account email, recorded when they claimed.
+        pub contact_label: String,
+        pub setup_id: String,
+        #[serde(default)]
+        pub setup_name: Option<String>,
+        /// The owner's own note from [`InviteRequest::label`], if they set one.
+        #[serde(default)]
+        pub label: Option<String>,
+        /// Epoch millis (server clock).
+        pub created_at: i64,
+    }
+
+    /// One grant as the **contact** sees it (`received` in [`SharesResponse`]).
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ReceivedGrant {
+        /// The owner's Cognito sub — the ctl topic space to address.
+        pub owner_sub: String,
+        pub owner_label: String,
+        pub setup_id: String,
+        #[serde(default)]
+        pub setup_name: Option<String>,
+        /// Epoch millis (server clock).
+        pub created_at: i64,
+    }
+
+    /// An outstanding invite on the owner's list. The code itself is not here
+    /// and cannot be: only its hash is stored, so a lost code is withdrawn and
+    /// re-minted rather than recovered.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct PendingInvite {
+        /// Handle for `DELETE /shares/invite/{codeRef}`.
+        pub code_ref: String,
+        pub setup_id: String,
+        #[serde(default)]
+        pub setup_name: Option<String>,
+        #[serde(default)]
+        pub label: Option<String>,
+        /// Epoch millis (server clock).
+        pub created_at: i64,
+        pub expires_at: i64,
+    }
+
+    /// Response to `GET /shares` — both directions plus outstanding invites in
+    /// one call, because every surface that shows one shows the others.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct SharesResponse {
+        /// Grants the caller has given away (they are the owner).
+        pub granted: Vec<Grant>,
+        /// Grants the caller has received (they are the contact).
+        pub received: Vec<ReceivedGrant>,
+        /// The caller's unclaimed, unexpired invites.
+        #[serde(default)]
+        pub pending: Vec<PendingInvite>,
+    }
+
+    /// Response to any successful `DELETE /shares/…` — revoke, leave, and
+    /// withdraw all answer the same shape.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct RevokeResponse {
+        pub revoked: bool,
+    }
+}
+
 pub mod nudge {
     //! The change-nudge channel: tiny events, opaque to clients.
     //!
@@ -427,6 +600,15 @@ pub mod nudge {
     /// only aids log readability; clients treat every frame identically.
     pub fn settings_changed_frame() -> String {
         serde_json::json!({ "changed": "settings" }).to_string()
+    }
+
+    /// `{"changed":"shares"}` — published to **both** parties after a grant
+    /// changes (claim, revoke, leave, account deletion). Same contract as its
+    /// siblings: opaque, any frame means pull. It reaches a party who is not
+    /// the writer, which is new for this channel and entirely within the
+    /// existing policy — the frame goes to each affected user's own topic.
+    pub fn shares_changed_frame() -> String {
+        serde_json::json!({ "changed": "shares" }).to_string()
     }
 
     /// The per-user nudge topic. The IoT custom authorizer scopes each
@@ -470,7 +652,9 @@ pub mod ctl {
     //!   session-scoped, not setup-scoped, because a connection has exactly one
     //!   will and the active setup changes without reconnecting — the card's
     //!   `setupId` carries the binding.
-    //! - `…/setup/<setupId>/config` — reserved for render-node compiled setups.
+    //! - `…/setup/<setupId>/config` — retained compiled setup ([`Config`]) for
+    //!   surfaces that hold no synced copy of it: shared-control guests today,
+    //!   render nodes later. An empty retained payload clears it.
     //!
     //! Unlike nudge frames (opaque by contract), ctl payloads are parsed —
     //! listeners route by topic. Every payload carries `v` from day one: the
@@ -507,8 +691,8 @@ pub mod ctl {
         format!("{}/setup/{setup_id}/state", user_prefix(sub))
     }
 
-    /// Reserved: retained compiled setup for render nodes. No publisher yet;
-    /// named now so the scheme is carved once.
+    /// Retained compiled setup ([`Config`]) for surfaces that never sync —
+    /// shared-control guests today, render nodes later.
     pub fn config_topic(sub: &str, setup_id: &str) -> String {
         format!("{}/setup/{setup_id}/config", user_prefix(sub))
     }
@@ -517,6 +701,26 @@ pub mod ctl {
     /// client-id suffix the connection already mints).
     pub fn presence_topic(sub: &str, session: &str) -> String {
         format!("{}/presence/{session}", user_prefix(sub))
+    }
+
+    /// A shared-control guest's presence card in the **owner's** space, so the
+    /// owner's desk can show who else is live on it.
+    ///
+    /// The session segment is prefixed with the guest's own sub, which is what
+    /// lets the IoT authorizer grant them `presence/<contactSub>-*` instead of
+    /// the whole `presence/*`: a guest can leave a card, and can never overwrite
+    /// or clear the owner's card or another guest's. (Sub-prefixing is the same
+    /// trick the connection's own client-id prefix uses — the authorizer runs
+    /// before the session id exists, so a wildcard is unavoidable; the question
+    /// is only how narrow it can be made.)
+    pub fn guest_presence_topic(owner_sub: &str, contact_sub: &str, session: &str) -> String {
+        format!("{}/presence/{contact_sub}-{session}", user_prefix(owner_sub))
+    }
+
+    /// The wildcard covering exactly one guest's presence cards in an owner's
+    /// space — the authorizer's resource for [`guest_presence_topic`].
+    pub fn guest_presence_filter(owner_sub: &str, contact_sub: &str) -> String {
+        format!("{}/presence/{contact_sub}-*", user_prefix(owner_sub))
     }
 
     /// One live control write. The two kinds mirror the command layer's two
@@ -619,6 +823,79 @@ pub mod ctl {
                 session,
                 setup_id,
                 name,
+            }
+        }
+    }
+
+    /// A setup compiled down to what it takes to *render a surface for it* —
+    /// published retained by the owner's applier so a consumer that never syncs
+    /// can draw the desk: shared-control guests today, render nodes later.
+    ///
+    /// This is deliberately not a [`super::SetupRecord`]. That shape is the
+    /// authoring model (opaque fixture JSON, revisions, tombstones) and it
+    /// belongs to accounts that own it. This one is the *rendering* model:
+    /// flat, small, and parseable by an embedded node with no JSON DOM — one
+    /// object, two arrays of fixed-shape objects, no nesting beyond that, no
+    /// maps, no optional-object soup.
+    ///
+    /// `role` is a plain string rather than an enum on purpose. A consumer
+    /// matches the roles it knows and treats the rest as a plain fader, so
+    /// adding a role never strands an older reader — the same
+    /// reader-drops-what-it-doesn't-know discipline as [`Frame`]'s `v`.
+    ///
+    /// `channels` lists only *patched* slots. An empty list is not an error and
+    /// not an empty desk: it means the setup has no patch, and a surface should
+    /// render the plain universe (matching what the app already does locally).
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Config {
+        pub v: u32,
+        pub setup_id: String,
+        /// The setup's display name, as the owner named it.
+        pub name: String,
+        pub universe: u16,
+        pub channels: Vec<ConfigChannel>,
+        pub fixtures: Vec<ConfigFixture>,
+    }
+
+    /// One patched DMX slot in a [`Config`].
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct ConfigChannel {
+        /// 1-based DMX slot number, matching [`Frame::Channel`]'s `ch`.
+        pub n: u16,
+        /// The channel's label from the patch.
+        pub name: String,
+        /// Semantic role driving the control affordance and colour ("Red",
+        /// "Brightness", "Generic", …). See the type docs on why it's a string.
+        pub role: String,
+    }
+
+    /// One patched fixture in a [`Config`] — enough to group the channels above
+    /// under a heading, not the fixture's authoring definition.
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct ConfigFixture {
+        pub name: String,
+        /// 1-based address of the fixture's first slot.
+        pub address: u16,
+        /// How many consecutive slots it occupies.
+        pub count: u16,
+    }
+
+    impl Config {
+        pub fn new(
+            setup_id: String,
+            name: String,
+            universe: u16,
+            channels: Vec<ConfigChannel>,
+            fixtures: Vec<ConfigFixture>,
+        ) -> Self {
+            Self {
+                v: VERSION,
+                setup_id,
+                name,
+                universe,
+                channels,
+                fixtures,
             }
         }
     }
@@ -995,8 +1272,184 @@ mod tests {
     fn nudge_frame_and_topics() {
         assert_eq!(nudge::setups_changed_frame(), r#"{"changed":"setups"}"#);
         assert_eq!(nudge::settings_changed_frame(), r#"{"changed":"settings"}"#);
+        assert_eq!(nudge::shares_changed_frame(), r#"{"changed":"shares"}"#);
         assert_eq!(nudge::user_topic("abc-123"), "lux/sync/user/abc-123");
         assert_eq!(nudge::client_id_prefix("abc-123"), "lux-sync-abc-123-");
+    }
+
+    #[test]
+    fn shares_invite_shapes() {
+        let req = shares::InviteRequest {
+            setup_id: "s-1".into(),
+            label: Some("Chelsea".into()),
+        };
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            r#"{"setupId":"s-1","label":"Chelsea"}"#
+        );
+
+        // The label is optional — an invite minted without one still parses.
+        let bare: shares::InviteRequest = serde_json::from_str(r#"{"setupId":"s-1"}"#).unwrap();
+        assert!(bare.label.is_none());
+
+        let resp = shares::InviteResponse {
+            code: "LUX-4KPT9-XQ2WM".into(),
+            code_ref: "9f86d081".into(),
+            expires_at: 1719000000000,
+        };
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            r#"{"code":"LUX-4KPT9-XQ2WM","codeRef":"9f86d081","expiresAt":1719000000000}"#
+        );
+    }
+
+    #[test]
+    fn shares_claim_shapes() {
+        assert_eq!(
+            serde_json::to_string(&shares::ClaimRequest {
+                code: "LUX-4KPT9-XQ2WM".into()
+            })
+            .unwrap(),
+            r#"{"code":"LUX-4KPT9-XQ2WM"}"#
+        );
+
+        let resp = shares::ClaimResponse {
+            owner_sub: "owner-1".into(),
+            owner_label: "owner@example.com".into(),
+            setup_id: "s-1".into(),
+            setup_name: Some("Living room".into()),
+        };
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            r#"{"ownerSub":"owner-1","ownerLabel":"owner@example.com","setupId":"s-1","setupName":"Living room"}"#
+        );
+
+        // A setup whose name the server couldn't resolve still claims.
+        let nameless: shares::ClaimResponse = serde_json::from_str(
+            r#"{"ownerSub":"o","ownerLabel":"l","setupId":"s","setupName":null}"#,
+        )
+        .unwrap();
+        assert!(nameless.setup_name.is_none());
+    }
+
+    #[test]
+    fn shares_list_shape() {
+        let body = shares::SharesResponse {
+            granted: vec![shares::Grant {
+                contact_sub: "contact-1".into(),
+                contact_label: "contact@example.com".into(),
+                setup_id: "s-1".into(),
+                setup_name: Some("Living room".into()),
+                label: Some("Chelsea".into()),
+                created_at: 1719000000000,
+            }],
+            received: vec![shares::ReceivedGrant {
+                owner_sub: "owner-2".into(),
+                owner_label: "owner@example.com".into(),
+                setup_id: "s-9".into(),
+                setup_name: None,
+                created_at: 1719000000001,
+            }],
+            pending: vec![shares::PendingInvite {
+                code_ref: "9f86d081".into(),
+                setup_id: "s-1".into(),
+                setup_name: Some("Living room".into()),
+                label: None,
+                created_at: 1719000000002,
+                expires_at: 1719172800002,
+            }],
+        };
+        assert_eq!(
+            serde_json::to_string(&body).unwrap(),
+            r#"{"granted":[{"contactSub":"contact-1","contactLabel":"contact@example.com","setupId":"s-1","setupName":"Living room","label":"Chelsea","createdAt":1719000000000}],"received":[{"ownerSub":"owner-2","ownerLabel":"owner@example.com","setupId":"s-9","setupName":null,"createdAt":1719000000001}],"pending":[{"codeRef":"9f86d081","setupId":"s-1","setupName":"Living room","label":null,"createdAt":1719000000002,"expiresAt":1719172800002}]}"#
+        );
+
+        // A reply from a server that predates the pending list still parses —
+        // shared control ships across an App Review lag, so an older client
+        // and a newer server (and the reverse) must both hold.
+        let old: shares::SharesResponse =
+            serde_json::from_str(r#"{"granted":[],"received":[]}"#).unwrap();
+        assert!(old.pending.is_empty());
+
+        assert_eq!(
+            serde_json::to_string(&shares::RevokeResponse { revoked: true }).unwrap(),
+            r#"{"revoked":true}"#
+        );
+    }
+
+    #[test]
+    fn shares_segments_and_caps() {
+        assert_eq!(
+            format!("/{}/{}", shares::SHARES_SEGMENT, shares::INVITE_SEGMENT),
+            "/shares/invite"
+        );
+        assert_eq!(shares::CLAIM_SEGMENT, "claim");
+        assert_eq!(
+            format!(
+                "/{}/{}/{}/{}",
+                shares::SHARES_SEGMENT,
+                shares::GRANTED_SEGMENT,
+                "contact-1",
+                "s-1"
+            ),
+            "/shares/granted/contact-1/s-1"
+        );
+        assert_eq!(shares::RECEIVED_SEGMENT, "received");
+
+        // The grant cap is a protocol constant, not a local policy: the sync
+        // API refuses past it and the authorizer truncates at it, so the two
+        // must read the same number from here. It is bounded by the IoT
+        // authorizer's 10-policy-document limit, one of which is the contact's
+        // own space.
+        assert_eq!(shares::MAX_GRANTS_PER_CONTACT, 9);
+        assert_eq!(shares::INVITE_TTL_SECS, 172_800);
+    }
+
+    #[test]
+    fn ctl_config_shape() {
+        let config = ctl::Config::new(
+            "s-1".into(),
+            "Living room".into(),
+            1,
+            vec![ctl::ConfigChannel {
+                n: 1,
+                name: "Red".into(),
+                role: "Red".into(),
+            }],
+            vec![ctl::ConfigFixture {
+                name: "Par 1".into(),
+                address: 1,
+                count: 5,
+            }],
+        );
+        assert_eq!(
+            serde_json::to_string(&config).unwrap(),
+            r#"{"v":1,"setupId":"s-1","name":"Living room","universe":1,"channels":[{"n":1,"name":"Red","role":"Red"}],"fixtures":[{"name":"Par 1","address":1,"count":5}]}"#
+        );
+
+        // An unpatched setup publishes empty lists, not a missing key: a fixed
+        // parser reads the same field set every time.
+        let bare = ctl::Config::new("s-2".into(), "Blank".into(), 3, vec![], vec![]);
+        assert_eq!(
+            serde_json::to_string(&bare).unwrap(),
+            r#"{"v":1,"setupId":"s-2","name":"Blank","universe":3,"channels":[],"fixtures":[]}"#
+        );
+
+        // A role this reader has never heard of is a string it can ignore, not
+        // a parse failure — the whole reason `role` isn't an enum.
+        let future: ctl::Config = serde_json::from_str(
+            r#"{"v":1,"setupId":"s","name":"n","universe":1,"channels":[{"n":7,"name":"UV","role":"Ultraviolet"}],"fixtures":[]}"#,
+        )
+        .unwrap();
+        assert_eq!(future.channels[0].role, "Ultraviolet");
+
+        // The version gate is the reader's job, so a newer payload of a known
+        // shape must survive deserialization to be dropped deliberately.
+        let newer: ctl::Config = serde_json::from_str(
+            r#"{"v":9,"setupId":"s","name":"n","universe":1,"channels":[],"fixtures":[]}"#,
+        )
+        .unwrap();
+        assert_eq!(newer.v, 9);
     }
 
     #[test]
@@ -1019,6 +1472,23 @@ mod tests {
             ctl::presence_topic("abc-123", "0a1b2c3d"),
             "lux/ctl/user/abc-123/presence/0a1b2c3d"
         );
+
+        // A guest's card lands in the owner's space, under the guest's own sub
+        // so the authorizer can wildcard exactly that guest and nothing else.
+        assert_eq!(
+            ctl::guest_presence_topic("owner-1", "contact-2", "0a1b2c3d"),
+            "lux/ctl/user/owner-1/presence/contact-2-0a1b2c3d"
+        );
+        assert_eq!(
+            ctl::guest_presence_filter("owner-1", "contact-2"),
+            "lux/ctl/user/owner-1/presence/contact-2-*"
+        );
+        // The filter must cover the topic and stop at the guest's own prefix.
+        let filter = ctl::guest_presence_filter("owner-1", "contact-2");
+        let stem = filter.trim_end_matches('*');
+        assert!(ctl::guest_presence_topic("owner-1", "contact-2", "s").starts_with(stem));
+        assert!(!ctl::presence_topic("owner-1", "owner-session").starts_with(stem));
+        assert!(!ctl::guest_presence_topic("owner-1", "contact-3", "s").starts_with(stem));
     }
 
     #[test]

--- a/docs/shared-control.md
+++ b/docs/shared-control.md
@@ -76,13 +76,15 @@ After any grant change, both affected accounts get an opaque `{"changed":"shares
 
 The one security-critical change. After the JWT verifies, the authorizer queries `SHARED#<sub>` and appends **one policy document per grant**:
 
-- **publish** `…/setup/<id>/frame` and `…/presence/<contactSub>-*`
-- **retain-publish** `…/presence/<contactSub>-*` only
+- **publish** `…/setup/<id>/frame` and `…/presence/<contactSub>`
+- **retain-publish** `…/presence/<contactSub>` only
 - **subscribe/receive** `…/setup/<id>/state` and `…/setup/<id>/config`
 
 The asymmetry is the design. A guest publishes live frames and its own presence card, and reads what the applier publishes. It cannot publish `state` or `config`: the owner's applier is the sole authority on both, and a guest that could retain either could lie to every other surface — including after it left.
 
-Guest presence cards are prefixed with the guest's own sub so the wildcard can be scoped to exactly one guest (`presence/<contactSub>-*`). The authorizer runs during the WebSocket handshake, before a session id exists, so *some* wildcard is unavoidable; the question is only how narrow it can be made. A guest can leave a card and can never clear the owner's or another guest's.
+Guest presence cards go to one exact topic per guest, `…/presence/<contactSub>` — deliberately not per session, and with no wildcard at all. The authorizer runs during the WebSocket handshake, before a session id exists, so a per-session topic could only be authorized as `presence/<contactSub>-*`; and a wildcard over a topic namespace is an unbounded retained-write primitive. A guest could retain messages on arbitrarily many topics, the owner would replay every one on each reconnect, and revoking the grant would remove the guest's ability to clear them — leaving a mess that outlives the grant and that revocation makes permanent rather than fixing. Per-session granularity buys nothing anyway, since a connection's one Last Will stays on the guest's own topic and cards in the owner's space are explicit publish/clear either way. The cost is that a guest signed in on two devices shows one card.
+
+Nothing unvalidated is spliced into an ARN. `PUT /setups/*` is a legal request, so a setup can genuinely be named `*` — and IAM wildcards match `/`, so that id reaching a policy would silently widen a grant across the owner's entire setup space. The invite route rejects ids outside `[A-Za-z0-9_-]`, and the authorizer refuses to emit a document for one regardless of what the write path allowed.
 
 **Why one document per grant, and why the cap is 9.** AWS IoT accepts at most 10 policy documents from a custom authorizer, each at most 2048 characters. A grant's six ARNs (UUID subs, UUID setup ids) run about 1 KB, so two grants will not reliably share a document, and an oversized document is rejected *wholesale* — which would take the caller's own access down with it. One grant per document, with the caller's own space taking the first, gives a hard ceiling of 9. That number lives in `lux_wire::shares::MAX_GRANTS_PER_CONTACT` so the claim route and the authorizer cannot disagree about it.
 
@@ -106,6 +108,10 @@ Deleting an account ends every grant it is part of, in both directions, and the 
 
 As an owner: every contact's mirror row is removed, outstanding invite codes are burned, and the retained `config` frames are cleared. As a contact: the mirrored row in each owner's partition is removed. Everyone affected gets a nudge.
 
+The config sweep runs over *every* setup on the account rather than the currently-granted ones: a setup that was shared and then revoked still has a retained config, and driving the sweep from live grants alone would walk straight past it.
+
+**This step is fallible and the wipe is gated on it.** A stale mirror is not a cosmetic leftover — the authorizer reads `SHARED#<sub>` and nothing else, so a surviving row is a live grant into a topic space whose owner account no longer exists, with the owner's row and the owner's Cognito user both gone. There is no revoking that. So a failed read or delete fails the whole request; deletion is idempotent end to end, and the client's retry re-reads a shorter list and finishes.
+
 Clearing retained config is done **server-side**, not by the app before it signs out. Two reasons. The contact direction has no app-side option at all — a departing guest has no publish rights in the owner's space, correctly — so one direction is forced server-side and one mechanism beats two. And an app that is killed mid-deletion (or an iOS app suspended between steps) would otherwise leave a retained frame carrying setup and channel names addressed to an account that no longer exists. Deleting an account has to mean the data actually leaves.
 
 The delete-account confirm shows both directions before it happens, alongside the setup and paired-device counts.
@@ -115,4 +121,5 @@ The delete-account confirm shows both directions before it happens, alongside th
 - **Presence can go stale.** A connection has exactly one Last Will and it targets the guest's own presence topic, so a guest's card in the owner's space is explicit-publish/explicit-clear. An ungraceful drop can leave a card up until the guest reconnects or signs out. Cards carry a timestamp so surfaces can render staleness.
 - **Guest publish rate** rides the existing ~25 Hz client-side coalescing. Among invited contacts that is a courtesy, not a defence.
 - **Grant labels are denormalized.** The contact's and owner's email are recorded on the grant when it is created; renaming a setup or changing an email later does not rewrite existing rows. The live name reaches the guest through `Config`, which is what their surface actually draws from.
-- **Two simultaneous claims** by one contact can both pass the cap check and land one grant over. The authorizer still holds the real line, and the next claim is refused.
+- **Simultaneous claims can overshoot the cap.** They can all read the grant count before any of them commits, so the overshoot is bounded by how many live codes one contact holds at once, not by one. The authorizer is the enforcing line either way and fails closed by truncating; the visible effect is that grants past the ninth silently do nothing.
+- **Deletion clears retained `config`, but not retained `state` or presence cards.** Those predate this feature and are not part of a grant, and clearing them would need `iot:Publish` on the `state` and `presence` topics — which would cost the property that makes the current grant safe: that the sync API cannot publish a frame or a state, and so cannot drive anybody's lights. (`iot:RetainPublish` alone does not suffice; IoT requires `iot:Publish` for any publish, retained or not.) Worth revisiting on its own terms — a presence card's `name` is the machine hostname, which is often a person's name — but not by quietly widening this role.

--- a/docs/shared-control.md
+++ b/docs/shared-control.md
@@ -1,0 +1,118 @@
+# Shared control — inviting a contact to run your lights
+
+Status: backend landed (phase 1) · 2026-07-19
+
+## Problem
+
+Two people are in a room with one lighting rig. One of them owns it: their app holds the setup, their machine talks to the fixtures. The other should be able to pick up a phone and move a fader. Today the only ways to do that are to hand over an account password or to stand behind them — the first is a real security answer to nothing, and the second is not a feature.
+
+The ask is narrow and worth stating precisely, because it rules out most of the obvious designs: **one contact, one setup, full desk, revocable, and the owner's machine stays the only thing that ever writes DMX.**
+
+## Shape
+
+A **grant** is a triple — `(owner, contact, setup)`. It is not a shared account, not an org, not a role on the owner's account. The contact signs in as themselves with their own credentials; the grant only widens what that existing identity is allowed to do inside the owner's control-topic space.
+
+Three consequences fall out of that and drive everything below:
+
+- **Nothing about the owner's account is exposed.** A grant names one setup. The contact cannot see the owner's other setups, cannot sync, cannot edit the patch, and cannot read anything outside the two topics the grant lists.
+- **The owner's applier stays the sole DMX authority.** A guest is one more attributed publisher into the owner's control space; frames carry `src`, and the applier merges them per-slot last-takes-precedence exactly as it already does for the owner's own devices. Nothing in this feature can drive a fixture directly.
+- **Guests never sync.** The guest's surface is drawn from the retained `config` topic, not from a copy of the setup. There is no local persistence of someone else's setup on a guest device, so there is nothing to leak, stale, or clean up when a grant ends.
+
+## Invites are claim codes, not emails
+
+The owner mints a short-lived single-use code and sends it over a channel they already trust — iMessage, Signal, saying it out loud. The app hands it to the OS share sheet where the platform makes that easy, and always offers a clipboard copy.
+
+This avoids building any mail infrastructure at all: no SES, no deliverability surface, no bounce handling, no address-verification flow, and no "did it land in spam". The sender is a human the recipient already knows, which is a stronger provenance signal than a From header. It also makes Hide My Email contacts work by construction, because nothing is ever matched on an address.
+
+A code is a bearer credential and is treated like one: 10 characters from a confusion-free alphabet (~2^46), stored only as its SHA-256, single-use, and expiring in 48 hours. Claiming requires a signed-in account, so guessing is not anonymous — an attacker needs a real Cognito user, and every attempt is attributable.
+
+The format is `LUX-XXXXX-XXXXX`. The alphabet drops vowels (so no code spells anything) and every lookalike pair (`0/O`, `1/I/L`, `S/5`). Since `L` and `U` are not in the alphabet, the `LUX` prefix can be stripped unambiguously on the way back in, and claiming accepts the code however a messaging app or a human mangled it: any case, with or without the dashes, with stray spaces.
+
+## Data
+
+Four item families in the `lux-sync` table, all in their own partitions so that sync's `USER#<sub>` query never sees them and the account wipe never races them — the pattern the Apple links and pairing records already use.
+
+```
+pk = INVITE#<sha256(code)>   sk = INVITE
+  ownerSub, ownerLabel, setupId, setupName, label?
+  createdAt, expiresAt, ttl
+
+pk = GRANT#<owner_sub>       sk = INVITE#<codeRef>            (owner's pending list)
+  codeRef, setupId, setupName, label?, createdAt, expiresAt, ttl
+
+pk = GRANT#<owner_sub>       sk = CONTACT#<contact_sub>#SETUP#<setup_id>
+  contactSub, contactLabel, setupId, setupName, label?, createdAt
+
+pk = SHARED#<contact_sub>    sk = OWNER#<owner_sub>#SETUP#<setup_id>
+  ownerSub, ownerLabel, setupId, setupName, createdAt
+```
+
+The last two are one grant written twice. That redundancy is deliberate and load-bearing: the owner needs a list keyed by *them* to manage, and the authorizer needs a list keyed by the *connecting user* to answer a connect in one lookup with no scan and no read of anyone else's partition. Both halves are written and deleted in a single transaction with `attribute_not_exists` guards, because either half alone is a bug with teeth — an orphaned `SHARED#` row is access the owner cannot see or revoke, and an orphaned `GRANT#` row is a revoke button that does nothing.
+
+Claiming consumes the invite inside that same transaction. The conditional delete is what makes a code single-use: exactly one concurrent claimer can win it.
+
+`INVITE#` rows carry `ttl` and self-expire; grants do not.
+
+## Routes (`services/sync-api`)
+
+| Route | Who | Does |
+|---|---|---|
+| `POST /shares/invite` | owner | mint a code for one of their own setups |
+| `POST /shares/claim` | contact | redeem a code, gaining the grant |
+| `GET /shares` | either | grants given, grants received, invites outstanding |
+| `DELETE /shares/granted/{contactSub}/{setupId}` | owner | revoke |
+| `DELETE /shares/received/{ownerSub}/{setupId}` | contact | leave |
+| `DELETE /shares/invite/{codeRef}` | owner | withdraw an unclaimed code |
+
+They live on the sync API because that is where identity-gated per-account state already lives; the auth service is about *becoming* a user, not about what users may do to each other.
+
+Revoke and leave are the same operation named from opposite ends, and both are always available. Leaving is not a lesser right than revoking: neither party needs the other's cooperation to end the arrangement.
+
+**The path never carries the caller's own identity.** It names the *other* party; the caller's side always comes from the verified token. Both DynamoDB keys a delete touches therefore embed the caller, so there is no request a caller can construct that names a grant they are not part of. The key derivation *is* the authorization check.
+
+After any grant change, both affected accounts get an opaque `{"changed":"shares"}` nudge on their own topic. Same contract as every other nudge: never parsed, any frame means pull.
+
+## Authorizer (`services/iot-authorizer`)
+
+The one security-critical change. After the JWT verifies, the authorizer queries `SHARED#<sub>` and appends **one policy document per grant**:
+
+- **publish** `…/setup/<id>/frame` and `…/presence/<contactSub>-*`
+- **retain-publish** `…/presence/<contactSub>-*` only
+- **subscribe/receive** `…/setup/<id>/state` and `…/setup/<id>/config`
+
+The asymmetry is the design. A guest publishes live frames and its own presence card, and reads what the applier publishes. It cannot publish `state` or `config`: the owner's applier is the sole authority on both, and a guest that could retain either could lie to every other surface — including after it left.
+
+Guest presence cards are prefixed with the guest's own sub so the wildcard can be scoped to exactly one guest (`presence/<contactSub>-*`). The authorizer runs during the WebSocket handshake, before a session id exists, so *some* wildcard is unavoidable; the question is only how narrow it can be made. A guest can leave a card and can never clear the owner's or another guest's.
+
+**Why one document per grant, and why the cap is 9.** AWS IoT accepts at most 10 policy documents from a custom authorizer, each at most 2048 characters. A grant's six ARNs (UUID subs, UUID setup ids) run about 1 KB, so two grants will not reliably share a document, and an oversized document is rejected *wholesale* — which would take the caller's own access down with it. One grant per document, with the caller's own space taking the first, gives a hard ceiling of 9. That number lives in `lux_wire::shares::MAX_GRANTS_PER_CONTACT` so the claim route and the authorizer cannot disagree about it.
+
+The cap is enforced at **claim**, not at invite: the contact is not known until they redeem, and the limit is a property of the contact's connection, not the owner's generosity. Claiming past it fails loudly with a typed error. The authorizer independently truncates and logs an error if it ever sees more, which should be unreachable.
+
+**Failure behaviour.** A grant lookup that errors yields no grants and logs an error — it does not deny the connection. This is closed with respect to shares (a failed read can never fabricate access) while keeping a DynamoDB blip from signing every user out of their own sync.
+
+**Revocation latency.** A policy lives for the connection's refresh window, one hour. A revoked guest keeps the access they already hold until their next re-auth. This is the documented cost of connect-time authorization; if it ever matters, forcing a disconnect on revoke is the sharpening.
+
+## The `config` topic
+
+`lux_wire::ctl::Config` finally gives the reserved `…/setup/<id>/config` topic its schema: a setup compiled down to what it takes to *render a surface for it* — id, name, universe, patched channels (`{n, name, role}`), fixture summaries.
+
+It is deliberately not a `SetupRecord`. That shape is the authoring model — opaque fixture JSON, revisions, tombstones — and it belongs to the account that owns it. This one is the rendering model: flat, small, and parseable by an embedded node with no JSON DOM. `role` is a plain string rather than an enum so that adding a role never strands an older reader, and the payload is versioned from day one because App Store review lag guarantees the two ends run different app versions.
+
+The same payload later feeds product-box render nodes, which is why it is carved this way now rather than shaped around what a phone happens to need.
+
+## Account deletion
+
+Deleting an account ends every grant it is part of, in both directions, and the cleanup runs **before** the partition wipe. The ordering is load-bearing: once the caller's half of a grant is gone there is nothing left to find the other half from, and every contact would keep a row pointing at a deleted account — plus, until the authorizer's cache expired, publish rights into a dead topic space.
+
+As an owner: every contact's mirror row is removed, outstanding invite codes are burned, and the retained `config` frames are cleared. As a contact: the mirrored row in each owner's partition is removed. Everyone affected gets a nudge.
+
+Clearing retained config is done **server-side**, not by the app before it signs out. Two reasons. The contact direction has no app-side option at all — a departing guest has no publish rights in the owner's space, correctly — so one direction is forced server-side and one mechanism beats two. And an app that is killed mid-deletion (or an iOS app suspended between steps) would otherwise leave a retained frame carrying setup and channel names addressed to an account that no longer exists. Deleting an account has to mean the data actually leaves.
+
+The delete-account confirm shows both directions before it happens, alongside the setup and paired-device counts.
+
+## Accepted limits
+
+- **Presence can go stale.** A connection has exactly one Last Will and it targets the guest's own presence topic, so a guest's card in the owner's space is explicit-publish/explicit-clear. An ungraceful drop can leave a card up until the guest reconnects or signs out. Cards carry a timestamp so surfaces can render staleness.
+- **Guest publish rate** rides the existing ~25 Hz client-side coalescing. Among invited contacts that is a courtesy, not a defence.
+- **Grant labels are denormalized.** The contact's and owner's email are recorded on the grant when it is created; renaming a setup or changing an email later does not rewrite existing rows. The live name reaches the guest through `Config`, which is what their surface actually draws from.
+- **Two simultaneous claims** by one contact can both pass the cap check and land one grant over. The authorizer still holds the real line, and the next claim is refused.

--- a/infra/nudge.tf
+++ b/infra/nudge.tf
@@ -65,6 +65,10 @@ resource "aws_lambda_function" "lux_iot_authorizer" {
       # (lux-node-device) both connect to the realtime channel.
       COGNITO_APP_CLIENT_ID = "${aws_cognito_user_pool_client.lux_app.id},${aws_cognito_user_pool_client.lux_node_device.id}"
       COGNITO_REGION        = data.aws_region.current.region
+      # Shared-control grants, read at connect time (shares.tf grants the
+      # LeadingKeys-pinned Query). Unset would simply mean no connection is
+      # ever widened past its own owner's space.
+      DYNAMODB_TABLE = aws_dynamodb_table.lux_sync.name
     }
   }
 }

--- a/infra/shares.tf
+++ b/infra/shares.tf
@@ -1,0 +1,61 @@
+# Shared control (docs/shared-control.md): the two IAM widenings that let one
+# account hand another the desk for a single setup. Both are deliberately
+# narrow, and both are in this file rather than beside the resources they attach
+# to so the whole authorization surface of the feature reads in one place.
+#
+# No new function, table, or topic: shared control rides the sync API, the
+# lux-sync table, and the ctl topic space that already exist. Its grant items
+# live in their own partitions (GRANT#/SHARED#/INVITE#) with the same
+# LeadingKeys discipline as the Apple links.
+
+# --- The IoT authorizer may read the grants a connecting user holds ----------
+
+# At connect time lux-iot-authorizer queries SHARED#<sub> — the grants *given
+# to* the connecting user — and appends one narrow policy document per grant.
+# LeadingKeys pins it to exactly that partition family: the authorizer can read
+# who shared with whom, and nothing else in the table. It has no write actions
+# at all, so a compromised authorizer can widen no one's access.
+resource "aws_iam_role_policy" "lux_iot_authorizer_shares" {
+  name = "lux-iot-authorizer-shares"
+  role = aws_iam_role.lux_iot_authorizer.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["dynamodb:Query"]
+      Resource = aws_dynamodb_table.lux_sync.arn
+      Condition = {
+        "ForAllValues:StringLike" = {
+          "dynamodb:LeadingKeys" = ["SHARED#*"]
+        }
+      }
+    }]
+  })
+}
+
+# --- The sync API may clear a retained compiled setup ------------------------
+
+# Account deletion has to leave no retained `config` frame behind: those carry
+# the setup's name and channel labels, and the app that would normally clear
+# them is the one being signed out. The owner's applier owns the config
+# lifecycle everywhere else (publish on change, clear on last revoke) — this
+# grant exists for the one case the applier cannot cover.
+#
+# The `/config` suffix is the point of the resource pattern: this role can
+# clear a compiled setup, and can never publish a `frame` or a `state`. The sync
+# API therefore cannot drive anybody's lights, which stays true no matter what
+# the handler code does.
+resource "aws_iam_role_policy" "lux_sync_api_ctl_config" {
+  name = "lux-sync-api-iot-ctl-config"
+  role = aws_iam_role.lux_sync_api.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      # RetainPublish because clearing a retained message *is* a retained
+      # publish (with an empty payload) — the same idiom presence cards use.
+      Action   = ["iot:Publish", "iot:RetainPublish"]
+      Resource = "${local.arn_prefix}:topic/lux/ctl/user/*/setup/*/config"
+    }]
+  })
+}

--- a/services/apple-auth/Cargo.toml
+++ b/services/apple-auth/Cargo.toml
@@ -34,7 +34,7 @@ reqwest = { workspace = true }
 # rustls with no baked-in crypto provider; main() installs ring as the process
 # default, sidestepping the aws-lc-rs C build that reqwest's `rustls` feature pulls.
 rustls = { workspace = true }
-sha2 = "0.11"
+sha2.workspace = true
 base64 = "0.22"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/services/iot-authorizer/Cargo.toml
+++ b/services/iot-authorizer/Cargo.toml
@@ -17,6 +17,9 @@ workspace = true
 [dependencies]
 lux-auth = { path = "../../crates/lux-auth" }
 lux-wire = { path = "../../crates/lux-wire" }
+# Shared-control grants are read from the lux-sync table at connect time.
+aws-config.workspace = true
+aws-sdk-dynamodb = "1"
 lambda_runtime = "1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde = { workspace = true }

--- a/services/iot-authorizer/src/main.rs
+++ b/services/iot-authorizer/src/main.rs
@@ -48,6 +48,20 @@ use serde_json::{json, Value};
 const MAX_POLICY_DOCUMENTS: usize = 10;
 const MAX_POLICY_DOCUMENT_CHARS: usize = 2048;
 
+/// Is this identifier safe to splice into an IAM resource ARN?
+///
+/// Subs and setup ids are UUIDs in practice, but "in practice" is not a check.
+/// IAM wildcards match `/`, so a single `*` reaching an ARN turns one grant
+/// into a grant over everything under that path segment — the difference
+/// between "one setup" and "every setup this owner will ever have".
+fn is_arn_safe(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
 /// One live grant, reduced to what a policy needs: whose space, which setup.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct GrantScope {
@@ -287,6 +301,19 @@ fn allow(region: &str, account: &str, sub: &str, grants: &[GrantScope]) -> Value
             );
             break;
         }
+        // Nothing unvalidated is ever spliced into an IAM resource. An id
+        // carrying `*` would silently widen the grant across the owner's whole
+        // setup space, since IAM wildcards match `/` — the ARN builder is the
+        // last place that can still refuse, so it does, whatever the write
+        // path allowed.
+        if !is_arn_safe(&grant.owner_sub) || !is_arn_safe(&grant.setup_id) {
+            tracing::error!(
+                "grant on {}/{} has an id unsafe for an ARN; skipping it",
+                grant.owner_sub,
+                grant.setup_id
+            );
+            continue;
+        }
         let document = grant_policy(&prefix, sub, grant);
         // A document over the ceiling is rejected by IoT as a whole, which
         // would take the caller's own access down with it. Dropping the one
@@ -331,7 +358,7 @@ fn grant_policy(prefix: &str, contact_sub: &str, grant: &GrantScope) -> Value {
     let frame = lux_wire::ctl::frame_topic(&grant.owner_sub, &grant.setup_id);
     let state = lux_wire::ctl::state_topic(&grant.owner_sub, &grant.setup_id);
     let config = lux_wire::ctl::config_topic(&grant.owner_sub, &grant.setup_id);
-    let presence = lux_wire::ctl::guest_presence_filter(&grant.owner_sub, contact_sub);
+    let presence = lux_wire::ctl::guest_presence_topic(&grant.owner_sub, contact_sub);
 
     json!({
         "Version": "2012-10-17",
@@ -537,7 +564,7 @@ mod tests {
             statements[0]["Resource"],
             json!([
                 arn("topic/lux/ctl/user/owner-9/setup/s-1/frame"),
-                arn("topic/lux/ctl/user/owner-9/presence/contact-1-*"),
+                arn("topic/lux/ctl/user/owner-9/presence/contact-1"),
             ])
         );
 
@@ -545,7 +572,7 @@ mod tests {
         assert_eq!(statements[1]["Action"], "iot:RetainPublish");
         assert_eq!(
             statements[1]["Resource"],
-            arn("topic/lux/ctl/user/owner-9/presence/contact-1-*").as_str()
+            arn("topic/lux/ctl/user/owner-9/presence/contact-1").as_str()
         );
 
         assert_eq!(statements[2]["Action"], "iot:Subscribe");
@@ -587,6 +614,10 @@ mod tests {
         assert!(!policy.contains("lux/sync/user/owner-9"));
         assert!(!policy.contains("client/lux-sync-owner-9"));
         assert!(!policy.contains("presence/*"));
+        // The guest's presence resource is an exact topic: no wildcard means
+        // no unbounded retained-write namespace, and nothing to leave behind
+        // that a revoked guest could no longer clear.
+        assert!(!policy.contains("presence/contact-1-"));
         assert!(!policy.contains("setup/s-2"));
         // …and the guest cannot write the two topics the owner's applier owns.
         for forbidden in ["setup/s-1/state", "setup/s-1/config"] {
@@ -594,6 +625,42 @@ mod tests {
                 + &shared["policyDocuments"][1]["Statement"][1]["Resource"].to_string();
             assert!(!publishable.contains(forbidden), "{forbidden} is publishable");
         }
+    }
+
+    #[test]
+    fn ids_unsafe_for_an_arn_never_reach_one() {
+        // `PUT /setups/*` is a legal request, so a setup really can be named
+        // `*`. Spliced into an ARN it would widen the grant across every setup
+        // the owner has, because IAM wildcards match `/`. The same goes for an
+        // id carrying a path separator or an over-long one.
+        for bad in ["*", "s-1/../s-2", "a/b", "", &"x".repeat(65)] {
+            let response = allow(
+                "us-west-1",
+                "735853783919",
+                "contact-1",
+                &[grant(UUID_A, bad)],
+            );
+            assert_eq!(
+                response["policyDocuments"].as_array().map(Vec::len),
+                Some(1),
+                "an id of {bad:?} produced a policy document"
+            );
+        }
+        // A hostile owner sub is refused the same way.
+        let response = allow("us-west-1", "735853783919", "contact-1", &[grant("*", "s-1")]);
+        assert_eq!(response["policyDocuments"].as_array().map(Vec::len), Some(1));
+
+        // …and one bad grant does not cost the caller their good ones.
+        let response = allow(
+            "us-west-1",
+            "735853783919",
+            "contact-1",
+            &[grant(UUID_A, "*"), grant(UUID_A, UUID_B)],
+        );
+        assert_eq!(response["policyDocuments"].as_array().map(Vec::len), Some(2));
+        assert!(response["policyDocuments"][1]
+            .to_string()
+            .contains(UUID_B));
     }
 
     #[test]

--- a/services/iot-authorizer/src/main.rs
+++ b/services/iot-authorizer/src/main.rs
@@ -14,12 +14,54 @@
 //! The authorizer is registered with signing disabled: the desktop is a public
 //! client and can't hold a signing key, so the JWT check here is the gate —
 //! the same posture as the sync-api's public Function URL with in-handler JWT.
+//!
+//! **Shared control** (docs/shared-control.md) is the one thing that widens a
+//! connection past its own owner's space. After the token verifies, we read the
+//! caller's `SHARED#<sub>` partition — the grants *other* accounts have given
+//! them — and append one narrow policy document per grant. A grant never
+//! confers the owner's own rights: a guest may publish live frames and its own
+//! presence card, and read the applier's state and config. It cannot retain
+//! anything but its own presence, cannot publish state or config (the owner's
+//! applier stays the sole authority on both), and cannot touch a setup it was
+//! not granted.
+//!
+//! Two properties are worth stating because the rest of the file depends on
+//! them. First, policy construction is pure: [`allow`] takes the grants it was
+//! handed and does no I/O, so every statement it can emit is unit-testable, and
+//! the DynamoDB read that finds those grants is separate and fallible.
+//! Second, revocation is bounded but not instant — a policy lives for the
+//! connection's refresh window (`refreshAfterInSeconds`, one hour), so a
+//! revoked guest keeps the access they already hold until their next re-auth.
+//! That window is the documented cost of connect-time authorization.
 
 use std::collections::HashMap;
 
+use aws_sdk_dynamodb::types::AttributeValue;
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
 use serde::Deserialize;
 use serde_json::{json, Value};
+
+/// AWS IoT accepts at most this many policy documents from a custom authorizer,
+/// each at most [`MAX_POLICY_DOCUMENT_CHARS`]. The caller's own space takes the
+/// first, so the rest are the grant budget — which is where
+/// [`lux_wire::shares::MAX_GRANTS_PER_CONTACT`] comes from.
+const MAX_POLICY_DOCUMENTS: usize = 10;
+const MAX_POLICY_DOCUMENT_CHARS: usize = 2048;
+
+/// One live grant, reduced to what a policy needs: whose space, which setup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GrantScope {
+    owner_sub: String,
+    setup_id: String,
+}
+
+/// Where grants are read from. `None` when `DYNAMODB_TABLE` is unset, which
+/// simply means no connection is ever widened — the pre-shared-control
+/// behaviour, and a safe state to deploy into.
+struct GrantStore {
+    ddb: aws_sdk_dynamodb::Client,
+    table: String,
+}
 
 /// The slice of IoT's custom-authorizer request we read. Everything is
 /// optional-with-default: IoT varies the shape by protocol, and a missing
@@ -71,8 +113,27 @@ async fn main() -> Result<(), Error> {
         .expect("failed to fetch Cognito JWKS");
     let verifier = &verifier;
 
+    // Shared-control grants. Absent table => nobody's connection is widened.
+    let store = match std::env::var("DYNAMODB_TABLE")
+        .ok()
+        .filter(|t| !t.is_empty())
+    {
+        Some(table) => {
+            let conf = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+            Some(GrantStore {
+                ddb: aws_sdk_dynamodb::Client::new(&conf),
+                table,
+            })
+        }
+        None => {
+            tracing::info!("DYNAMODB_TABLE unset; shared-control grants disabled");
+            None
+        }
+    };
+    let store = store.as_ref();
+
     run(service_fn(move |event: LambdaEvent<Value>| async move {
-        Ok::<Value, Error>(authorize(verifier, event))
+        Ok::<Value, Error>(authorize(verifier, store, event).await)
     }))
     .await
 }
@@ -81,7 +142,11 @@ fn env(key: &str) -> Result<String, Error> {
     std::env::var(key).map_err(|_| format!("missing required env var {key}").into())
 }
 
-fn authorize(verifier: &lux_auth::Verifier, event: LambdaEvent<Value>) -> Value {
+async fn authorize(
+    verifier: &lux_auth::Verifier,
+    store: Option<&GrantStore>,
+    event: LambdaEvent<Value>,
+) -> Value {
     // Region + account for the policy ARNs, from our own function ARN
     // (arn:aws:lambda:<region>:<account>:function:<name>).
     let arn: Vec<&str> = event.context.invoked_function_arn.split(':').collect();
@@ -111,7 +176,50 @@ fn authorize(verifier: &lux_auth::Verifier, event: LambdaEvent<Value>) -> Value 
         }
     };
 
-    allow(region, account, &sub)
+    // A grant read that fails grants nothing. It deliberately does not deny the
+    // connection outright: this user's own sync and control are not a
+    // shared-control feature, and a DynamoDB blip must not sign everyone out.
+    // Closed with respect to *shares* — no lookup, no widening, ever — while
+    // the caller's own space is unaffected.
+    let grants = match store {
+        Some(store) => live_grants(store, &sub).await.unwrap_or_else(|e| {
+            tracing::error!("grant lookup failed for {sub} ({e}); authorizing own space only");
+            Vec::new()
+        }),
+        None => Vec::new(),
+    };
+
+    allow(region, account, &sub, &grants)
+}
+
+/// The grants this user holds *as a contact* — one query on their own
+/// `SHARED#<sub>` partition, which exists in this shape precisely so that the
+/// connect path is a single key lookup and never a scan or a filter over
+/// someone else's data.
+async fn live_grants(store: &GrantStore, sub: &str) -> Result<Vec<GrantScope>, String> {
+    let out = store
+        .ddb
+        .query()
+        .table_name(&store.table)
+        .key_condition_expression("pk = :pk")
+        .expression_attribute_values(":pk", AttributeValue::S(format!("SHARED#{sub}")))
+        .send()
+        .await
+        .map_err(|e| format!("query failed: {e}"))?;
+
+    let s = |item: &HashMap<String, AttributeValue>, key: &str| {
+        item.get(key)?.as_s().ok().cloned()
+    };
+    Ok(out
+        .items()
+        .iter()
+        .filter_map(|item| {
+            Some(GrantScope {
+                owner_sub: s(item, "ownerSub")?,
+                setup_id: s(item, "setupId")?,
+            })
+        })
+        .collect())
 }
 
 /// The allow response for a verified user: connect under their own client-id
@@ -122,54 +230,145 @@ fn authorize(verifier: &lux_auth::Verifier, event: LambdaEvent<Value>) -> Value 
 /// grant matches the client's `…/#` filter; Subscribe takes `topicfilter`
 /// ARNs, Publish/Receive take `topic` ARNs. The Publish grant also covers the
 /// connection's Last Will on the presence topic.)
-fn allow(region: &str, account: &str, sub: &str) -> Value {
+fn allow(region: &str, account: &str, sub: &str, grants: &[GrantScope]) -> Value {
     let prefix = format!("arn:aws:iot:{region}:{account}");
     let nudge_topic = lux_wire::nudge::user_topic(sub);
     let client_prefix = lux_wire::nudge::client_id_prefix(sub);
     let ctl_prefix = lux_wire::ctl::user_prefix(sub);
+
+    // One document per grant, after the caller's own. Packing two grants into a
+    // document would risk the 2048-character ceiling (a grant runs ~1 KB), and
+    // an oversized document is rejected wholesale — so the cheap, checkable
+    // arrangement is one each. `documents` therefore holds at most
+    // MAX_POLICY_DOCUMENTS entries and the claim route refuses past the same
+    // number, which is what keeps this truncation unreachable in practice.
+    let mut documents = vec![json!({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "iot:Connect",
+                "Resource": format!("{prefix}:client/{client_prefix}*"),
+            },
+            {
+                "Effect": "Allow",
+                "Action": "iot:Subscribe",
+                "Resource": [
+                    format!("{prefix}:topicfilter/{nudge_topic}"),
+                    format!("{prefix}:topicfilter/{ctl_prefix}/*"),
+                ],
+            },
+            {
+                "Effect": "Allow",
+                "Action": "iot:Receive",
+                "Resource": [
+                    format!("{prefix}:topic/{nudge_topic}"),
+                    format!("{prefix}:topic/{ctl_prefix}/*"),
+                ],
+            },
+            {
+                "Effect": "Allow",
+                // RetainPublish too: presence cards, state echoes, and the
+                // connection's Last Will are all retained — and IoT refuses
+                // the CONNECT itself when the retained will isn't covered.
+                "Action": ["iot:Publish", "iot:RetainPublish"],
+                "Resource": format!("{prefix}:topic/{ctl_prefix}/*"),
+            },
+        ],
+    })];
+
+    for grant in grants {
+        if documents.len() >= MAX_POLICY_DOCUMENTS {
+            tracing::error!(
+                "{sub} holds more than {} grants; the rest are unauthorized until some are \
+                 revoked (the claim route should have refused past {})",
+                MAX_POLICY_DOCUMENTS - 1,
+                lux_wire::shares::MAX_GRANTS_PER_CONTACT
+            );
+            break;
+        }
+        let document = grant_policy(&prefix, sub, grant);
+        // A document over the ceiling is rejected by IoT as a whole, which
+        // would take the caller's own access down with it. Dropping the one
+        // grant keeps the connection working and says so loudly.
+        let size = document.to_string().len();
+        if size > MAX_POLICY_DOCUMENT_CHARS {
+            tracing::error!(
+                "grant on {}/{} builds a {size}-character policy document, over the {} ceiling; \
+                 skipping it",
+                grant.owner_sub,
+                grant.setup_id,
+                MAX_POLICY_DOCUMENT_CHARS
+            );
+            continue;
+        }
+        documents.push(document);
+    }
 
     json!({
         "isAuthenticated": true,
         // principalId must be alphanumeric; Cognito subs are UUIDs with hyphens.
         "principalId": sub.chars().filter(char::is_ascii_alphanumeric).collect::<String>(),
         // Hourly forced re-auth: matches the ID token's validity, and the
-        // client's reconnect brings a fresh token + an on-connect pull.
+        // client's reconnect brings a fresh token + an on-connect pull. It is
+        // also the upper bound on how long a revoked grant keeps working.
         "disconnectAfterInSeconds": 3600,
         "refreshAfterInSeconds": 3600,
-        "policyDocuments": [{
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Action": "iot:Connect",
-                    "Resource": format!("{prefix}:client/{client_prefix}*"),
-                },
-                {
-                    "Effect": "Allow",
-                    "Action": "iot:Subscribe",
-                    "Resource": [
-                        format!("{prefix}:topicfilter/{nudge_topic}"),
-                        format!("{prefix}:topicfilter/{ctl_prefix}/*"),
-                    ],
-                },
-                {
-                    "Effect": "Allow",
-                    "Action": "iot:Receive",
-                    "Resource": [
-                        format!("{prefix}:topic/{nudge_topic}"),
-                        format!("{prefix}:topic/{ctl_prefix}/*"),
-                    ],
-                },
-                {
-                    "Effect": "Allow",
-                    // RetainPublish too: presence cards, state echoes, and the
-                    // connection's Last Will are all retained — and IoT refuses
-                    // the CONNECT itself when the retained will isn't covered.
-                    "Action": ["iot:Publish", "iot:RetainPublish"],
-                    "Resource": format!("{prefix}:topic/{ctl_prefix}/*"),
-                },
-            ],
-        }],
+        "policyDocuments": documents,
+    })
+}
+
+/// One grant's policy document: what a guest may do in an owner's space, and
+/// nothing else.
+///
+/// The asymmetry is the design. A guest **publishes** live frames (never
+/// retained — the retain grant below is only for their own presence card) and
+/// **reads** the applier's `state` and `config`. It cannot publish `state` or
+/// `config`: the owner's applier is the sole authority on what the fixtures are
+/// doing and what the setup looks like, and a guest that could retain either
+/// would be able to lie to every other surface, including after it left.
+fn grant_policy(prefix: &str, contact_sub: &str, grant: &GrantScope) -> Value {
+    let frame = lux_wire::ctl::frame_topic(&grant.owner_sub, &grant.setup_id);
+    let state = lux_wire::ctl::state_topic(&grant.owner_sub, &grant.setup_id);
+    let config = lux_wire::ctl::config_topic(&grant.owner_sub, &grant.setup_id);
+    let presence = lux_wire::ctl::guest_presence_filter(&grant.owner_sub, contact_sub);
+
+    json!({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "iot:Publish",
+                "Resource": [
+                    format!("{prefix}:topic/{frame}"),
+                    format!("{prefix}:topic/{presence}"),
+                ],
+            },
+            {
+                "Effect": "Allow",
+                // Only the guest's own presence card may be retained, and the
+                // resource is wildcarded to their sub — never the owner's card
+                // or another guest's.
+                "Action": "iot:RetainPublish",
+                "Resource": format!("{prefix}:topic/{presence}"),
+            },
+            {
+                "Effect": "Allow",
+                "Action": "iot:Subscribe",
+                "Resource": [
+                    format!("{prefix}:topicfilter/{state}"),
+                    format!("{prefix}:topicfilter/{config}"),
+                ],
+            },
+            {
+                "Effect": "Allow",
+                "Action": "iot:Receive",
+                "Resource": [
+                    format!("{prefix}:topic/{state}"),
+                    format!("{prefix}:topic/{config}"),
+                ],
+            },
+        ],
     })
 }
 
@@ -249,11 +448,27 @@ mod tests {
         assert_eq!(extract_token(&event(json!({}))), None);
     }
 
+    fn grant(owner: &str, setup: &str) -> GrantScope {
+        GrantScope {
+            owner_sub: owner.to_owned(),
+            setup_id: setup.to_owned(),
+        }
+    }
+
+    /// A realistically-sized identity pair: Cognito subs and setup ids are both
+    /// UUIDs, and the policy budget is measured in characters.
+    const UUID_A: &str = "7f0175a6-3b64-4a2a-9e1c-000000000001";
+    const UUID_B: &str = "7f0175a6-3b64-4a2a-9e1c-000000000002";
+
     #[test]
     fn allow_policy_grants_nudge_and_ctl_scoped_to_the_sub() {
-        let response = allow("us-west-1", "735853783919", "abc-123");
+        let response = allow("us-west-1", "735853783919", "abc-123", &[]);
         assert_eq!(response["isAuthenticated"], true);
         assert_eq!(response["principalId"], "abc123"); // non-alphanumerics dropped
+
+        // No grants, no extra documents: an ordinary user's policy is exactly
+        // what it was before shared control existed.
+        assert_eq!(response["policyDocuments"][1], Value::Null);
 
         let statements = &response["policyDocuments"][0]["Statement"];
         let arn = |suffix: &str| format!("arn:aws:iot:us-west-1:735853783919:{suffix}");
@@ -296,5 +511,129 @@ mod tests {
         // json indexing past the end yields Null — asserts there is no fifth
         // statement without unwrapping.
         assert_eq!(statements[4], Value::Null);
+    }
+
+    #[test]
+    fn a_grant_adds_one_document_and_nothing_to_the_callers_own() {
+        let base = allow("us-west-1", "735853783919", "contact-1", &[]);
+        let shared = allow(
+            "us-west-1",
+            "735853783919",
+            "contact-1",
+            &[grant("owner-9", "s-1")],
+        );
+
+        // The caller's own document is untouched by holding a grant.
+        assert_eq!(base["policyDocuments"][0], shared["policyDocuments"][0]);
+        assert_eq!(shared["policyDocuments"].as_array().map(Vec::len), Some(2));
+
+        let arn = |suffix: &str| format!("arn:aws:iot:us-west-1:735853783919:{suffix}");
+        let statements = &shared["policyDocuments"][1]["Statement"];
+
+        // Publish: live frames and the guest's own presence card. Note what is
+        // absent — no state, no config, no other setup.
+        assert_eq!(statements[0]["Action"], "iot:Publish");
+        assert_eq!(
+            statements[0]["Resource"],
+            json!([
+                arn("topic/lux/ctl/user/owner-9/setup/s-1/frame"),
+                arn("topic/lux/ctl/user/owner-9/presence/contact-1-*"),
+            ])
+        );
+
+        // Retain: presence only. A guest may not leave a retained frame.
+        assert_eq!(statements[1]["Action"], "iot:RetainPublish");
+        assert_eq!(
+            statements[1]["Resource"],
+            arn("topic/lux/ctl/user/owner-9/presence/contact-1-*").as_str()
+        );
+
+        assert_eq!(statements[2]["Action"], "iot:Subscribe");
+        assert_eq!(
+            statements[2]["Resource"],
+            json!([
+                arn("topicfilter/lux/ctl/user/owner-9/setup/s-1/state"),
+                arn("topicfilter/lux/ctl/user/owner-9/setup/s-1/config"),
+            ])
+        );
+
+        assert_eq!(statements[3]["Action"], "iot:Receive");
+        assert_eq!(
+            statements[3]["Resource"],
+            json!([
+                arn("topic/lux/ctl/user/owner-9/setup/s-1/state"),
+                arn("topic/lux/ctl/user/owner-9/setup/s-1/config"),
+            ])
+        );
+        assert_eq!(statements[4], Value::Null);
+    }
+
+    #[test]
+    fn a_grant_confers_nothing_over_the_owners_wider_space() {
+        let shared = allow(
+            "us-west-1",
+            "735853783919",
+            "contact-1",
+            &[grant("owner-9", "s-1")],
+        );
+        let policy = shared["policyDocuments"].to_string();
+
+        // Every resource naming the owner is pinned to the granted setup or to
+        // this guest's own presence prefix. A wildcard over the owner's ctl
+        // space, their nudge topic, their client ids, or a second setup would
+        // all show up here.
+        assert!(!policy.contains("lux/ctl/user/owner-9/*"));
+        assert!(!policy.contains("lux/ctl/user/owner-9/#"));
+        assert!(!policy.contains("lux/sync/user/owner-9"));
+        assert!(!policy.contains("client/lux-sync-owner-9"));
+        assert!(!policy.contains("presence/*"));
+        assert!(!policy.contains("setup/s-2"));
+        // …and the guest cannot write the two topics the owner's applier owns.
+        for forbidden in ["setup/s-1/state", "setup/s-1/config"] {
+            let publishable = shared["policyDocuments"][1]["Statement"][0]["Resource"].to_string()
+                + &shared["policyDocuments"][1]["Statement"][1]["Resource"].to_string();
+            assert!(!publishable.contains(forbidden), "{forbidden} is publishable");
+        }
+    }
+
+    #[test]
+    fn grants_stay_inside_the_iot_policy_budget() {
+        // The real shapes: UUID subs, UUID setup ids, a full grant load. If a
+        // topic ever grows and this trips, the cap in lux-wire is what moves —
+        // silently emitting documents IoT rejects is the failure this prevents.
+        let grants: Vec<GrantScope> = (0..lux_wire::shares::MAX_GRANTS_PER_CONTACT)
+            .map(|i| grant(UUID_A, &format!("{UUID_B}{i}")))
+            .collect();
+        let response = allow("us-west-1", "735853783919", UUID_A, &grants);
+        let documents = response["policyDocuments"]
+            .as_array()
+            .expect("policyDocuments is an array");
+
+        // Every grant made it in, and the whole set fits the 10-document limit.
+        assert_eq!(documents.len(), lux_wire::shares::MAX_GRANTS_PER_CONTACT + 1);
+        assert!(documents.len() <= MAX_POLICY_DOCUMENTS);
+        for document in documents {
+            let size = document.to_string().len();
+            assert!(size <= MAX_POLICY_DOCUMENT_CHARS, "document is {size} chars");
+        }
+    }
+
+    #[test]
+    fn grants_past_the_document_budget_are_dropped_not_smuggled() {
+        // The claim route refuses past the cap, so reaching this means the
+        // table disagrees with the API — the connection must still work, minus
+        // the grants that don't fit.
+        let grants: Vec<GrantScope> = (0..MAX_POLICY_DOCUMENTS + 5)
+            .map(|i| grant(UUID_A, &format!("setup-{i}")))
+            .collect();
+        let response = allow("us-west-1", "735853783919", UUID_B, &grants);
+        let documents = response["policyDocuments"]
+            .as_array()
+            .expect("policyDocuments is an array");
+
+        assert_eq!(documents.len(), MAX_POLICY_DOCUMENTS);
+        // Truncation never costs the caller their own space, which is first.
+        assert_eq!(response["isAuthenticated"], true);
+        assert!(documents[0].to_string().contains("iot:Connect"));
     }
 }

--- a/services/sync-api/Cargo.toml
+++ b/services/sync-api/Cargo.toml
@@ -21,6 +21,8 @@ lambda_http.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde.workspace = true
 serde_json.workspace = true
+# Claim codes are stored as their sha256, never in the clear (see shares.rs).
+sha2.workspace = true
 aws-config.workspace = true
 aws-sdk-dynamodb = "1"
 aws-sdk-iotdataplane = "1"

--- a/services/sync-api/src/main.rs
+++ b/services/sync-api/src/main.rs
@@ -17,12 +17,19 @@
 //! - `DELETE /setups/{id}?baseUpdatedAt=N` — soft-delete (tombstone)
 //! - `PUT    /settings`      — create/update the settings record, optimistic-concurrency on `baseUpdatedAt`
 //! - `DELETE /user`          — hard-delete the caller's whole partition (account deletion)
+//! - `/shares/…`             — shared control: invite, claim, list, revoke (`shares`)
+//!
+//! Shared control is the one feature here that reaches outside the caller's own
+//! partition, and it does so only through grants the two accounts both agreed
+//! to — see [`shares`] for the item families and how the key derivation itself
+//! carries the authorization.
 //!
 //! After each committed write the handler publishes a tiny opaque nudge frame
 //! to the caller's own IoT topic (`lux_wire::nudge`) so their other devices
 //! pull promptly. Publishing is best-effort and never fails the request; with
 //! `IOT_ENDPOINT` unset (tests, minimal dev stacks) it is skipped entirely.
 
+mod shares;
 mod store;
 
 use std::sync::Arc;
@@ -38,11 +45,11 @@ use serde::{Deserialize, Serialize};
 use store::StoreError;
 
 struct Ctx {
-    ddb: aws_sdk_dynamodb::Client,
-    table: String,
-    verifier: lux_auth::Verifier,
+    pub(crate) ddb: aws_sdk_dynamodb::Client,
+    pub(crate) table: String,
+    pub(crate) verifier: lux_auth::Verifier,
     /// IoT data-plane client for change nudges; `None` when `IOT_ENDPOINT` is unset.
-    iot: Option<aws_sdk_iotdataplane::Client>,
+    pub(crate) iot: Option<aws_sdk_iotdataplane::Client>,
 }
 
 #[tokio::main]
@@ -109,10 +116,12 @@ fn env(key: &str) -> Result<String, Error> {
 
 async fn handle(ctx: Arc<Ctx>, req: Request) -> Result<Response<Body>, Error> {
     // Identity comes only from the verified token; the request never names a user.
-    let sub = match bearer(&req).and_then(|t| ctx.verifier.verify(&t).ok()) {
-        Some(claims) => claims.sub,
-        None => return reply(401, error("invalid or missing token")),
+    // Identity and the display label both come from the one verification: the
+    // `sub` authorizes, the `email` only ever labels (see shares::label_for).
+    let Some(claims) = bearer(&req).and_then(|t| ctx.verifier.verify(&t).ok()) else {
+        return reply(401, error("invalid or missing token"));
     };
+    let (sub, email) = (claims.sub, claims.email);
 
     let method = req.method().clone();
     let path = req.uri().path().to_owned();
@@ -130,6 +139,42 @@ async fn handle(ctx: Arc<Ctx>, req: Request) -> Result<Response<Body>, Error> {
             upsert_settings(&ctx, &sub, &req).await
         }
         ("DELETE", [seg]) if *seg == lux_wire::USER_SEGMENT => delete_user_data(&ctx, &sub).await,
+
+        // Shared control. The path names the *other* party; the caller's own
+        // side always comes from the verified token, so no route here can be
+        // pointed at a grant the caller isn't part of.
+        ("POST", [seg, action])
+            if *seg == lux_wire::shares::SHARES_SEGMENT
+                && *action == lux_wire::shares::INVITE_SEGMENT =>
+        {
+            shares::invite(&ctx, &sub, email.as_deref(), &req).await
+        }
+        ("POST", [seg, action])
+            if *seg == lux_wire::shares::SHARES_SEGMENT
+                && *action == lux_wire::shares::CLAIM_SEGMENT =>
+        {
+            shares::claim(&ctx, &sub, email.as_deref(), &req).await
+        }
+        ("GET", [seg]) if *seg == lux_wire::shares::SHARES_SEGMENT => shares::list(&ctx, &sub).await,
+        ("DELETE", [seg, kind, contact_sub, setup_id])
+            if *seg == lux_wire::shares::SHARES_SEGMENT
+                && *kind == lux_wire::shares::GRANTED_SEGMENT =>
+        {
+            shares::revoke(&ctx, &sub, contact_sub, setup_id, true).await
+        }
+        ("DELETE", [seg, kind, owner_sub, setup_id])
+            if *seg == lux_wire::shares::SHARES_SEGMENT
+                && *kind == lux_wire::shares::RECEIVED_SEGMENT =>
+        {
+            shares::revoke(&ctx, owner_sub, &sub, setup_id, false).await
+        }
+        ("DELETE", [seg, kind, code_ref])
+            if *seg == lux_wire::shares::SHARES_SEGMENT
+                && *kind == lux_wire::shares::INVITE_SEGMENT =>
+        {
+            shares::withdraw(&ctx, &sub, code_ref).await
+        }
+
         _ => reply(404, error("not found")),
     }
 }
@@ -224,9 +269,17 @@ async fn tombstone(ctx: &Ctx, sub: &str, id: &str, req: &Request) -> Result<Resp
 
 /// Account deletion, step 1 of 2: hard-delete everything the caller owns. The
 /// app calls this while the tokens still authenticate, then removes the Cognito
-/// user itself (self-service `DeleteUser`). No nudge: the other devices' next
-/// refresh fails and they simply sign out.
+/// user itself (self-service `DeleteUser`). No nudge for the caller's own
+/// devices: their next refresh fails and they simply sign out.
+///
+/// Shares are cleaned up **first**, and the order is load-bearing. Grants live
+/// half in the caller's partition and half in the other party's; once the
+/// caller's half is gone there is nothing left to find the other half from, and
+/// every contact would keep a row pointing at a deleted account (and, until the
+/// authorizer's cache expired, publish rights into a dead topic space). Same
+/// discipline as revoking the Apple grant before the wipe.
 async fn delete_user_data(ctx: &Ctx, sub: &str) -> Result<Response<Body>, Error> {
+    shares::cleanup_for_deleted_user(ctx, sub).await;
     match store::delete_all(&ctx.ddb, &ctx.table, sub).await {
         Ok(deleted_items) => reply(200, DeleteUserDataResponse { deleted_items }),
         Err(e) => {
@@ -242,7 +295,7 @@ async fn delete_user_data(ctx: &Ctx, sub: &str) -> Result<Response<Body>, Error>
 /// connected devices get the frame, including the writer; its re-pull is
 /// coalesced client-side and harmless. The frame's label only aids logs —
 /// clients treat every frame identically.)
-async fn nudge(ctx: &Ctx, sub: &str, frame: String) {
+pub(crate) async fn nudge(ctx: &Ctx, sub: &str, frame: String) {
     let Some(iot) = &ctx.iot else { return };
     let topic = lux_wire::nudge::user_topic(sub);
     if let Err(e) = iot
@@ -262,7 +315,7 @@ async fn nudge(ctx: &Ctx, sub: &str, frame: String) {
 // --- request/response helpers -----------------------------------------------
 
 /// The bearer token from the `Authorization` header, if present and well-formed.
-fn bearer(req: &Request) -> Option<String> {
+pub(crate) fn bearer(req: &Request) -> Option<String> {
     req.headers()
         .get("authorization")?
         .to_str()
@@ -280,11 +333,11 @@ fn body_bytes(req: &Request) -> Vec<u8> {
     }
 }
 
-fn parse_body<T: for<'de> Deserialize<'de>>(req: &Request) -> Result<T, String> {
+pub(crate) fn parse_body<T: for<'de> Deserialize<'de>>(req: &Request) -> Result<T, String> {
     serde_json::from_slice(&body_bytes(req)).map_err(|e| format!("bad body: {e}"))
 }
 
-fn now_millis() -> i64 {
+pub(crate) fn now_millis() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -292,13 +345,13 @@ fn now_millis() -> i64 {
         .unwrap_or(0)
 }
 
-fn error(message: &str) -> ErrorResponse {
+pub(crate) fn error(message: &str) -> ErrorResponse {
     ErrorResponse {
         error: message.to_owned(),
     }
 }
 
-fn reply<T: Serialize>(status: u16, body: T) -> Result<Response<Body>, Error> {
+pub(crate) fn reply<T: Serialize>(status: u16, body: T) -> Result<Response<Body>, Error> {
     Ok(Response::builder()
         .status(status)
         .header("content-type", "application/json")

--- a/services/sync-api/src/main.rs
+++ b/services/sync-api/src/main.rs
@@ -279,7 +279,14 @@ async fn tombstone(ctx: &Ctx, sub: &str, id: &str, req: &Request) -> Result<Resp
 /// authorizer's cache expired, publish rights into a dead topic space). Same
 /// discipline as revoking the Apple grant before the wipe.
 async fn delete_user_data(ctx: &Ctx, sub: &str) -> Result<Response<Body>, Error> {
-    shares::cleanup_for_deleted_user(ctx, sub).await;
+    // Refuse to wipe on a failed cleanup rather than proceed and strand a
+    // grant: once this partition is gone there is nothing left to find the
+    // other halves from, and a surviving mirror is access no one can revoke.
+    // The whole flow is idempotent, so the client's retry finishes the job.
+    if let Err(e) = shares::cleanup_for_deleted_user(ctx, sub).await {
+        tracing::error!("shares cleanup failed, refusing to wipe: {e}");
+        return reply(500, error("internal"));
+    }
     match store::delete_all(&ctx.ddb, &ctx.table, sub).await {
         Ok(deleted_items) => reply(200, DeleteUserDataResponse { deleted_items }),
         Err(e) => {

--- a/services/sync-api/src/shares.rs
+++ b/services/sync-api/src/shares.rs
@@ -1,0 +1,919 @@
+//! Shared control — granting one contact the desk for one setup
+//! (docs/shared-control.md).
+//!
+//! Three item families in the `lux-sync` table, all in their own partitions so
+//! sync's `USER#<sub>` list query never sees them (the `APPLE#` pattern):
+//!
+//! - `pk = INVITE#<sha256(code)>,  sk = INVITE` — one outstanding claim code.
+//!   Keyed by the hash, so the bearer secret is never at rest; carries `ttl`
+//!   and self-expires.
+//! - `pk = GRANT#<owner_sub>,      sk = CONTACT#<contact_sub>#SETUP#<setup_id>`
+//!   — the owner's manage list. Its `sk = INVITE#<ref>` siblings mirror the
+//!   outstanding codes, so the owner can list and withdraw them (and the
+//!   per-owner invite cap is one query, not a scan).
+//! - `pk = SHARED#<contact_sub>,   sk = OWNER#<owner_sub>#SETUP#<setup_id>`
+//!   — the contact's "shared with you" list **and** the IoT authorizer's
+//!   connect-time lookup, which is why it is a partition keyed by the
+//!   connecting user and not a filter over someone else's.
+//!
+//! The two halves of a grant are written and deleted in one transaction with
+//! `attribute_not_exists` guards: a half-written grant would either be an
+//! invisible grant (authorizer allows, owner can't revoke) or an unenforceable
+//! one, and neither is allowed to exist. Claiming consumes the invite in that
+//! same transaction, which is what makes a code single-use — exactly one
+//! concurrent claimer wins the conditional delete.
+
+use std::collections::{HashMap, HashSet};
+
+use aws_sdk_dynamodb::types::{AttributeValue, Delete, Put, TransactWriteItem};
+use lambda_http::{Body, Error, Request, Response};
+use lux_wire::shares::{
+    ClaimRequest, ClaimResponse, Grant, InviteRequest, InviteResponse, PendingInvite,
+    ReceivedGrant, RevokeResponse, SharesResponse, INVITE_TTL_SECS, MAX_GRANTS_PER_CONTACT,
+    MAX_PENDING_INVITES,
+};
+use sha2::{Digest, Sha256};
+
+use crate::{error, now_millis, nudge, parse_body, reply, Ctx};
+
+// --- codes ------------------------------------------------------------------
+
+/// Claim-code alphabet: no vowels (so no code ever spells a word) and no
+/// 0/O/1/I/L/S lookalikes — the same set the device-pairing display codes use.
+/// Note that `L` and `U` are deliberately absent, which is what makes the
+/// `LUX` prefix unambiguous to strip on the way back in.
+const CODE_ALPHABET: &[u8] = b"23456789CDFGHJKMNPQRTVWXZ";
+
+/// Code body length. 25^10 ≈ 2^46 — a claim is bearer-authorized but reaching
+/// it still requires a signed-in account, a live 48-hour window, and surviving
+/// single use, so this is a very large multiple of what the exposure needs.
+const CODE_LEN: usize = 10;
+
+/// Mint a code in the shape a human sends in a message: `LUX-XXXXX-XXXXX`.
+fn mint_code() -> Result<String, String> {
+    let bytes = random::<CODE_LEN>()?;
+    let body: String = bytes
+        .iter()
+        .map(|b| CODE_ALPHABET[*b as usize % CODE_ALPHABET.len()] as char)
+        .collect();
+    Ok(format!("LUX-{}-{}", &body[..5], &body[5..]))
+}
+
+/// Undo every formatting kindness a messaging app or a human might apply:
+/// case, the grouping dashes, stray whitespace, and the `LUX` prefix.
+fn normalize_code(raw: &str) -> String {
+    let compact: String = raw
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect::<String>()
+        .to_ascii_uppercase();
+    compact.strip_prefix("LUX").unwrap_or(&compact).to_owned()
+}
+
+/// The at-rest key for a code: hex sha256 of its normalized body. The code
+/// itself never touches the table, so a database reader cannot claim anything.
+fn code_ref(code: &str) -> String {
+    hex(&Sha256::digest(normalize_code(code).as_bytes()))
+}
+
+fn random<const N: usize>() -> Result<[u8; N], String> {
+    use std::io::Read;
+    let mut bytes = [0u8; N];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut f| f.read_exact(&mut bytes))
+        .map_err(|e| format!("no OS randomness: {e}"))?;
+    Ok(bytes)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().fold(String::new(), |mut acc, b| {
+        use std::fmt::Write;
+        let _ = write!(acc, "{b:02x}");
+        acc
+    })
+}
+
+// --- keys -------------------------------------------------------------------
+
+fn invite_pk(code_ref: &str) -> String {
+    format!("INVITE#{code_ref}")
+}
+
+const INVITE_SK: &str = "INVITE";
+
+fn grant_pk(owner_sub: &str) -> String {
+    format!("GRANT#{owner_sub}")
+}
+
+fn grant_sk(contact_sub: &str, setup_id: &str) -> String {
+    format!("CONTACT#{contact_sub}#SETUP#{setup_id}")
+}
+
+/// The owner's mirror row for an outstanding invite, in the same partition as
+/// their grants so one query serves the whole manage list.
+fn pending_sk(code_ref: &str) -> String {
+    format!("INVITE#{code_ref}")
+}
+
+fn shared_pk(contact_sub: &str) -> String {
+    format!("SHARED#{contact_sub}")
+}
+
+fn shared_sk(owner_sub: &str, setup_id: &str) -> String {
+    format!("OWNER#{owner_sub}#SETUP#{setup_id}")
+}
+
+fn s(v: &str) -> AttributeValue {
+    AttributeValue::S(v.to_owned())
+}
+
+fn n(v: i64) -> AttributeValue {
+    AttributeValue::N(v.to_string())
+}
+
+fn read_s(item: &HashMap<String, AttributeValue>, key: &str) -> Option<String> {
+    item.get(key)?.as_s().ok().cloned()
+}
+
+fn read_n(item: &HashMap<String, AttributeValue>, key: &str) -> Option<i64> {
+    item.get(key)?.as_n().ok()?.parse().ok()
+}
+
+// --- routes -----------------------------------------------------------------
+
+/// `POST /shares/invite` — the owner mints a claim code for one of their setups.
+pub async fn invite(
+    ctx: &Ctx,
+    sub: &str,
+    email: Option<&str>,
+    req: &Request,
+) -> Result<Response<Body>, Error> {
+    let body: InviteRequest = match parse_body(req) {
+        Ok(b) => b,
+        Err(e) => return reply(400, error(&e)),
+    };
+
+    // Only over a setup the caller actually owns and hasn't deleted. This is
+    // the authorization check for the whole feature: a grant can only ever name
+    // a setup in the minting caller's own partition.
+    let setup_name = match live_setup_name(ctx, sub, &body.setup_id).await {
+        Ok(Some(name)) => name,
+        Ok(None) => return reply(404, error("no such setup")),
+        Err(e) => {
+            tracing::error!("setup lookup failed: {e}");
+            return reply(500, error("internal"));
+        }
+    };
+
+    let rows = match query_partition(ctx, &grant_pk(sub)).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("invite count failed: {e}");
+            return reply(500, error("internal"));
+        }
+    };
+    let now = now_millis();
+    let outstanding = rows
+        .iter()
+        .filter(|item| is_pending_invite(item, now))
+        .count();
+    if outstanding >= MAX_PENDING_INVITES {
+        return reply(
+            409,
+            error("too many unused invite codes; withdraw one before minting another"),
+        );
+    }
+
+    let code = match mint_code() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("{e}");
+            return reply(500, error("internal"));
+        }
+    };
+    let reference = code_ref(&code);
+    let expires_at = now + INVITE_TTL_SECS * 1000;
+    // Keep the row a day past expiry so a "why didn't this work" question is
+    // still answerable; DynamoDB TTL is epoch seconds.
+    let ttl = expires_at / 1000 + 86_400;
+
+    let mut invite_item: HashMap<String, AttributeValue> = HashMap::from([
+        ("pk".into(), s(&invite_pk(&reference))),
+        ("sk".into(), s(INVITE_SK)),
+        ("ownerSub".into(), s(sub)),
+        ("ownerLabel".into(), s(&label_for(sub, email))),
+        ("setupId".into(), s(&body.setup_id)),
+        ("setupName".into(), s(&setup_name)),
+        ("createdAt".into(), n(now)),
+        ("expiresAt".into(), n(expires_at)),
+        ("ttl".into(), n(ttl)),
+    ]);
+    let mut pending_item: HashMap<String, AttributeValue> = HashMap::from([
+        ("pk".into(), s(&grant_pk(sub))),
+        ("sk".into(), s(&pending_sk(&reference))),
+        ("codeRef".into(), s(&reference)),
+        ("setupId".into(), s(&body.setup_id)),
+        ("setupName".into(), s(&setup_name)),
+        ("createdAt".into(), n(now)),
+        ("expiresAt".into(), n(expires_at)),
+        ("ttl".into(), n(ttl)),
+    ]);
+    if let Some(label) = body.label.as_deref().filter(|l| !l.is_empty()) {
+        invite_item.insert("label".into(), s(label));
+        pending_item.insert("label".into(), s(label));
+    }
+
+    if let Err(e) = put_both(ctx, invite_item, pending_item).await {
+        tracing::error!("invite write failed: {e}");
+        return reply(500, error("internal"));
+    }
+
+    // The owner's other devices refresh their manage list.
+    nudge(ctx, sub, lux_wire::nudge::shares_changed_frame()).await;
+
+    reply(
+        200,
+        InviteResponse {
+            code,
+            code_ref: reference,
+            expires_at,
+        },
+    )
+}
+
+/// `POST /shares/claim` — the contact redeems a code and gains the grant.
+///
+/// Every way a code can fail to be usable — never existed, expired, already
+/// claimed, withdrawn — answers identically: a caller learns nothing about
+/// codes they don't hold.
+pub async fn claim(
+    ctx: &Ctx,
+    sub: &str,
+    email: Option<&str>,
+    req: &Request,
+) -> Result<Response<Body>, Error> {
+    let body: ClaimRequest = match parse_body(req) {
+        Ok(b) => b,
+        Err(e) => return reply(400, error(&e)),
+    };
+    let reference = code_ref(&body.code);
+    let no_such = || reply(404, error("that invite code is not valid"));
+
+    let invite = match get_item(ctx, &invite_pk(&reference), INVITE_SK).await {
+        Ok(Some(item)) => item,
+        Ok(None) => return no_such(),
+        Err(e) => {
+            tracing::error!("invite lookup failed: {e}");
+            return reply(500, error("internal"));
+        }
+    };
+    let now = now_millis();
+    let (Some(owner_sub), Some(setup_id), Some(expires_at)) = (
+        read_s(&invite, "ownerSub"),
+        read_s(&invite, "setupId"),
+        read_n(&invite, "expiresAt"),
+    ) else {
+        tracing::error!("malformed invite item");
+        return reply(500, error("internal"));
+    };
+    if expires_at <= now {
+        return no_such();
+    }
+    if owner_sub == sub {
+        return reply(400, error("that is your own invite code"));
+    }
+
+    // The setup must still be there — an owner who deleted it between minting
+    // and claiming would otherwise hand out a grant onto nothing. Re-reading it
+    // also refreshes the name the contact will see.
+    let setup_name = match live_setup_name(ctx, &owner_sub, &setup_id).await {
+        Ok(Some(name)) => name,
+        Ok(None) => return reply(409, error("that setup is no longer shared")),
+        Err(e) => {
+            tracing::error!("setup lookup failed: {e}");
+            return reply(500, error("internal"));
+        }
+    };
+
+    let existing = match query_partition(ctx, &shared_pk(sub)).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("grant count failed: {e}");
+            return reply(500, error("internal"));
+        }
+    };
+    if existing
+        .iter()
+        .any(|item| read_s(item, "sk").as_deref() == Some(&shared_sk(&owner_sub, &setup_id)))
+    {
+        return reply(409, error("you already have access to that setup"));
+    }
+    // The cap the IoT authorizer's policy-document budget forces (see
+    // lux_wire::shares::MAX_GRANTS_PER_CONTACT). Refusing here is the loud half
+    // of "cap loudly"; the authorizer truncating is the silent half we never
+    // want to reach. Two simultaneous claims could both pass this read and land
+    // one over — the authorizer still holds the real line, and the next claim
+    // is refused.
+    if existing.len() >= MAX_GRANTS_PER_CONTACT {
+        return reply(
+            409,
+            error("you are already in as many shared setups as one account can hold"),
+        );
+    }
+
+    let owner_label = read_s(&invite, "ownerLabel").unwrap_or_default();
+    let contact_label = label_for(sub, email);
+    let label = read_s(&invite, "label");
+
+    let mut grant_item: HashMap<String, AttributeValue> = HashMap::from([
+        ("pk".into(), s(&grant_pk(&owner_sub))),
+        ("sk".into(), s(&grant_sk(sub, &setup_id))),
+        ("contactSub".into(), s(sub)),
+        ("contactLabel".into(), s(&contact_label)),
+        ("setupId".into(), s(&setup_id)),
+        ("setupName".into(), s(&setup_name)),
+        ("createdAt".into(), n(now)),
+    ]);
+    if let Some(label) = label.as_deref() {
+        grant_item.insert("label".into(), s(label));
+    }
+    let shared_item: HashMap<String, AttributeValue> = HashMap::from([
+        ("pk".into(), s(&shared_pk(sub))),
+        ("sk".into(), s(&shared_sk(&owner_sub, &setup_id))),
+        ("ownerSub".into(), s(&owner_sub)),
+        ("ownerLabel".into(), s(&owner_label)),
+        ("setupId".into(), s(&setup_id)),
+        ("setupName".into(), s(&setup_name)),
+        ("createdAt".into(), n(now)),
+    ]);
+
+    // One transaction: burn the code (both its rows) and write both halves of
+    // the grant. The conditional delete is the single-use gate.
+    let burn = Delete::builder()
+        .table_name(&ctx.table)
+        .key("pk", s(&invite_pk(&reference)))
+        .key("sk", s(INVITE_SK))
+        .condition_expression("attribute_exists(pk) AND expiresAt > :now")
+        .expression_attribute_values(":now", n(now))
+        .build()
+        .map_err(|e| format!("invite delete malformed: {e}"))?;
+    let drop_pending = Delete::builder()
+        .table_name(&ctx.table)
+        .key("pk", s(&grant_pk(&owner_sub)))
+        .key("sk", s(&pending_sk(&reference)))
+        .build()
+        .map_err(|e| format!("pending delete malformed: {e}"))?;
+    let put = |item| {
+        Put::builder()
+            .table_name(&ctx.table)
+            .set_item(Some(item))
+            .condition_expression("attribute_not_exists(pk)")
+            .build()
+            .map_err(|e| format!("grant put malformed: {e}"))
+    };
+    if let Err(e) = ctx
+        .ddb
+        .transact_write_items()
+        .transact_items(TransactWriteItem::builder().delete(burn).build())
+        .transact_items(TransactWriteItem::builder().delete(drop_pending).build())
+        .transact_items(TransactWriteItem::builder().put(put(grant_item)?).build())
+        .transact_items(TransactWriteItem::builder().put(put(shared_item)?).build())
+        .send()
+        .await
+    {
+        // Losing the race for a single-use code is the expected shape of this
+        // failure, so it reads as an invalid code rather than an error.
+        tracing::warn!("claim transaction rejected: {e}");
+        return no_such();
+    }
+
+    // Both parties learn immediately: the owner's manage list gains a contact,
+    // the contact's shared list gains a setup.
+    nudge(ctx, &owner_sub, lux_wire::nudge::shares_changed_frame()).await;
+    nudge(ctx, sub, lux_wire::nudge::shares_changed_frame()).await;
+
+    reply(
+        200,
+        ClaimResponse {
+            owner_sub,
+            owner_label,
+            setup_id,
+            setup_name: Some(setup_name),
+        },
+    )
+}
+
+/// `GET /shares` — both directions plus the caller's outstanding invites.
+pub async fn list(ctx: &Ctx, sub: &str) -> Result<Response<Body>, Error> {
+    let (owned_pk, received_pk) = (grant_pk(sub), shared_pk(sub));
+    let (owned, received) = match tokio::try_join!(
+        query_partition(ctx, &owned_pk),
+        query_partition(ctx, &received_pk),
+    ) {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::error!("shares list failed: {e}");
+            return reply(500, error("internal"));
+        }
+    };
+
+    let now = now_millis();
+    let mut granted = Vec::new();
+    let mut pending = Vec::new();
+    for item in &owned {
+        let Some(sk) = read_s(item, "sk") else { continue };
+        if sk.starts_with("CONTACT#") {
+            let (Some(contact_sub), Some(setup_id), Some(created_at)) = (
+                read_s(item, "contactSub"),
+                read_s(item, "setupId"),
+                read_n(item, "createdAt"),
+            ) else {
+                continue;
+            };
+            granted.push(Grant {
+                contact_sub,
+                contact_label: read_s(item, "contactLabel").unwrap_or_default(),
+                setup_id,
+                setup_name: read_s(item, "setupName"),
+                label: read_s(item, "label"),
+                created_at,
+            });
+        } else if is_pending_invite(item, now) {
+            let (Some(code_ref), Some(setup_id), Some(created_at), Some(expires_at)) = (
+                read_s(item, "codeRef"),
+                read_s(item, "setupId"),
+                read_n(item, "createdAt"),
+                read_n(item, "expiresAt"),
+            ) else {
+                continue;
+            };
+            pending.push(PendingInvite {
+                code_ref,
+                setup_id,
+                setup_name: read_s(item, "setupName"),
+                label: read_s(item, "label"),
+                created_at,
+                expires_at,
+            });
+        }
+    }
+
+    let received = received
+        .iter()
+        .filter_map(|item| {
+            Some(ReceivedGrant {
+                owner_sub: read_s(item, "ownerSub")?,
+                owner_label: read_s(item, "ownerLabel").unwrap_or_default(),
+                setup_id: read_s(item, "setupId")?,
+                setup_name: read_s(item, "setupName"),
+                created_at: read_n(item, "createdAt")?,
+            })
+        })
+        .collect();
+
+    reply(
+        200,
+        SharesResponse {
+            granted,
+            received,
+            pending,
+        },
+    )
+}
+
+/// `DELETE /shares/granted/{contactSub}/{setupId}` (owner revokes) and
+/// `DELETE /shares/received/{ownerSub}/{setupId}` (contact leaves).
+///
+/// Both name the same grant from opposite ends and do the same thing, which is
+/// the point: leaving is not a lesser operation than revoking, and neither side
+/// needs the other's cooperation to end the arrangement.
+pub async fn revoke(
+    ctx: &Ctx,
+    owner_sub: &str,
+    contact_sub: &str,
+    setup_id: &str,
+    caller_is_owner: bool,
+) -> Result<Response<Body>, Error> {
+    match delete_grant(ctx, owner_sub, contact_sub, setup_id, caller_is_owner).await {
+        Ok(()) => {}
+        Err(e) => {
+            // The caller's own half not existing is the only ordinary failure
+            // here, and it means there is nothing to revoke.
+            tracing::warn!("grant delete rejected: {e}");
+            return reply(404, error("no such share"));
+        }
+    }
+
+    nudge(ctx, owner_sub, lux_wire::nudge::shares_changed_frame()).await;
+    nudge(ctx, contact_sub, lux_wire::nudge::shares_changed_frame()).await;
+
+    reply(200, RevokeResponse { revoked: true })
+}
+
+/// `DELETE /shares/invite/{codeRef}` — the owner withdraws an unclaimed code.
+pub async fn withdraw(ctx: &Ctx, sub: &str, reference: &str) -> Result<Response<Body>, Error> {
+    // The ownership condition is on the invite row, which is the one an
+    // attacker could name: a `codeRef` from someone else's pending list is
+    // useless without also being that owner.
+    let burn = Delete::builder()
+        .table_name(&ctx.table)
+        .key("pk", s(&invite_pk(reference)))
+        .key("sk", s(INVITE_SK))
+        .condition_expression("ownerSub = :sub")
+        .expression_attribute_values(":sub", s(sub))
+        .build()
+        .map_err(|e| format!("invite delete malformed: {e}"))?;
+    let drop_pending = Delete::builder()
+        .table_name(&ctx.table)
+        .key("pk", s(&grant_pk(sub)))
+        .key("sk", s(&pending_sk(reference)))
+        .build()
+        .map_err(|e| format!("pending delete malformed: {e}"))?;
+
+    if let Err(e) = ctx
+        .ddb
+        .transact_write_items()
+        .transact_items(TransactWriteItem::builder().delete(burn).build())
+        .transact_items(TransactWriteItem::builder().delete(drop_pending).build())
+        .send()
+        .await
+    {
+        tracing::warn!("invite withdraw rejected: {e}");
+        return reply(404, error("no such invite"));
+    }
+
+    nudge(ctx, sub, lux_wire::nudge::shares_changed_frame()).await;
+    reply(200, RevokeResponse { revoked: true })
+}
+
+// --- account deletion -------------------------------------------------------
+
+/// Everything shared control leaves behind, cleared before the caller's own
+/// partition is wiped (`DELETE /user`).
+///
+/// This runs in both directions and neither is optional. As an **owner**, the
+/// caller's grants live half in their own partition and half in each contact's;
+/// wiping only their own would leave every contact holding a "shared with you"
+/// row forever, pointing at an account that no longer exists. As a **contact**,
+/// the mirror sits in each owner's partition and would show a ghost in their
+/// manage list with a revoke button that does nothing.
+///
+/// The retained `config` topics go too: they carry the setup's name and channel
+/// labels, and deleting an account has to mean the data actually leaves.
+///
+/// Best-effort per item, deliberately: a failure to clean one grant must not
+/// abort a deletion the user asked for and Cognito is about to complete. What
+/// survives a partial failure is at worst a stale row, and the next reader
+/// (list, authorizer) resolves an unmatched half as no access.
+pub async fn cleanup_for_deleted_user(ctx: &Ctx, sub: &str) {
+    let owned = query_partition(ctx, &grant_pk(sub)).await.unwrap_or_else(|e| {
+        tracing::error!("deletion: own grant partition unreadable: {e}");
+        Vec::new()
+    });
+    let received = query_partition(ctx, &shared_pk(sub))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("deletion: shared partition unreadable: {e}");
+            Vec::new()
+        });
+
+    let mut notify: HashSet<String> = HashSet::new();
+    let mut shared_setups: HashSet<String> = HashSet::new();
+
+    // As owner: drop each contact's mirror, and remember the setups whose
+    // retained config has to be cleared.
+    for item in &owned {
+        let Some(sk) = read_s(item, "sk") else { continue };
+        if let Some(contact_sub) = read_s(item, "contactSub") {
+            if sk.starts_with("CONTACT#") {
+                if let Some(setup_id) = read_s(item, "setupId") {
+                    shared_setups.insert(setup_id);
+                }
+                delete_key(ctx, &shared_pk(&contact_sub), &mirror_sk_of_owned(item, sub)).await;
+                notify.insert(contact_sub);
+            }
+        }
+        // Outstanding invites: the code row lives in its own partition and
+        // would otherwise stay claimable until its TTL.
+        if let Some(reference) = read_s(item, "codeRef") {
+            delete_key(ctx, &invite_pk(&reference), INVITE_SK).await;
+        }
+        delete_key(ctx, &grant_pk(sub), &sk).await;
+    }
+
+    // As contact: drop each owner's half of the grant.
+    for item in &received {
+        let (Some(sk), Some(owner_sub), Some(setup_id)) = (
+            read_s(item, "sk"),
+            read_s(item, "ownerSub"),
+            read_s(item, "setupId"),
+        ) else {
+            continue;
+        };
+        delete_key(ctx, &grant_pk(&owner_sub), &grant_sk(sub, &setup_id)).await;
+        delete_key(ctx, &shared_pk(sub), &sk).await;
+        notify.insert(owner_sub);
+    }
+
+    // Retained config carries setup and channel names; clear it with an empty
+    // retained payload, the same idiom presence cards already use.
+    for setup_id in &shared_setups {
+        clear_retained_config(ctx, sub, setup_id).await;
+    }
+
+    for other in &notify {
+        nudge(ctx, other, lux_wire::nudge::shares_changed_frame()).await;
+    }
+}
+
+/// Given a row from the owner's `GRANT#` partition, the key of its mirror in
+/// the contact's `SHARED#` partition. The two sort keys are not symmetrical —
+/// each names the *other* party — so deleting the far half means rebuilding its
+/// key rather than reusing the near one.
+fn mirror_sk_of_owned(item: &HashMap<String, AttributeValue>, owner_sub: &str) -> String {
+    let setup_id = read_s(item, "setupId").unwrap_or_default();
+    shared_sk(owner_sub, &setup_id)
+}
+
+/// Publish an empty retained payload to a setup's config topic, deleting the
+/// retained message. Best-effort like every other publish on this path.
+async fn clear_retained_config(ctx: &Ctx, sub: &str, setup_id: &str) {
+    let Some(iot) = &ctx.iot else { return };
+    let topic = lux_wire::ctl::config_topic(sub, setup_id);
+    if let Err(e) = iot
+        .publish()
+        .topic(&topic)
+        .qos(0)
+        .retain(true)
+        .payload(aws_sdk_iotdataplane::primitives::Blob::new(Vec::new()))
+        .send()
+        .await
+    {
+        tracing::warn!("retained config clear on {topic} failed: {e}");
+    }
+}
+
+// --- store helpers ----------------------------------------------------------
+
+/// The name of a live (existing, untombstoned) setup in a user's partition.
+async fn live_setup_name(ctx: &Ctx, sub: &str, setup_id: &str) -> Result<Option<String>, String> {
+    let out = ctx
+        .ddb
+        .get_item()
+        .table_name(&ctx.table)
+        .key("pk", s(&format!("USER#{sub}")))
+        .key("sk", s(&format!("SETUP#{setup_id}")))
+        .send()
+        .await
+        .map_err(|e| format!("setup get failed: {e}"))?;
+    let Some(item) = out.item else {
+        return Ok(None);
+    };
+    let deleted = item
+        .get("deleted")
+        .and_then(|v| v.as_bool().ok().copied())
+        .unwrap_or(false);
+    if deleted {
+        return Ok(None);
+    }
+    Ok(Some(read_s(&item, "name").unwrap_or_default()))
+}
+
+async fn get_item(
+    ctx: &Ctx,
+    pk: &str,
+    sk: &str,
+) -> Result<Option<HashMap<String, AttributeValue>>, String> {
+    let out = ctx
+        .ddb
+        .get_item()
+        .table_name(&ctx.table)
+        .key("pk", s(pk))
+        .key("sk", s(sk))
+        .send()
+        .await
+        .map_err(|e| format!("get failed: {e}"))?;
+    Ok(out.item)
+}
+
+/// Every item in one partition, paged. These partitions hold at most a handful
+/// of rows each (both caps are single digits), so paging is belt-and-braces.
+async fn query_partition(
+    ctx: &Ctx,
+    pk: &str,
+) -> Result<Vec<HashMap<String, AttributeValue>>, String> {
+    let mut items = Vec::new();
+    let mut start_key = None;
+    loop {
+        let out = ctx
+            .ddb
+            .query()
+            .table_name(&ctx.table)
+            .key_condition_expression("pk = :pk")
+            .expression_attribute_values(":pk", s(pk))
+            .set_exclusive_start_key(start_key.take())
+            .send()
+            .await
+            .map_err(|e| format!("query failed: {e}"))?;
+        items.extend(out.items.clone().unwrap_or_default());
+        start_key = out.last_evaluated_key().cloned();
+        if start_key.is_none() {
+            return Ok(items);
+        }
+    }
+}
+
+/// Write two items in one transaction, each insisting it is new.
+async fn put_both(
+    ctx: &Ctx,
+    first: HashMap<String, AttributeValue>,
+    second: HashMap<String, AttributeValue>,
+) -> Result<(), String> {
+    let put = |item| {
+        Put::builder()
+            .table_name(&ctx.table)
+            .set_item(Some(item))
+            .condition_expression("attribute_not_exists(pk)")
+            .build()
+            .map_err(|e| format!("put malformed: {e}"))
+    };
+    ctx.ddb
+        .transact_write_items()
+        .transact_items(TransactWriteItem::builder().put(put(first)?).build())
+        .transact_items(TransactWriteItem::builder().put(put(second)?).build())
+        .send()
+        .await
+        .map_err(|e| format!("transaction failed: {e}"))?;
+    Ok(())
+}
+
+/// Drop both halves of a grant in one transaction.
+///
+/// The existence condition goes on the *caller's* half, so a revoke of nothing
+/// is an error rather than a silent success — and so either party can always
+/// clear their own row even if the other half has somehow gone missing. Putting
+/// it unconditionally on the owner's half would let a stray `SHARED#` row trap
+/// a contact in a share they cannot leave.
+async fn delete_grant(
+    ctx: &Ctx,
+    owner_sub: &str,
+    contact_sub: &str,
+    setup_id: &str,
+    caller_is_owner: bool,
+) -> Result<(), String> {
+    let exists = "attribute_exists(pk)";
+    let mut owner_half = Delete::builder()
+        .table_name(&ctx.table)
+        .key("pk", s(&grant_pk(owner_sub)))
+        .key("sk", s(&grant_sk(contact_sub, setup_id)));
+    let mut contact_half = Delete::builder()
+        .table_name(&ctx.table)
+        .key("pk", s(&shared_pk(contact_sub)))
+        .key("sk", s(&shared_sk(owner_sub, setup_id)));
+    if caller_is_owner {
+        owner_half = owner_half.condition_expression(exists);
+    } else {
+        contact_half = contact_half.condition_expression(exists);
+    }
+    let owner_half = owner_half
+        .build()
+        .map_err(|e| format!("grant delete malformed: {e}"))?;
+    let contact_half = contact_half
+        .build()
+        .map_err(|e| format!("mirror delete malformed: {e}"))?;
+    ctx.ddb
+        .transact_write_items()
+        .transact_items(TransactWriteItem::builder().delete(owner_half).build())
+        .transact_items(TransactWriteItem::builder().delete(contact_half).build())
+        .send()
+        .await
+        .map_err(|e| format!("grant delete failed: {e}"))?;
+    Ok(())
+}
+
+/// Best-effort single-item delete for the cleanup paths (see
+/// [`cleanup_for_deleted_user`] on why one failure must not stop the rest).
+async fn delete_key(ctx: &Ctx, pk: &str, sk: &str) {
+    if let Err(e) = ctx
+        .ddb
+        .delete_item()
+        .table_name(&ctx.table)
+        .key("pk", s(pk))
+        .key("sk", s(sk))
+        .send()
+        .await
+    {
+        tracing::warn!("cleanup delete of {pk}/{sk} failed: {e}");
+    }
+}
+
+/// Is this row an outstanding (unclaimed, unexpired) invite?
+fn is_pending_invite(item: &HashMap<String, AttributeValue>, now: i64) -> bool {
+    read_s(item, "sk").is_some_and(|sk| sk.starts_with("INVITE#"))
+        && read_n(item, "expiresAt").is_some_and(|exp| exp > now)
+}
+
+/// How the caller should appear in the other party's list. The email claim is
+/// display-only and optional (an appliance session's token has none), so a
+/// missing one degrades to an unlabelled share rather than blocking it — the
+/// grant is authorized by `sub`, which is always present.
+fn label_for(sub: &str, email: Option<&str>) -> String {
+    match email.filter(|e| !e.is_empty()) {
+        Some(email) => email.to_owned(),
+        None => {
+            tracing::info!("no email claim for {sub}; sharing with an unlabelled account");
+            String::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minted_codes_use_the_display_alphabet() {
+        let code = mint_code().unwrap();
+        assert!(code.starts_with("LUX-"));
+        let body: String = code.chars().filter(char::is_ascii_alphanumeric).collect();
+        assert_eq!(body.len(), "LUX".len() + CODE_LEN);
+        assert!(body["LUX".len()..]
+            .bytes()
+            .all(|b| CODE_ALPHABET.contains(&b)));
+    }
+
+    #[test]
+    fn normalization_survives_however_a_human_sends_it() {
+        let canonical = normalize_code("LUX-4KPT9-XQ2WM");
+        assert_eq!(canonical, "4KPT9XQ2WM");
+        // Lowercased by a keyboard, re-spaced by a chat app, pasted bare.
+        assert_eq!(normalize_code("lux-4kpt9-xq2wm"), canonical);
+        assert_eq!(normalize_code("  LUX 4KPT9 XQ2WM "), canonical);
+        assert_eq!(normalize_code("4KPT9XQ2WM"), canonical);
+        // The prefix is unambiguous because L and U are not in the alphabet, so
+        // stripping it can never eat a code's own leading characters.
+        assert!(!CODE_ALPHABET.contains(&b'L') && !CODE_ALPHABET.contains(&b'U'));
+    }
+
+    #[test]
+    fn code_ref_is_a_stable_hash_not_the_secret() {
+        let code = "LUX-4KPT9-XQ2WM";
+        let reference = code_ref(code);
+        assert_eq!(reference.len(), 64);
+        assert_eq!(reference, code_ref(code));
+        // Every spelling of one code resolves to one row.
+        assert_eq!(reference, code_ref("lux 4kpt9 xq2wm"));
+        assert!(!reference.contains("4KPT9"));
+        assert_ne!(reference, code_ref("LUX-4KPT9-XQ2WN"));
+    }
+
+    #[test]
+    fn keys_keep_the_two_halves_addressable_from_either_end() {
+        // The owner's half is found by (owner, contact, setup); the contact's
+        // by (contact, owner, setup). Revoke and leave each hold one and derive
+        // the other, so both must be pure functions of the same triple.
+        assert_eq!(grant_pk("owner-1"), "GRANT#owner-1");
+        assert_eq!(grant_sk("contact-1", "s-1"), "CONTACT#contact-1#SETUP#s-1");
+        assert_eq!(shared_pk("contact-1"), "SHARED#contact-1");
+        assert_eq!(shared_sk("owner-1", "s-1"), "OWNER#owner-1#SETUP#s-1");
+        // Pending invites share the owner's partition, distinguished by prefix.
+        assert!(pending_sk("abc").starts_with("INVITE#"));
+        assert!(!grant_sk("c", "s").starts_with("INVITE#"));
+    }
+
+    #[test]
+    fn deletion_rebuilds_the_far_half_of_a_grant() {
+        // An owner-side row names the contact; its mirror names the owner. The
+        // deletion path holds the former and must derive the latter, and
+        // getting this wrong would silently leave every contact holding a row
+        // pointing at a deleted account.
+        let owned = HashMap::from([
+            ("sk".to_owned(), s(&grant_sk("contact-1", "s-1"))),
+            ("contactSub".to_owned(), s("contact-1")),
+            ("setupId".to_owned(), s("s-1")),
+        ]);
+        assert_eq!(
+            mirror_sk_of_owned(&owned, "owner-1"),
+            shared_sk("owner-1", "s-1")
+        );
+        // …and the round trip closes: the mirror's own key rebuilds the near
+        // half, which is what the contact-side deletion loop does.
+        assert_eq!(Some(grant_sk("contact-1", "s-1")), read_s(&owned, "sk"));
+    }
+
+    #[test]
+    fn pending_invites_are_the_unexpired_invite_rows() {
+        let row = |sk: &str, expires: i64| {
+            HashMap::from([("sk".to_owned(), s(sk)), ("expiresAt".to_owned(), n(expires))])
+        };
+        let now = 1_000;
+        assert!(is_pending_invite(&row("INVITE#abc", now + 1), now));
+        // Expired codes stay in the table until TTL sweeps them, but they are
+        // not offered to the owner and never count against the cap.
+        assert!(!is_pending_invite(&row("INVITE#abc", now), now));
+        assert!(!is_pending_invite(
+            &row("CONTACT#c#SETUP#s", now + 1),
+            now
+        ));
+    }
+}

--- a/services/sync-api/src/shares.rs
+++ b/services/sync-api/src/shares.rs
@@ -50,12 +50,26 @@ const CODE_ALPHABET: &[u8] = b"23456789CDFGHJKMNPQRTVWXZ";
 const CODE_LEN: usize = 10;
 
 /// Mint a code in the shape a human sends in a message: `LUX-XXXXX-XXXXX`.
+///
+/// Rejection-sampled rather than reduced modulo the alphabet, so every symbol
+/// is equally likely and the entropy noted above is the real figure rather than
+/// an upper bound. (Plain `% 25` would favour 6 of the 25 symbols by about
+/// 10%, costing roughly a bit — immaterial against a single-use 48-hour code,
+/// but the property is free to keep.)
 fn mint_code() -> Result<String, String> {
-    let bytes = random::<CODE_LEN>()?;
-    let body: String = bytes
-        .iter()
-        .map(|b| CODE_ALPHABET[*b as usize % CODE_ALPHABET.len()] as char)
-        .collect();
+    let span = CODE_ALPHABET.len() as u16;
+    let ceiling = (256 / span) * span; // largest whole multiple of the alphabet
+    let mut body = String::with_capacity(CODE_LEN);
+    while body.len() < CODE_LEN {
+        for b in random::<CODE_LEN>()? {
+            if (b as u16) < ceiling {
+                body.push(CODE_ALPHABET[b as usize % CODE_ALPHABET.len()] as char);
+                if body.len() == CODE_LEN {
+                    break;
+                }
+            }
+        }
+    }
     Ok(format!("LUX-{}-{}", &body[..5], &body[5..]))
 }
 
@@ -152,6 +166,15 @@ pub async fn invite(
         Ok(b) => b,
         Err(e) => return reply(400, error(&e)),
     };
+
+    // A setup id ends up inside an IAM resource ARN at the authorizer, where
+    // `*` matches `/` — so `PUT /setups/*` followed by an invite would widen
+    // the grant across the owner's whole setup space. Refuse the id here as
+    // well as there; the write path still accepts whatever it always did, so
+    // no existing setup stops syncing over this.
+    if !is_shareable_id(&body.setup_id) {
+        return reply(400, error("that setup cannot be shared"));
+    }
 
     // Only over a setup the caller actually owns and hasn't deleted. This is
     // the authorization check for the whole feature: a grant can only ever name
@@ -311,9 +334,10 @@ pub async fn claim(
     // The cap the IoT authorizer's policy-document budget forces (see
     // lux_wire::shares::MAX_GRANTS_PER_CONTACT). Refusing here is the loud half
     // of "cap loudly"; the authorizer truncating is the silent half we never
-    // want to reach. Two simultaneous claims could both pass this read and land
-    // one over — the authorizer still holds the real line, and the next claim
-    // is refused.
+    // want to reach. Simultaneous claims can all pass this read before any of
+    // them commits, so the overshoot is bounded by how many live codes one
+    // contact holds at once, not by one — the authorizer is the enforcing line
+    // either way, and it fails closed by truncating.
     if existing.len() >= MAX_GRANTS_PER_CONTACT {
         return reply(
             409,
@@ -561,44 +585,38 @@ pub async fn withdraw(ctx: &Ctx, sub: &str, reference: &str) -> Result<Response<
 /// The retained `config` topics go too: they carry the setup's name and channel
 /// labels, and deleting an account has to mean the data actually leaves.
 ///
-/// Best-effort per item, deliberately: a failure to clean one grant must not
-/// abort a deletion the user asked for and Cognito is about to complete. What
-/// survives a partial failure is at worst a stale row, and the next reader
-/// (list, authorizer) resolves an unmatched half as no access.
-pub async fn cleanup_for_deleted_user(ctx: &Ctx, sub: &str) {
-    let owned = query_partition(ctx, &grant_pk(sub)).await.unwrap_or_else(|e| {
-        tracing::error!("deletion: own grant partition unreadable: {e}");
-        Vec::new()
-    });
-    let received = query_partition(ctx, &shared_pk(sub))
-        .await
-        .unwrap_or_else(|e| {
-            tracing::error!("deletion: shared partition unreadable: {e}");
-            Vec::new()
-        });
+/// **Fallible on purpose, and the caller must not wipe on an error.** An
+/// earlier draft of this ran best-effort and claimed a stale half "resolves as
+/// no access" — that is false, and the module header above says why: the
+/// authorizer reads `SHARED#<sub>` and nothing else, so a surviving mirror is a
+/// live grant into a topic space whose owner no longer exists, with both the
+/// owner's row and the owner's Cognito user gone. There is no revoking that.
+///
+/// So a read or delete that fails here fails the whole request. Deletion is
+/// already idempotent and retryable end to end (the app deletes the Cognito
+/// user only after this returns), and a retry re-reads a shorter list and
+/// finishes the job.
+pub async fn cleanup_for_deleted_user(ctx: &Ctx, sub: &str) -> Result<(), String> {
+    let owned = query_partition(ctx, &grant_pk(sub)).await?;
+    let received = query_partition(ctx, &shared_pk(sub)).await?;
 
     let mut notify: HashSet<String> = HashSet::new();
-    let mut shared_setups: HashSet<String> = HashSet::new();
 
-    // As owner: drop each contact's mirror, and remember the setups whose
-    // retained config has to be cleared.
+    // As owner: drop each contact's mirror.
     for item in &owned {
         let Some(sk) = read_s(item, "sk") else { continue };
         if let Some(contact_sub) = read_s(item, "contactSub") {
             if sk.starts_with("CONTACT#") {
-                if let Some(setup_id) = read_s(item, "setupId") {
-                    shared_setups.insert(setup_id);
-                }
-                delete_key(ctx, &shared_pk(&contact_sub), &mirror_sk_of_owned(item, sub)).await;
+                delete_key(ctx, &shared_pk(&contact_sub), &mirror_sk_of_owned(item, sub)).await?;
                 notify.insert(contact_sub);
             }
         }
         // Outstanding invites: the code row lives in its own partition and
         // would otherwise stay claimable until its TTL.
         if let Some(reference) = read_s(item, "codeRef") {
-            delete_key(ctx, &invite_pk(&reference), INVITE_SK).await;
+            delete_key(ctx, &invite_pk(&reference), INVITE_SK).await?;
         }
-        delete_key(ctx, &grant_pk(sub), &sk).await;
+        delete_key(ctx, &grant_pk(sub), &sk).await?;
     }
 
     // As contact: drop each owner's half of the grant.
@@ -610,20 +628,32 @@ pub async fn cleanup_for_deleted_user(ctx: &Ctx, sub: &str) {
         ) else {
             continue;
         };
-        delete_key(ctx, &grant_pk(&owner_sub), &grant_sk(sub, &setup_id)).await;
-        delete_key(ctx, &shared_pk(sub), &sk).await;
+        delete_key(ctx, &grant_pk(&owner_sub), &grant_sk(sub, &setup_id)).await?;
+        delete_key(ctx, &shared_pk(sub), &sk).await?;
         notify.insert(owner_sub);
     }
 
-    // Retained config carries setup and channel names; clear it with an empty
-    // retained payload, the same idiom presence cards already use.
-    for setup_id in &shared_setups {
-        clear_retained_config(ctx, sub, setup_id).await;
+    // Retained config carries the setup's name and every channel label. Sweep
+    // *every* setup the account has, not just the currently-granted ones: a
+    // setup that was shared and then revoked still has a retained config, and
+    // driving this from live grants alone would walk straight past it.
+    // Clearing a topic that never had a retained message is a no-op.
+    for item in query_partition(ctx, &format!("USER#{sub}")).await? {
+        if let Some(setup_id) = read_s(&item, "sk").and_then(|sk| {
+            sk.strip_prefix("SETUP#")
+                .filter(|id| !id.is_empty())
+                .map(str::to_owned)
+        }) {
+            clear_retained_config(ctx, sub, &setup_id).await;
+        }
     }
 
+    // Nudges stay best-effort, as everywhere else: a missed one is healed by
+    // the other party's next pull, and it is not a correctness boundary.
     for other in &notify {
         nudge(ctx, other, lux_wire::nudge::shares_changed_frame()).await;
     }
+    Ok(())
 }
 
 /// Given a row from the owner's `GRANT#` partition, the key of its mirror in
@@ -791,20 +821,30 @@ async fn delete_grant(
     Ok(())
 }
 
-/// Best-effort single-item delete for the cleanup paths (see
-/// [`cleanup_for_deleted_user`] on why one failure must not stop the rest).
-async fn delete_key(ctx: &Ctx, pk: &str, sk: &str) {
-    if let Err(e) = ctx
-        .ddb
+/// Single-item delete for the cleanup paths. Failing loudly matters here: a
+/// mirror that survives is access nobody can revoke (see
+/// [`cleanup_for_deleted_user`]).
+async fn delete_key(ctx: &Ctx, pk: &str, sk: &str) -> Result<(), String> {
+    ctx.ddb
         .delete_item()
         .table_name(&ctx.table)
         .key("pk", s(pk))
         .key("sk", s(sk))
         .send()
         .await
-    {
-        tracing::warn!("cleanup delete of {pk}/{sk} failed: {e}");
-    }
+        .map_err(|e| format!("cleanup delete of {pk}/{sk} failed: {e}"))?;
+    Ok(())
+}
+
+/// Can this setup id safely become part of an IAM resource ARN? Setup ids are
+/// UUIDs in practice, but the write path never enforced that, and "in practice"
+/// is not a check when the answer decides how wide a grant is.
+fn is_shareable_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
 }
 
 /// Is this row an outstanding (unclaimed, unexpired) invite?
@@ -899,6 +939,20 @@ mod tests {
         // …and the round trip closes: the mirror's own key rebuilds the near
         // half, which is what the contact-side deletion loop does.
         assert_eq!(Some(grant_sk("contact-1", "s-1")), read_s(&owned, "sk"));
+    }
+
+    #[test]
+    fn ids_that_would_widen_a_grant_are_not_shareable() {
+        // A UUID, which is what every real setup id is.
+        assert!(is_shareable_id("7f0175a6-3b64-4a2a-9e1c-000000000001"));
+        // `PUT /setups/*` is a legal request, so this id can genuinely exist —
+        // and in an ARN it would grant the owner's entire setup space, because
+        // IAM wildcards match `/`.
+        assert!(!is_shareable_id("*"));
+        assert!(!is_shareable_id("a/b"));
+        assert!(!is_shareable_id("s-1/../s-2"));
+        assert!(!is_shareable_id(""));
+        assert!(!is_shareable_id(&"x".repeat(65)));
     }
 
     #[test]


### PR DESCRIPTION
Phase 1 of shared control: the backend that lets one account grant another the desk for a single setup. Ships dark — no UI reaches any of this yet, and nothing changes for an account that never mints an invite.

A grant is a triple `(owner, contact, setup)`. The contact signs in as themselves; the grant only widens what that existing identity may do inside the owner's control-topic space. The owner's applier stays the sole DMX authority, and guests never sync — their surface will render from the retained `config` topic, which finally gets its schema here.

Design and rationale: `docs/shared-control.md` (new).

## What's here

- **`crates/lux-wire`** — a `shares` module (route segments, invite/claim/grant/list shapes, the caps) and `ctl::Config`, the compiled-setup payload the reserved `…/setup/<id>/config` topic has been waiting for. Every shape is golden-tested, including the both-directions compatibility cases: an older client parsing a newer server's reply and the reverse, because App Review lag guarantees the two ends run different versions.
- **`services/sync-api`** — `POST /shares/invite`, `POST /shares/claim`, `GET /shares`, and three `DELETE` routes (owner revokes, contact leaves, owner withdraws an unclaimed code), plus the `INVITE#`/`GRANT#`/`SHARED#` item families. Grant halves are written and deleted in one transaction with `attribute_not_exists` guards; claiming consumes the invite in that same transaction, which is what makes a code single-use.
- **`services/iot-authorizer`** — the security-critical change. After the JWT verifies, one query on `SHARED#<sub>` and one narrow policy document per grant. Policy construction stays a pure, unit-tested function; the DynamoDB read is separate and fallible.
- **Account deletion** — cleanup in both directions, before the partition wipe, plus the share tally in the confirm dialog.
- **`infra/shares.tf`** — two IAM widenings, both narrow, in one file so the feature's whole authorization surface reads in one place.

## Deviations from the ratified spec

The spec predates the device-pairing brick, so a few things reconciled rather than landed as written:

1. **The grant cap is 9, not "~10", and it is enforced at claim rather than at invite.** The contact is not known until they redeem, and the limit is a property of the contact's connection, not the owner's generosity. The number is now derived rather than chosen: AWS IoT accepts at most 10 policy documents from a custom authorizer, each at most 2048 characters. A grant's six ARNs (UUID subs, UUID setup ids) run about 1 KB, so two grants will not reliably share a document, and an oversized document is rejected wholesale — which would take the caller's own access down with it. One grant per document, with the caller's own space taking the first, gives 9. It lives in `lux_wire::shares::MAX_GRANTS_PER_CONTACT` so the claim route and the authorizer cannot disagree, and there is a test that builds a full grant load at realistic UUID sizes and asserts every document fits.

2. **Outstanding invites are capped too (10 per owner), which needed an item the spec didn't have.** Counting invites by owner would otherwise be a scan, so each invite also writes a mirror row in the owner's own `GRANT#` partition. That makes the cap one query, and it also means an owner can *list and withdraw* codes they've handed out — without it, a code sent to the wrong person could only be waited out. `GET /shares` gained a `pending` array for this; it is `#[serde(default)]`, so older clients are unaffected.

3. **Guest presence is one exact topic per guest, `…/presence/<contactSub>`** — not the spec's `presence/<session>`, and with no wildcard at all. The authorizer runs during the WebSocket handshake, before a session id exists, so a per-session topic could only be authorized as a wildcard, and a wildcard over a topic namespace is an unbounded retained-write primitive (see the audit note below). Per-session granularity buys nothing here anyway: the connection's one Last Will stays on the guest's own topic, so cards in the owner's space are explicit publish/clear either way. Cost: a guest signed in on two devices shows one card. **P2 must publish guest cards on this topic.**

4. **DynamoDB TTL was already enabled** by the pairing work (`accounts.tf`), so `INVITE#` rows ride it as hoped — no infra change needed.

5. **`dynamodb:ConditionCheckItem` was not needed.** That permission covers `ConditionCheck` operations specifically; this code uses only conditional `Put` and `Delete` inside transactions, which need `PutItem`/`DeleteItem` — both already granted. The runbook's claim step is the live proof, and it runs before any UI exists.

## Retained-config clearing: server-side

Flagged as a decision to make. It is server-side, for two reasons.

The contact direction has no app-side option at all — a departing guest has no publish rights in the owner's space, correctly — so one direction is forced server-side, and one mechanism beats two. And an app killed mid-deletion, or an iOS app suspended between steps, would otherwise leave a retained frame carrying setup and channel names addressed to an account that no longer exists.

The IAM cost is one policy pinned to `topic/lux/ctl/user/*/setup/*/config`. The `/config` suffix is the point: the sync API can clear a compiled setup and can never publish a `frame` or a `state`, so it cannot drive anybody's lights no matter what the handler does.

Everywhere else the owner's applier still owns the config lifecycle (publish on change, clear on last revoke) — that's P2.

## Security audit

I ran an adversarial review of this diff before asking you to look at it. It confirmed the parts I most wanted confirmed — the DELETE key derivation really does make a cross-tenant revoke unconstructible, the guest policy asymmetry holds, single-use claiming is real, and there's no arbitrary-nudge primitive despite the sync API holding `iot:Publish` on `lux/sync/user/*`. It also found four things worth fixing, all addressed in the second commit:

- **The guest presence wildcard was an unbounded retained-write namespace.** `presence/<contactSub>-*` matches `/`, so a guest could retain messages on arbitrarily many topics; the owner replays every one on each reconnect into an uncapped map; and revoking the grant removes the guest's ability to clear them. Revocation made it permanent rather than fixing it. Now one exact topic, no wildcard — deviation 3 above.
- **`setup_id` reached an IAM resource unvalidated.** `PUT /setups/*` is a legal request, and `*` in an ARN would widen a grant across the owner's entire setup space. Now refused at the invite route and again at the authorizer. The write path is unchanged, so nothing that syncs today stops.
- **Deletion cleanup ran best-effort behind a comment I'd written that was wrong.** It claimed an unmatched half "resolves as no access"; the module header three hundred lines up correctly says the opposite. The authorizer reads `SHARED#<sub>` and nothing else, so a surviving mirror is a live grant into a dead account's topic space, unrevocable in principle. Cleanup is now fallible and the wipe is gated on it — the flow was already idempotent, so a retry finishes the job. The config sweep also walks every setup rather than the live grants, so a shared-then-revoked setup gets cleared.
- **Presence identity came from the card body rather than the topic.** A guest could have presented itself under another peer's session id. Cosmetic, fixed.

Two smaller things I fixed because they were nearly free: claim codes are rejection-sampled so the ~2^46 figure is exact rather than an upper bound, and the concurrent-claim overshoot is now described correctly (bounded by codes held, not by one).

One finding I did **not** act on, and the reasoning, since it's a judgement call: retained `state` frames and presence cards still survive account deletion. Both predate this feature and neither is part of a grant. Clearing them needs `iot:Publish` on those topics — the audit suggested `RetainPublish` alone would do it, but that's not right; IoT requires `iot:Publish` for any publish, retained or not. So the fix would cost exactly the property that makes the current config grant safe: that the sync API cannot publish a frame or a state, and therefore cannot drive anybody's lights. It's worth doing on its own terms — a presence card's `name` is the machine hostname, which is often a person's name — but not by quietly widening this role inside this PR. Documented in `docs/shared-control.md`.

## Security notes for review

- **The path never carries the caller's own identity.** Every route names the *other* party; the caller's side comes from the verified token. Both DynamoDB keys a delete touches therefore embed the caller, so there is no request that names a grant the caller isn't part of. The key derivation is the authorization check.
- **A guest's policy is asymmetric on purpose.** Publish frames and its own presence card; read `state` and `config`. It cannot publish or retain `state` or `config` — the owner's applier is the sole authority on both, and a guest that could retain either could lie to every other surface, including after it left. There's a test that greps a rendered policy for the wildcards and topics that must not appear.
- **A failed grant lookup grants nothing but does not deny the connection.** Closed with respect to shares — a failed read can never fabricate access — while a DynamoDB blip doesn't sign every user out of their own sync.
- **Revocation latency is one hour**, the connection's refresh window. Documented, not fixed here; forcing a disconnect on revoke is the sharpening if it ever matters.
- **Claim codes**: 10 characters from the pairing brick's confusion-free alphabet (~2^46), SHA-256 at rest, single-use via conditional delete, 48-hour expiry. Claiming requires a signed-in account, so guessing is neither anonymous nor unattributable. Unknown, expired, consumed, and withdrawn codes all answer identically.

## Pipeline smokes, and the one that isn't here

Added: typed 401s on `GET /shares` and `POST /shares/claim` (proves the module shipped and is gated — an unrouted path would 404), and an assertion that the authorizer's `DYNAMODB_TABLE` is actually set, because a missing one degrades silently to "no connection is ever widened" rather than failing.

The two-account grant → policy assertion is **not** in the pipeline. Wiring it would mean two permanent test users in the production pool, their passwords in Secrets Manager, the deploy role gaining Cognito auth permissions, and real grant writes on every release. That is a standing cost and a widened deploy role for a check that the unit tests already cover structurally. It is instead the runbook below, run once against prod after the release merge. Say the word and it becomes a pipeline job.

## Runbook — invite → claim → policy, against prod, before any UI exists

Run after the release merge that deploys this. Uses two throwaway accounts created through the normal sign-up path, and deletes them at the end.

```bash
SYNC=https://ql2e5b4hdjnfsns467vesieul40vbvsb.lambda-url.us-west-1.on.aws
POOL=us-west-1_jV7esPwmi
CLIENT=2t2l4fn537ttb3vul39olt3of3
REGION=us-west-1
OWNER_EMAIL=you+shareowner@example.com
CONTACT_EMAIL=you+sharecontact@example.com
PW='Runbook123'

# 1. Two throwaway accounts, normal sign-up (public API, no AWS credentials).
#    Cognito emails each a 6-digit code; confirm both.
for e in "$OWNER_EMAIL" "$CONTACT_EMAIL"; do
  aws cognito-idp sign-up --region $REGION --client-id $CLIENT \
    --username "$e" --password "$PW" --user-attributes Name=email,Value="$e"
done
aws cognito-idp confirm-sign-up --region $REGION --client-id $CLIENT \
  --username "$OWNER_EMAIL" --confirmation-code <code from email>
aws cognito-idp confirm-sign-up --region $REGION --client-id $CLIENT \
  --username "$CONTACT_EMAIL" --confirmation-code <code from email>

# 2. ID tokens. ADMIN_USER_PASSWORD_AUTH exists for exactly this (accounts.tf).
mint() {
  aws cognito-idp admin-initiate-auth --region $REGION --user-pool-id $POOL \
    --client-id $CLIENT --auth-flow ADMIN_USER_PASSWORD_AUTH \
    --auth-parameters USERNAME="$1",PASSWORD="$PW" \
    --query 'AuthenticationResult.IdToken' --output text
}
OWNER=$(mint "$OWNER_EMAIL"); CONTACT=$(mint "$CONTACT_EMAIL")
sub() { cut -d. -f2 <<<"$1" | base64 -d 2>/dev/null | jq -r .sub; }
OWNER_SUB=$(sub "$OWNER"); CONTACT_SUB=$(sub "$CONTACT")

# 3. A setup to share.
SETUP=$(uuidgen | tr 'A-Z' 'a-z')
curl -s -X PUT "$SYNC/setups/$SETUP" -H "authorization: Bearer $OWNER" \
  -H 'content-type: application/json' \
  -d '{"name":"Runbook","universe":1,"fixtures":[],"baseUpdatedAt":null}'; echo

# 4. Mint an invite  → {"code":"LUX-XXXXX-XXXXX","codeRef":"…","expiresAt":…}
CODE=$(curl -s -X POST "$SYNC/shares/invite" -H "authorization: Bearer $OWNER" \
  -H 'content-type: application/json' \
  -d "{\"setupId\":\"$SETUP\",\"label\":\"Runbook contact\"}" | jq -r .code)
echo "code: $CODE"

# 5. Claim it  → {"ownerSub":…,"ownerLabel":…,"setupId":…,"setupName":"Runbook"}
curl -s -X POST "$SYNC/shares/claim" -H "authorization: Bearer $CONTACT" \
  -H 'content-type: application/json' -d "{\"code\":\"$CODE\"}" | jq

# …and single use: the second claim must 404, in any spelling.
curl -s -o /dev/null -w 'replay: %{http_code}\n' -X POST "$SYNC/shares/claim" \
  -H "authorization: Bearer $CONTACT" -H 'content-type: application/json' \
  -d "{\"code\":\"$(tr 'A-Z' 'a-z' <<<"$CODE" | tr -d -)\"}"

# 6. Both lists agree.
curl -s "$SYNC/shares" -H "authorization: Bearer $OWNER"   | jq '{granted,pending}'
curl -s "$SYNC/shares" -H "authorization: Bearer $CONTACT" | jq '.received'

# 7. THE PROOF — the contact's connect-time policy now reaches the owner's setup.
#    (No --token-signature: the authorizer is registered signing_disabled.)
policy() {
  aws iot test-invoke-authorizer --region $REGION --authorizer-name lux-sync-auth \
    --token "$1" --query 'policyDocuments' --output text
}
policy "$CONTACT" | jq
```

Expect exactly two documents: the contact's own space unchanged, plus one granting

- publish `lux/ctl/user/$OWNER_SUB/setup/$SETUP/frame`
- publish + retain `lux/ctl/user/$OWNER_SUB/presence/$CONTACT_SUB-*`
- subscribe/receive `lux/ctl/user/$OWNER_SUB/setup/$SETUP/{state,config}`

and nothing wildcarded over the owner's space. Worth grepping for what must be absent:

```bash
policy "$CONTACT" | grep -E "user/$OWNER_SUB/\*|sync/user/$OWNER_SUB|presence/\*" && echo "LEAK" || echo "clean"

# 8. Leave from the contact's end; the second document disappears.
curl -s -X DELETE "$SYNC/shares/received/$OWNER_SUB/$SETUP" \
  -H "authorization: Bearer $CONTACT" | jq
policy "$CONTACT" | jq 'length'   # → 1

# 9. Deletion cleanup: re-claim (new code), then delete the OWNER and confirm
#    the contact's grant is gone from their side too.
#    → received: []   and the contact's policy is back to one document.
curl -s -X DELETE "$SYNC/user" -H "authorization: Bearer $OWNER" | jq
curl -s "$SYNC/shares" -H "authorization: Bearer $CONTACT" | jq '.received'
policy "$CONTACT" | jq 'length'   # → 1

# 10. Tear down.
for e in "$OWNER_EMAIL" "$CONTACT_EMAIL"; do
  aws cognito-idp admin-delete-user --region $REGION --user-pool-id $POOL --username "$e"
done
```

## Next

P2 is the surfaces: the retained-`Config` publisher in the applier (publish on setup change / first grant / reconnect, clear on setup delete / last revoke / sharing off), the owner's invite-and-manage UI in the setup dropdown, and the guest's "Shared with you" list rendering from `Config` and publishing `src`-attributed frames.
