### PR TITLE
feat(desktop): claim-code pairing — Add-device UI, device list, and revoke

### DIFF
--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -396,6 +396,113 @@ impl LuxAccount {
         })
     }
 
+    /// Pending (unclaimed) devices the auth service saw from the *caller's own*
+    /// public egress — the Add-device screen's list. The backend filters to
+    /// same-NAT, so a phone on cellular gets an empty list (not the venue's
+    /// boxes). No auth service configured means nothing to pair: an empty list.
+    pub fn list_pending_devices(&self) -> Result<Vec<lux_wire::device::PendingDevice>, String> {
+        let Some(base) = self.apple_auth_url.clone() else {
+            return Ok(Vec::new());
+        };
+        let Some(token) = self.current_id_token() else {
+            return Err("not signed in".into());
+        };
+        block_on(async move {
+            let response = reqwest::Client::new()
+                .get(format!(
+                    "{base}/{}/{}/{}",
+                    lux_wire::apple::AUTH_SEGMENT,
+                    lux_wire::device::DEVICE_SEGMENT,
+                    lux_wire::device::PENDING_SEGMENT
+                ))
+                .bearer_auth(token)
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            if !response.status().is_success() {
+                return Err(format!("device pending answered {}", response.status()));
+            }
+            response
+                .json::<lux_wire::device::PendingResponse>()
+                .await
+                .map(|r| r.devices)
+                .map_err(|e| e.to_string())
+        })
+    }
+
+    /// Approve a pending device: bind it to this account and the chosen setup
+    /// (the picker replaces `lux-node install`'s interactive list). The box's
+    /// next `/token` poll returns the grant and it comes online.
+    pub fn approve_device(
+        &self,
+        pair_ref: String,
+        setup_id: String,
+        universe: Option<u16>,
+        name: Option<String>,
+    ) -> Result<(), String> {
+        let Some(base) = self.apple_auth_url.clone() else {
+            return Err("device pairing is not available on this build".into());
+        };
+        let Some(token) = self.current_id_token() else {
+            return Err("not signed in".into());
+        };
+        block_on(async move {
+            let response = reqwest::Client::new()
+                .post(format!(
+                    "{base}/{}/{}/{}",
+                    lux_wire::apple::AUTH_SEGMENT,
+                    lux_wire::device::DEVICE_SEGMENT,
+                    lux_wire::device::APPROVE_SEGMENT
+                ))
+                .bearer_auth(token)
+                .json(&lux_wire::device::ApproveRequest {
+                    pair_ref,
+                    setup_id,
+                    universe,
+                    name,
+                })
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            if response.status().is_success() {
+                Ok(())
+            } else {
+                Err(format!("device approve answered {}", response.status()))
+            }
+        })
+    }
+
+    /// Remove a paired device from the account registry ("Remove device"). The
+    /// box drops out of the device list immediately; cutting its live IoT
+    /// access is a later (authorizer-level) phase.
+    pub fn revoke_device(&self, device_id: String) -> Result<(), String> {
+        let Some(base) = self.apple_auth_url.clone() else {
+            return Err("device pairing is not available on this build".into());
+        };
+        let Some(token) = self.current_id_token() else {
+            return Err("not signed in".into());
+        };
+        block_on(async move {
+            let response = reqwest::Client::new()
+                .post(format!(
+                    "{base}/{}/{}/{}",
+                    lux_wire::apple::AUTH_SEGMENT,
+                    lux_wire::device::DEVICE_SEGMENT,
+                    lux_wire::device::REVOKE_SEGMENT
+                ))
+                .bearer_auth(token)
+                .json(&lux_wire::device::RevokeRequest { device_id })
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            if response.status().is_success() {
+                Ok(())
+            } else {
+                Err(format!("device revoke answered {}", response.status()))
+            }
+        })
+    }
+
     pub fn sign_out(&self) -> AuthStatus {
         clear_session();
         self.session.lock_or_recover().clear();

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -124,8 +124,21 @@ pub trait CmdMethods {
     // don't reliably reach the webview on iOS).
     fn list_remote_peers(&self, app_handle: AppHandle) -> Result<Vec<RemotePeer>, String>;
     // Paired headless devices (lux-node boxes) from the account's registry —
-    // the delete-account confirm shows them so the blast radius is visible.
+    // the Devices list, and the delete-account confirm (blast radius).
     fn list_paired_devices(&self, app_handle: AppHandle) -> Result<Vec<PairedDevice>, String>;
+    // Add-device pairing: the same-egress pending list, then approve one onto a
+    // setup, then remove a paired device. Sync (blocking HTTP off-thread, like
+    // list_paired_devices) — the UI polls the pending list while its dialog is open.
+    fn list_pending_devices(&self, app_handle: AppHandle) -> Result<Vec<PendingDevice>, String>;
+    fn approve_device(
+        &self,
+        app_handle: AppHandle,
+        pair_ref: String,
+        setup_id: String,
+        universe: Option<u16>,
+        name: Option<String>,
+    ) -> Result<(), String>;
+    fn remove_device(&self, app_handle: AppHandle, device_id: String) -> Result<(), String>;
     // DMX output — the in-app device picker (the only output selector on mobile,
     // where there's no tray). Mirrors the desktop tray's device menu.
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String>;
@@ -136,13 +149,34 @@ pub trait CmdMethods {
     ) -> Result<Vec<DmxDeviceInfo>, String>;
     fn rescan_dmx_devices(&self, app_handle: AppHandle) -> Result<(), String>;
 }
-/// One paired headless device (a lux-node box) on the account, thinned from
-/// [`lux_wire::device::DeviceRecord`] to what the confirm dialog shows.
+/// One paired headless device (a lux-node box) on the account, mirrored from
+/// [`lux_wire::device::DeviceRecord`] for the Devices list and the
+/// delete-account confirm's tally. `paired_at` is epoch millis (an `f64` so it
+/// crosses to the webview as a plain `number`).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct PairedDevice {
+    pub device_id: String,
     pub name: String,
     pub hostname: String,
+    pub setup_id: String,
+    pub universe: u16,
+    pub paired_at: f64,
+}
+
+/// One pending (unclaimed, same-egress) device on the Add-device screen,
+/// mirrored from [`lux_wire::device::PendingDevice`]. `pair_ref` is the opaque
+/// handle the approve call takes; `first_seen` is epoch millis as an `f64`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingDevice {
+    pub pair_ref: String,
+    pub user_code: String,
+    pub hostname: String,
+    pub mac_tail: String,
+    pub version: String,
+    pub arch: String,
+    pub first_seen: f64,
 }
 
 #[derive(ttipc::Event)]
@@ -471,10 +505,48 @@ impl CmdMethods for CmdEndpoint {
             .list_paired_devices()?
             .into_iter()
             .map(|d| PairedDevice {
+                device_id: d.device_id,
                 name: d.name,
                 hostname: d.hostname,
+                setup_id: d.setup_id,
+                universe: d.universe,
+                paired_at: d.paired_at as f64,
             })
             .collect())
+    }
+
+    fn list_pending_devices(&self, app_handle: AppHandle) -> Result<Vec<PendingDevice>, String> {
+        Ok(app_handle
+            .state::<LuxAccount>()
+            .list_pending_devices()?
+            .into_iter()
+            .map(|d| PendingDevice {
+                pair_ref: d.pair_ref,
+                user_code: d.user_code,
+                hostname: d.hostname,
+                mac_tail: d.mac_tail,
+                version: d.version,
+                arch: d.arch,
+                first_seen: d.first_seen as f64,
+            })
+            .collect())
+    }
+
+    fn approve_device(
+        &self,
+        app_handle: AppHandle,
+        pair_ref: String,
+        setup_id: String,
+        universe: Option<u16>,
+        name: Option<String>,
+    ) -> Result<(), String> {
+        app_handle
+            .state::<LuxAccount>()
+            .approve_device(pair_ref, setup_id, universe, name)
+    }
+
+    fn remove_device(&self, app_handle: AppHandle, device_id: String) -> Result<(), String> {
+        app_handle.state::<LuxAccount>().revoke_device(device_id)
     }
 
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String> {

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -160,6 +160,21 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  list_pending_devices(): Promise<PendingDevice[]> {
+    return invoke("cmd.list_pending_devices");
+  },
+
+  /** @throws {string} */
+  approve_device(pairRef: string, setupId: string, universe: number | null, name: string | null): Promise<null> {
+    return invoke("cmd.approve_device", { pair_ref: pairRef, setup_id: setupId, universe, name });
+  },
+
+  /** @throws {string} */
+  remove_device(deviceId: string): Promise<null> {
+    return invoke("cmd.remove_device", { device_id: deviceId });
+  },
+
+  /** @throws {string} */
   list_dmx_devices(): Promise<DmxDeviceInfo[]> {
     return invoke("cmd.list_dmx_devices");
   },
@@ -298,12 +313,33 @@ export type LuxLabelColor = "Red" | "Green" | "Blue" | "Amber" | "White" | "Brig
 "Generic";
 
 /**
- *  One paired headless device (a lux-node box) on the account, thinned from
- *  [`lux_wire::device::DeviceRecord`] to what the confirm dialog shows.
+ *  One paired headless device (a lux-node box) on the account, mirrored from
+ *  [`lux_wire::device::DeviceRecord`] for the Devices list and the
+ *  delete-account confirm's tally. `paired_at` is epoch millis (an `f64` so it
+ *  crosses to the webview as a plain `number`).
  */
 export type PairedDevice = {
+	deviceId: string,
 	name: string,
 	hostname: string,
+	setupId: string,
+	universe: number,
+	pairedAt: number | null,
+};
+
+/**
+ *  One pending (unclaimed, same-egress) device on the Add-device screen,
+ *  mirrored from [`lux_wire::device::PendingDevice`]. `pair_ref` is the opaque
+ *  handle the approve call takes; `first_seen` is epoch millis as an `f64`.
+ */
+export type PendingDevice = {
+	pairRef: string,
+	userCode: string,
+	hostname: string,
+	macTail: string,
+	version: string,
+	arch: string,
+	firstSeen: number | null,
 };
 
 /**

--- a/apps/desktop/src/components/devices-dialog.tsx
+++ b/apps/desktop/src/components/devices-dialog.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, MonitorSmartphone, Trash2, Wifi } from "lucide-react";
+import { createTauRPCProxy, type PairedDevice, type PendingDevice } from "@/bindings";
+import useAuth from "@/hooks/useAuth";
+import useRemotePeers from "@/hooks/useRemotePeers";
+import useSetups from "@/hooks/useSetups";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const cmd = () => createTauRPCProxy().cmd;
+
+/** Query key for the account's paired lux-node boxes (also used by the delete-account confirm). */
+export const PAIRED_DEVICES_QUERY_KEY = ["pairedDevices"] as const;
+/** Query key for the same-egress pending devices on the Add-device screen. */
+export const PENDING_DEVICES_QUERY_KEY = ["pendingDevices"] as const;
+
+/**
+ * Settings → Devices: pair a headless lux-node box and manage the ones already
+ * paired.
+ *
+ * Add flow (docs/claim-code-pairing.md): the box registers over HTTPS and the
+ * backend only lists registrations that share the caller's public egress, so a
+ * phone on the venue Wi-Fi sees the box on the venue ethernet — the human
+ * confirms identity by matching the short code / MAC tail on the box's label,
+ * picks the setup it should drive, and approves. The box's retained presence
+ * card is the success signal, so a paired box flips to online (reusing the same
+ * presence handling as the remote indicator) once it connects.
+ *
+ * Remove drops the box from the account registry; it disappears from this list.
+ */
+export default function DevicesDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const status = useAuth();
+  const signedIn = !!status?.signedIn;
+  const queryClient = useQueryClient();
+  const setups = useSetups();
+  const peers = useRemotePeers();
+
+  // Transient UI state, reset whenever the dialog closes.
+  const [expanded, setExpanded] = useState<string | null>(null); // pairRef of the device being approved
+  const [chosenSetup, setChosenSetup] = useState<string | null>(null);
+  const [busyRef, setBusyRef] = useState<string | null>(null); // pairRef mid-approve
+  const [armedRemove, setArmedRemove] = useState<string | null>(null); // deviceId armed for removal
+  useEffect(() => {
+    if (!open) {
+      setExpanded(null);
+      setChosenSetup(null);
+      setBusyRef(null);
+      setArmedRemove(null);
+    }
+  }, [open]);
+
+  const { data: paired } = useQuery({
+    queryKey: PAIRED_DEVICES_QUERY_KEY,
+    queryFn: () => cmd().list_paired_devices(),
+    enabled: signedIn && open,
+    // A just-approved box appears here and comes online within a poll or two.
+    refetchInterval: open ? 3000 : false,
+  });
+  const { data: pending } = useQuery({
+    queryKey: PENDING_DEVICES_QUERY_KEY,
+    queryFn: () => cmd().list_pending_devices(),
+    enabled: signedIn && open,
+    refetchInterval: open ? 3000 : false,
+  });
+
+  const refresh = () => {
+    queryClient.invalidateQueries({ queryKey: PAIRED_DEVICES_QUERY_KEY });
+    queryClient.invalidateQueries({ queryKey: PENDING_DEVICES_QUERY_KEY });
+  };
+
+  // A paired box is "online" when a retained presence card matches its setup
+  // and hostname — the node publishes `lux-node (<hostname>)` on the setup it
+  // drives, the same signal the remote indicator reads.
+  const isOnline = (d: PairedDevice) =>
+    !!peers?.some((p) => p.setupId === d.setupId && p.name.includes(d.hostname));
+
+  const toggleExpand = (pairRef: string) => {
+    setExpanded((cur) => (cur === pairRef ? null : pairRef));
+    setChosenSetup(null);
+  };
+
+  const approve = async (device: PendingDevice) => {
+    if (!chosenSetup) {
+      toast.error("Pick a setup for this device first.");
+      return;
+    }
+    const setup = setups?.find((s) => s.id === chosenSetup);
+    setBusyRef(device.pairRef);
+    try {
+      await cmd().approve_device(
+        device.pairRef,
+        chosenSetup,
+        setup?.universe ?? null,
+        null,
+      );
+      toast.success(`Approved ${device.hostname}. Waiting for it to come online…`);
+      setExpanded(null);
+      setChosenSetup(null);
+      refresh();
+    } catch (e) {
+      toast.error(String(e));
+    } finally {
+      setBusyRef(null);
+    }
+  };
+
+  const remove = async (device: PairedDevice) => {
+    try {
+      await cmd().remove_device(device.deviceId);
+      toast.success(`Removed ${device.name}.`);
+      setArmedRemove(null);
+      refresh();
+    } catch (e) {
+      toast.error(String(e));
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Devices</DialogTitle>
+          <DialogDescription>
+            Pair a lux-node box and manage the ones already on your account.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!signedIn ? (
+          <p className="py-4 text-sm text-muted-foreground">
+            Sign in to pair and manage devices.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-5">
+            {/* Paired devices */}
+            <section className="flex flex-col gap-2">
+              <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Paired
+              </h3>
+              {paired && paired.length > 0 ? (
+                <ul className="flex flex-col gap-1.5">
+                  {paired.map((d) => (
+                    <li
+                      key={d.deviceId}
+                      className="flex items-center gap-3 rounded-md border px-3 py-2"
+                    >
+                      <span
+                        className={cn(
+                          "size-2 shrink-0 rounded-full",
+                          isOnline(d) ? "bg-emerald-500" : "bg-muted-foreground/40",
+                        )}
+                        aria-label={isOnline(d) ? "online" : "offline"}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium">{d.name}</div>
+                        <div className="truncate text-xs text-muted-foreground">
+                          {d.hostname} · universe {d.universe}
+                        </div>
+                      </div>
+                      {armedRemove === d.deviceId ? (
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => remove(d)}
+                        >
+                          Confirm remove
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-muted-foreground hover:text-destructive"
+                          aria-label={`Remove ${d.name}`}
+                          onClick={() => setArmedRemove(d.deviceId)}
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-muted-foreground">No paired devices yet.</p>
+              )}
+            </section>
+
+            {/* Add device */}
+            <section className="flex flex-col gap-2">
+              <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Add a device
+              </h3>
+              {pending && pending.length > 0 ? (
+                <ul className="flex flex-col gap-1.5">
+                  {pending.map((p) => {
+                    const isExpanded = expanded === p.pairRef;
+                    return (
+                      <li key={p.pairRef} className="rounded-md border">
+                        <button
+                          type="button"
+                          className="flex w-full items-center gap-3 px-3 py-2 text-left"
+                          onClick={() => toggleExpand(p.pairRef)}
+                        >
+                          <MonitorSmartphone className="size-4 shrink-0 text-muted-foreground" />
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-sm font-medium">
+                              {p.hostname}
+                            </div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              MAC …{p.macTail} · v{p.version}
+                            </div>
+                          </div>
+                          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
+                            {p.userCode}
+                          </code>
+                        </button>
+                        {isExpanded ? (
+                          <div className="flex flex-col gap-2 border-t px-3 py-2">
+                            <p className="text-xs text-muted-foreground">
+                              Confirm <span className="font-medium">{p.userCode}</span>{" "}
+                              and MAC …{p.macTail} on the box's label, then pick the
+                              setup it should drive.
+                            </p>
+                            {setups && setups.length > 0 ? (
+                              <div className="flex flex-wrap gap-1.5">
+                                {setups.map((s) => (
+                                  <Button
+                                    key={s.id}
+                                    variant={chosenSetup === s.id ? "default" : "outline"}
+                                    size="sm"
+                                    onClick={() => setChosenSetup(s.id)}
+                                  >
+                                    {chosenSetup === s.id ? (
+                                      <Check className="size-3.5" />
+                                    ) : null}
+                                    {s.name}
+                                    <span className="opacity-60">U{s.universe}</span>
+                                  </Button>
+                                ))}
+                              </div>
+                            ) : (
+                              <p className="text-xs text-muted-foreground">
+                                Create a setup first, then assign this device to it.
+                              </p>
+                            )}
+                            <div className="flex justify-end">
+                              <Button
+                                size="sm"
+                                disabled={!chosenSetup || busyRef === p.pairRef}
+                                onClick={() => approve(p)}
+                              >
+                                {busyRef === p.pairRef ? "…" : "Approve"}
+                              </Button>
+                            </div>
+                          </div>
+                        ) : null}
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <div className="flex items-start gap-2 rounded-md border border-dashed px-3 py-3 text-sm text-muted-foreground">
+                  <Wifi className="mt-0.5 size-4 shrink-0" />
+                  <span>
+                    No devices found. Join the venue's Wi-Fi to add a box on the same
+                    network — a device on cellular won't appear here.
+                  </span>
+                </div>
+              )}
+            </section>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/settings-menu.tsx
+++ b/apps/desktop/src/components/settings-menu.tsx
@@ -1,24 +1,32 @@
+import { useState } from "react";
 import { toast } from "sonner";
-import { Settings } from "lucide-react";
+import { MonitorSmartphone, Settings } from "lucide-react";
 import type { SliderOrientation } from "@/bindings";
+import useAuth from "@/hooks/useAuth";
 import { useSliderOrientation } from "@/hooks/useSettings";
 import { setSliderOrientation } from "@/lib/actions";
 import { Button } from "@/components/ui/button";
+import DevicesDialog from "@/components/devices-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
 /**
  * App settings in the nav — user preferences that persist on this device and
- * sync to the account when signed in. Currently: the desk's fader orientation.
+ * sync to the account when signed in (the desk's fader orientation), plus the
+ * Devices manager (pair/remove headless lux-node boxes) once signed in.
  */
 export default function SettingsMenu() {
   const orientation = useSliderOrientation();
+  const status = useAuth();
+  const [devicesOpen, setDevicesOpen] = useState(false);
 
   const onOrientationChange = (value: string) => {
     setSliderOrientation(value as SliderOrientation).catch((e) =>
@@ -27,33 +35,48 @@ export default function SettingsMenu() {
   };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="px-2 text-muted-foreground hover:text-foreground"
-          aria-label="Settings"
-        >
-          <Settings className="size-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-48">
-        <DropdownMenuLabel className="font-normal text-muted-foreground">
-          Slider orientation
-        </DropdownMenuLabel>
-        <DropdownMenuRadioGroup
-          value={orientation}
-          onValueChange={onOrientationChange}
-        >
-          <DropdownMenuRadioItem value="vertical">
-            Vertical
-          </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="horizontal">
-            Horizontal
-          </DropdownMenuRadioItem>
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="px-2 text-muted-foreground hover:text-foreground"
+            aria-label="Settings"
+          >
+            <Settings className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuLabel className="font-normal text-muted-foreground">
+            Slider orientation
+          </DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={orientation}
+            onValueChange={onOrientationChange}
+          >
+            <DropdownMenuRadioItem value="vertical">
+              Vertical
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="horizontal">
+              Horizontal
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+          {status?.signedIn ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() => setDevicesOpen(true)}
+                className="gap-2"
+              >
+                <MonitorSmartphone className="size-4" /> Devices…
+              </DropdownMenuItem>
+            </>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DevicesDialog open={devicesOpen} onOpenChange={setDevicesOpen} />
+    </>
   );
 }

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -238,17 +238,20 @@ pub mod device {
     //! - `POST /auth/device/token`     — device: poll for the grant
     //! - `GET  /auth/device/pending`   — bearer-authed: same-egress pending list
     //! - `POST /auth/device/approve`   — bearer-authed: approve one device
+    //! - `GET  /auth/device/list`      — bearer-authed: the owner's paired devices
+    //! - `POST /auth/device/revoke`    — bearer-authed: remove a paired device
 
     use serde::{Deserialize, Serialize};
 
     /// Path segments under [`super::apple::AUTH_SEGMENT`]:
-    /// `/auth/device/{authorize|token|pending|approve}`.
+    /// `/auth/device/{authorize|token|pending|approve|list|revoke}`.
     pub const DEVICE_SEGMENT: &str = "device";
     pub const AUTHORIZE_SEGMENT: &str = "authorize";
     pub const TOKEN_SEGMENT: &str = "token";
     pub const PENDING_SEGMENT: &str = "pending";
     pub const APPROVE_SEGMENT: &str = "approve";
     pub const LIST_SEGMENT: &str = "list";
+    pub const REVOKE_SEGMENT: &str = "revoke";
 
     /// Body for `POST /auth/device/authorize`. Everything here is display
     /// metadata for the approve screen — identity is established by approval,
@@ -379,6 +382,26 @@ pub mod device {
     #[serde(rename_all = "camelCase")]
     pub struct ListResponse {
         pub devices: Vec<DeviceRecord>,
+    }
+
+    /// Body for `POST /auth/device/revoke` — bearer-authed: the owner removes
+    /// one of their paired devices. v1 is data-plane only — the device drops
+    /// out of [`ListResponse`] at once; cutting the box's live IoT access is
+    /// authorizer-level enforcement, a deliberately deferred design
+    /// open-question (docs/claim-code-pairing.md §Revocation).
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct RevokeRequest {
+        /// [`DeviceRecord::device_id`] of the device to remove.
+        pub device_id: String,
+    }
+
+    /// Response to a `POST /auth/device/revoke`. `revoked` is `false` only when
+    /// the caller owns no such device (an idempotent no-op, not an error).
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct RevokeResponse {
+        pub revoked: bool,
     }
 }
 
@@ -929,6 +952,43 @@ mod tests {
         assert_eq!(device::TOKEN_SEGMENT, "token");
         assert_eq!(device::PENDING_SEGMENT, "pending");
         assert_eq!(device::APPROVE_SEGMENT, "approve");
+        assert_eq!(device::LIST_SEGMENT, "list");
+        assert_eq!(device::REVOKE_SEGMENT, "revoke");
+    }
+
+    #[test]
+    fn device_list_and_revoke_shapes() {
+        let record = device::DeviceRecord {
+            device_id: "d-1".into(),
+            name: "Stage node".into(),
+            hostname: "venue-node".into(),
+            setup_id: "s-1".into(),
+            universe: 1,
+            paired_at: 1_700_000_000_000,
+        };
+        assert_eq!(
+            serde_json::to_string(&record).unwrap(),
+            r#"{"deviceId":"d-1","name":"Stage node","hostname":"venue-node","setupId":"s-1","universe":1,"pairedAt":1700000000000}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&device::ListResponse {
+                devices: vec![record],
+            })
+            .unwrap(),
+            r#"{"devices":[{"deviceId":"d-1","name":"Stage node","hostname":"venue-node","setupId":"s-1","universe":1,"pairedAt":1700000000000}]}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&device::ApproveResponse { approved: true }).unwrap(),
+            r#"{"approved":true}"#
+        );
+
+        // Revoke: request parses the app's body, response is a bare flag.
+        let req: device::RevokeRequest = serde_json::from_str(r#"{"deviceId":"d-1"}"#).unwrap();
+        assert_eq!(req.device_id, "d-1");
+        assert_eq!(
+            serde_json::to_string(&device::RevokeResponse { revoked: true }).unwrap(),
+            r#"{"revoked":true}"#
+        );
     }
 
     #[test]

--- a/services/apple-auth/src/device.rs
+++ b/services/apple-auth/src/device.rs
@@ -19,7 +19,8 @@ use std::sync::Arc;
 use lambda_runtime::Error;
 use lux_wire::device::{
     ApproveRequest, ApproveResponse, AuthorizeRequest, AuthorizeResponse, DeviceRecord,
-    ListResponse, PendingDevice, PendingResponse, TokenRequest, TokenResponse,
+    ListResponse, PendingDevice, PendingResponse, RevokeRequest, RevokeResponse, TokenRequest,
+    TokenResponse,
 };
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -196,6 +197,7 @@ pub async fn list(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
     };
     let devices: Vec<DeviceRecord> = rows
         .iter()
+        .filter(|item| item.get("revoked").and_then(|v| v.as_bool().ok()) != Some(&true))
         .filter_map(|item| {
             let s = |k: &str| item.get(k)?.as_s().ok().cloned();
             let n = |k: &str| {
@@ -214,6 +216,28 @@ pub async fn list(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
         })
         .collect();
     reply(200, &ListResponse { devices })
+}
+
+/// `POST /auth/device/revoke` — bearer-authed: the owner removes one of their
+/// paired devices. Data-plane only in v1: the device drops out of `/list` at
+/// once (a revoked registry row), but cutting the box's live IoT access is
+/// authorizer-level enforcement, deferred by design. Removing a device the
+/// caller doesn't own is an idempotent no-op (`revoked: false`), never an error.
+pub async fn revoke(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
+    let Some(caller_sub) = caller(ctx, event) else {
+        return reply(401, &error("invalid or missing token"));
+    };
+    let req: RevokeRequest = match parse_body(event) {
+        Ok(b) => b,
+        Err(e) => return reply(400, &error(&e)),
+    };
+    match store::revoke_device(ctx, &caller_sub, &req.device_id).await {
+        Ok(revoked) => reply(200, &RevokeResponse { revoked }),
+        Err(e) => {
+            tracing::error!("device revoke failed: {e}");
+            reply(500, &error("internal"))
+        }
+    }
 }
 
 /// `GET /auth/device/pending` — bearer-authed: unexpired registrations that

--- a/services/apple-auth/src/http.rs
+++ b/services/apple-auth/src/http.rs
@@ -65,7 +65,7 @@ pub async fn handle(ctx: &Arc<Ctx>, payload: Value) -> Result<Value, Error> {
 
     use lux_wire::device::{
         APPROVE_SEGMENT, AUTHORIZE_SEGMENT, DEVICE_SEGMENT, LIST_SEGMENT, PENDING_SEGMENT,
-        TOKEN_SEGMENT,
+        REVOKE_SEGMENT as DEVICE_REVOKE_SEGMENT, TOKEN_SEGMENT,
     };
 
     match (method, segments.as_slice()) {
@@ -102,6 +102,11 @@ pub async fn handle(ctx: &Arc<Ctx>, payload: Value) -> Result<Value, Error> {
             if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == APPROVE_SEGMENT =>
         {
             crate::device::approve(ctx, &event).await
+        }
+        ("POST", [a, b, c])
+            if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == DEVICE_REVOKE_SEGMENT =>
+        {
+            crate::device::revoke(ctx, &event).await
         }
         _ => reply(404, &error("not found")),
     }

--- a/services/apple-auth/src/store.rs
+++ b/services/apple-auth/src/store.rs
@@ -475,6 +475,39 @@ pub async fn approve_pair(
     Ok(())
 }
 
+/// Mark one of the owner's paired devices revoked (soft delete: the row stays
+/// for audit, carrying `revoked`/`revokedAt`, and drops out of `/list`). Returns
+/// `false` when the caller owns no such device — an idempotent no-op, not an
+/// error. Data-plane only; the box's live access is cut at the authorizer in a
+/// later phase (docs/claim-code-pairing.md §Revocation).
+pub async fn revoke_device(ctx: &Ctx, sub: &str, device_id: &str) -> Result<bool, String> {
+    let result = ctx
+        .ddb
+        .update_item()
+        .table_name(&ctx.table)
+        .key("pk", AttributeValue::S(device_pk(sub)))
+        .key("sk", AttributeValue::S(device_id.to_owned()))
+        .update_expression("SET #rv = :true, revokedAt = :now")
+        .condition_expression("attribute_exists(pk)")
+        .expression_attribute_names("#rv", "revoked")
+        .expression_attribute_values(":true", AttributeValue::Bool(true))
+        .expression_attribute_values(":now", AttributeValue::N(now_millis().to_string()))
+        .send()
+        .await;
+    match result {
+        Ok(_) => Ok(true),
+        Err(e) => {
+            if e.as_service_error()
+                .is_some_and(|se| se.is_conditional_check_failed_exception())
+            {
+                Ok(false)
+            } else {
+                Err(format!("device revoke failed: {e}"))
+            }
+        }
+    }
+}
+
 /// Claim an approved grant for redemption — the single-use gate. Exactly one
 /// caller wins the `approved → redeemed` flip; everyone else hits the
 /// condition. (If the mint after this fails, the code is burned and the node


### PR DESCRIPTION
Phase 4 of the claim-code pairing flow (docs/claim-code-pairing.md) — the app side. Phases 1–3 (backend routes/trigger, node state machine) are merged; this adds the Settings → Devices UI, the paired-device list with removal, and the `/auth/device/revoke` route that removal needs.

## Settings → Devices
A "Devices…" item in the settings (gear) menu — shown when signed in — opens a dialog:

**Add a device.** Lists `GET /auth/device/pending` (the backend filters to the caller's own NAT egress, so a phone on the venue Wi-Fi sees the box on the venue ethernet; cellular gets an empty list + a "join the venue's Wi-Fi" hint). Tap a device to confirm its `user_code` + MAC tail against the box's label, pick the setup it should drive, and Approve (`POST /auth/device/approve`). The box comes online and its retained presence card flips it to "online" in the Paired list — reusing the exact presence handling the remote indicator already uses (`useRemotePeers`).

**Paired.** Lists `GET /auth/device/list` with presence-derived health (green = a matching presence card is live) and a two-tap **Remove** (armed-confirm, like the setup switcher's delete).

Device naming defaults to hostname (design open-question 5); no rename UI (it doesn't fall out trivially, and the design leaves it optional).

## Revoke route (`services/apple-auth`)
`POST /auth/device/revoke` — bearer-authed, body `{deviceId}`. Soft-deletes the owner's `DEVICE#<sub>/<device_id>` registry row (sets `revoked`/`revokedAt`); revoked rows drop out of `/list`. Removing a device the caller doesn't own is an idempotent no-op (`revoked: false`), never an error.

**v1 is data-plane only.** The box disappears from the account's device list, but cutting its *live* IoT access is authorizer-level enforcement — design open-question 2, deliberately deferred (docs/claim-code-pairing.md §Revocation). No infra change: the auth role already grants `dynamodb:UpdateItem` on the `DEVICE#*` partition (infra/apple-auth.tf).

## Wire + bindings
- lux-wire `device` module gains `REVOKE_SEGMENT` + `RevokeRequest`/`RevokeResponse`, with golden tests (and backfilled golden coverage for the `list`/`revoke` shapes).
- The thinned `PairedDevice` ttipc type is widened to the full `DeviceRecord` (device_id/setup_id/universe/paired_at) for the list + remove, and a `PendingDevice` type is added for the add flow. New ttipc commands: `list_pending_devices`, `approve_device`, `remove_device`.
- `apps/desktop/src/bindings.ts` was **regenerated** (`REGEN_BINDINGS=1 cargo test -p lux --test bindings`), not hand-edited; the drift test passes.

## Verified locally
`cargo clippy` (lux, lux-apple-auth, lux-wire) clean under `-D warnings`; lux-wire golden tests, apple-auth tests, and the bindings drift test pass; frontend `typecheck` + `lint` + `vite build` clean.
