### PR TITLE
fix(shares): fallible retained-config clear, and the runbook in-repo

### DIFF
--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -569,7 +569,9 @@ impl CmdMethods for CmdEndpoint {
     fn list_shares(&self, app_handle: AppHandle) -> Result<ShareTally, String> {
         let shares = crate::cloud::list_shares(&app_handle)?;
         // One person can hold several of the caller's setups; the dialog is
-        // counting people, so fold by account and keep first-seen order.
+        // counting people, so fold by account. Sorted by sub rather than kept
+        // in list order because the dedup below is adjacent-only, and a stable
+        // order beats DynamoDB's for a sentence a human reads.
         let names = |mut seen: Vec<(String, String)>| -> Vec<String> {
             seen.dedup_by(|a, b| a.0 == b.0);
             seen.into_iter().map(|(_, label)| label).collect()

--- a/docs/shared-control.md
+++ b/docs/shared-control.md
@@ -116,6 +116,104 @@ Clearing retained config is done **server-side**, not by the app before it signs
 
 The delete-account confirm shows both directions before it happens, alongside the setup and paired-device counts.
 
+## Verifying it end to end
+
+There is no UI for any of this in phase 1, so the proof is a runbook. It creates two throwaway accounts through the normal sign-up path, walks invite → claim → policy, and deletes them again. Run it against a stack after the backend deploys there.
+
+```bash
+SYNC=$(aws lambda get-function-url-config --function-name lux-sync-api --query FunctionUrl --output text)
+POOL=us-west-1_jV7esPwmi
+CLIENT=2t2l4fn537ttb3vul39olt3of3
+REGION=us-west-1
+OWNER_EMAIL=you+shareowner@example.com
+CONTACT_EMAIL=you+sharecontact@example.com
+PW='Runbook123'
+
+# 1. Two throwaway accounts (public API, no AWS credentials). Cognito emails
+#    each a 6-digit code; confirm both before continuing.
+for e in "$OWNER_EMAIL" "$CONTACT_EMAIL"; do
+  aws cognito-idp sign-up --region $REGION --client-id $CLIENT \
+    --username "$e" --password "$PW" --user-attributes Name=email,Value="$e"
+done
+aws cognito-idp confirm-sign-up --region $REGION --client-id $CLIENT \
+  --username "$OWNER_EMAIL" --confirmation-code <code from email>
+aws cognito-idp confirm-sign-up --region $REGION --client-id $CLIENT \
+  --username "$CONTACT_EMAIL" --confirmation-code <code from email>
+
+# 2. ID tokens. ADMIN_USER_PASSWORD_AUTH exists for exactly this (accounts.tf).
+mint() {
+  aws cognito-idp admin-initiate-auth --region $REGION --user-pool-id $POOL \
+    --client-id $CLIENT --auth-flow ADMIN_USER_PASSWORD_AUTH \
+    --auth-parameters USERNAME="$1",PASSWORD="$PW" \
+    --query 'AuthenticationResult.IdToken' --output text
+}
+OWNER=$(mint "$OWNER_EMAIL"); CONTACT=$(mint "$CONTACT_EMAIL")
+sub() { cut -d. -f2 <<<"$1" | base64 -d 2>/dev/null | jq -r .sub; }
+OWNER_SUB=$(sub "$OWNER"); CONTACT_SUB=$(sub "$CONTACT")
+
+# 3. A setup to share.
+SETUP=$(uuidgen | tr 'A-Z' 'a-z')
+curl -s -X PUT "$SYNC/setups/$SETUP" -H "authorization: Bearer $OWNER" \
+  -H 'content-type: application/json' \
+  -d '{"name":"Runbook","universe":1,"fixtures":[],"baseUpdatedAt":null}'; echo
+
+# 4. Mint an invite  → {"code":"LUX-XXXXX-XXXXX","codeRef":"…","expiresAt":…}
+CODE=$(curl -s -X POST "$SYNC/shares/invite" -H "authorization: Bearer $OWNER" \
+  -H 'content-type: application/json' \
+  -d "{\"setupId\":\"$SETUP\",\"label\":\"Runbook contact\"}" | jq -r .code)
+echo "code: $CODE"
+
+# 5. Claim it  → {"ownerSub":…,"ownerLabel":…,"setupId":…,"setupName":"Runbook"}
+curl -s -X POST "$SYNC/shares/claim" -H "authorization: Bearer $CONTACT" \
+  -H 'content-type: application/json' -d "{\"code\":\"$CODE\"}" | jq
+
+# …and single use: the replay must 404, in any spelling.
+curl -s -o /dev/null -w 'replay: %{http_code}\n' -X POST "$SYNC/shares/claim" \
+  -H "authorization: Bearer $CONTACT" -H 'content-type: application/json' \
+  -d "{\"code\":\"$(tr 'A-Z' 'a-z' <<<"$CODE" | tr -d -)\"}"
+
+# 6. Both lists agree.
+curl -s "$SYNC/shares" -H "authorization: Bearer $OWNER"   | jq '{granted,pending}'
+curl -s "$SYNC/shares" -H "authorization: Bearer $CONTACT" | jq '.received'
+
+# 7. THE PROOF — the contact's connect-time policy now reaches the owner's setup.
+#    No --token-signature: the authorizer is registered signing_disabled.
+policy() {
+  aws iot test-invoke-authorizer --region $REGION --authorizer-name lux-sync-auth \
+    --token "$1" --query 'policyDocuments' --output text
+}
+policy "$CONTACT" | jq
+```
+
+Step 7 must return exactly two documents: the contact's own space unchanged, plus one granting
+
+- publish `lux/ctl/user/$OWNER_SUB/setup/$SETUP/frame` and `lux/ctl/user/$OWNER_SUB/presence/$CONTACT_SUB`
+- retain-publish `lux/ctl/user/$OWNER_SUB/presence/$CONTACT_SUB` — that topic and nothing else
+- subscribe/receive `lux/ctl/user/$OWNER_SUB/setup/$SETUP/{state,config}`
+
+The presence resource is an exact topic with no trailing wildcard; a `*` anywhere in it is a bug, not a formatting difference. Worth grepping for what must be absent:
+
+```bash
+policy "$CONTACT" | grep -E "user/$OWNER_SUB/\*|sync/user/$OWNER_SUB|presence/\*|presence/$CONTACT_SUB-" \
+  && echo "LEAK" || echo "clean"
+
+# 8. Leave from the contact's end; the second document disappears.
+curl -s -X DELETE "$SYNC/shares/received/$OWNER_SUB/$SETUP" \
+  -H "authorization: Bearer $CONTACT" | jq
+policy "$CONTACT" | jq 'length'   # → 1
+
+# 9. Deletion cleanup: re-claim with a fresh code, then delete the OWNER and
+#    confirm the grant is gone from the contact's side too.
+curl -s -X DELETE "$SYNC/user" -H "authorization: Bearer $OWNER" | jq
+curl -s "$SYNC/shares" -H "authorization: Bearer $CONTACT" | jq '.received'  # → []
+policy "$CONTACT" | jq 'length'   # → 1
+
+# 10. Tear down.
+for e in "$OWNER_EMAIL" "$CONTACT_EMAIL"; do
+  aws cognito-idp admin-delete-user --region $REGION --user-pool-id $POOL --username "$e"
+done
+```
+
 ## Accepted limits
 
 - **Presence can go stale.** A connection has exactly one Last Will and it targets the guest's own presence topic, so a guest's card in the owner's space is explicit-publish/explicit-clear. An ungraceful drop can leave a card up until the guest reconnects or signs out. Cards carry a timestamp so surfaces can render staleness.

--- a/services/sync-api/src/shares.rs
+++ b/services/sync-api/src/shares.rs
@@ -44,6 +44,11 @@ use crate::{error, now_millis, nudge, parse_body, reply, Ctx};
 /// `LUX` prefix unambiguous to strip on the way back in.
 const CODE_ALPHABET: &[u8] = b"23456789CDFGHJKMNPQRTVWXZ";
 
+/// Longest invite note the owner may attach. Their own label for their own
+/// list — never shown to the contact — so this is hygiene rather than a trust
+/// boundary: it stops one field from being an unbounded write into three rows.
+const MAX_LABEL_CHARS: usize = 120;
+
 /// Code body length. 25^10 ≈ 2^46 — a claim is bearer-authorized but reaching
 /// it still requires a signed-in account, a live 48-hour window, and surviving
 /// single use, so this is a very large multiple of what the exposure needs.
@@ -174,6 +179,13 @@ pub async fn invite(
     // no existing setup stops syncing over this.
     if !is_shareable_id(&body.setup_id) {
         return reply(400, error("that setup cannot be shared"));
+    }
+    if body
+        .label
+        .as_deref()
+        .is_some_and(|l| l.chars().count() > MAX_LABEL_CHARS)
+    {
+        return reply(400, error("that note is too long"));
     }
 
     // Only over a setup the caller actually owns and hasn't deleted. This is
@@ -644,7 +656,7 @@ pub async fn cleanup_for_deleted_user(ctx: &Ctx, sub: &str) -> Result<(), String
                 .filter(|id| !id.is_empty())
                 .map(str::to_owned)
         }) {
-            clear_retained_config(ctx, sub, &setup_id).await;
+            clear_retained_config(ctx, sub, &setup_id).await?;
         }
     }
 
@@ -666,21 +678,28 @@ fn mirror_sk_of_owned(item: &HashMap<String, AttributeValue>, owner_sub: &str) -
 }
 
 /// Publish an empty retained payload to a setup's config topic, deleting the
-/// retained message. Best-effort like every other publish on this path.
-async fn clear_retained_config(ctx: &Ctx, sub: &str, setup_id: &str) {
-    let Some(iot) = &ctx.iot else { return };
+/// retained message.
+///
+/// Fallible, unlike the nudges on this path — and for the same reason the item
+/// deletes are: nothing retries it. Deletion proceeds, no actor ever runs the
+/// sweep again, and a warning in a log is not a cleanup. A compiled setup
+/// carries the setup's name and every channel label, so a failure here is
+/// exactly the remanence this step exists to prevent.
+///
+/// No IoT client configured is a skip, not a failure: there is no retained
+/// message to clear on a stack that never had a broker.
+async fn clear_retained_config(ctx: &Ctx, sub: &str, setup_id: &str) -> Result<(), String> {
+    let Some(iot) = &ctx.iot else { return Ok(()) };
     let topic = lux_wire::ctl::config_topic(sub, setup_id);
-    if let Err(e) = iot
-        .publish()
+    iot.publish()
         .topic(&topic)
         .qos(0)
         .retain(true)
         .payload(aws_sdk_iotdataplane::primitives::Blob::new(Vec::new()))
         .send()
         .await
-    {
-        tracing::warn!("retained config clear on {topic} failed: {e}");
-    }
+        .map_err(|e| format!("retained config clear on {topic} failed: {e}"))?;
+    Ok(())
 }
 
 // --- store helpers ----------------------------------------------------------


### PR DESCRIPTION
Follow-ups from review of #223. Small, and none of them change the feature's shape.

**The retained-config clear was best-effort while everything else in deletion cleanup gates the wipe.** That inconsistency matters more than it looks: nothing retries it. Deletion proceeds, no actor ever runs the sweep again, and a warning in a log is not a cleanup. A compiled setup carries the setup's name and every channel label, so a failure there is exactly the remanence the step exists to prevent — the one place `docs/shared-control.md`'s own principle ("deleting an account has to mean the data actually leaves") quietly didn't hold. It's fallible now, like the item deletes beside it. An unconfigured IoT client stays a skip rather than a failure: there is no retained message to clear on a stack that never had a broker.

The exposure this closes is hygiene rather than a live leak — after cleanup the grants are gone, so within the authorizer's refresh window nobody can read an orphaned frame anyway. It's worth the one line because the alternative is a documented promise the code doesn't keep.

**The end-to-end runbook moved into `docs/shared-control.md`.** It was only ever in #223's description, which is the wrong home for the artifact that proves the backend before any UI exists — and it had already drifted. The expectation block still described guest presence as `…/presence/<contactSub>-*`, the sub-prefixed wildcard the security audit removed; the shipped code emits the exact topic `…/presence/<contactSub>`. Anyone following it would have hit what looked like a failure at step 7, the one step the whole runbook is for. The presence lines now name the exact topic, the leak grep also looks for the old wildcard form, and the sync URL is read from the deployed function rather than pasted.

**Also:** the owner's invite note is length-clamped — it's their own private label on their own list, so this is hygiene rather than a trust boundary, but it was an unbounded field written into three rows. And the share-tally comment claimed "first-seen order" while the code sorts by sub, which the adjacent dedup requires.

Gate green locally: 17 Rust suites, clippy, eslint, tsc.