### PR TITLE
feat(shares): publish the retained compiled setup for shared setups

### DIFF
--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -289,6 +289,14 @@ async fn list_shares_req(
 /// An account with cloud sync never configured has no shares at all, which is
 /// an empty answer rather than an error.
 pub fn list_shares(app: &AppHandle) -> Result<lux_wire::shares::SharesResponse, String> {
+    let app = app.clone();
+    crate::account::block_on(async move { shares(&app).await })
+}
+
+/// The async half of [`list_shares`], for callers already inside the runtime —
+/// the retained-config publisher runs on the nudge connection's task, where
+/// blocking on a worker thread would stall the whole user channel.
+pub async fn shares(app: &AppHandle) -> Result<lux_wire::shares::SharesResponse, String> {
     let (base, token) = {
         let account = app.state::<LuxAccount>();
         let Some(base) = account.sync_url() else {
@@ -301,16 +309,13 @@ pub fn list_shares(app: &AppHandle) -> Result<lux_wire::shares::SharesResponse, 
         let token = account.current_id_token().ok_or("not signed in")?;
         (base, token)
     };
-    let app = app.clone();
-    crate::account::block_on(async move {
-        let client = Client::new();
-        let mut result = list_shares_req(&client, &base, token).await;
-        if matches!(result, Err(SyncError::Unauthorized)) {
-            let fresh = refresh(&app).await.map_err(|e| e.to_string())?;
-            result = list_shares_req(&client, &base, fresh).await;
-        }
-        result.map_err(|e| format!("could not list shares: {e}"))
-    })
+    let client = Client::new();
+    let mut result = list_shares_req(&client, &base, token).await;
+    if matches!(result, Err(SyncError::Unauthorized)) {
+        let fresh = refresh(app).await.map_err(|e| e.to_string())?;
+        result = list_shares_req(&client, &base, fresh).await;
+    }
+    result.map_err(|e| format!("could not list shares: {e}"))
 }
 
 async fn read_json<T: DeserializeOwned>(resp: reqwest::Response) -> Result<T, SyncError> {

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -371,6 +371,11 @@ impl CmdMethods for CmdEndpoint {
         let setups = app_handle.state::<LuxSetups>();
         let was_active = setups.active_id() == id;
         setups.delete(id)?;
+        // Clear the retained config here rather than leaving it to the
+        // reconcile: once the setup is out of the store nothing can name its
+        // topic, and a guest's whole view of a setup is that frame — an
+        // orphaned one would outlive the setup it describes.
+        crate::nudge::clear_config(&app_handle, id);
         // Deleting the active setup reassigns active inside the store; re-sync the
         // output and UI to whatever became active, exactly like a manual switch.
         if was_active {
@@ -650,6 +655,9 @@ fn commit_patch(app: &AppHandle, setups: &LuxSetups) -> Result<Vec<Fixture>, Str
     .emit(app)
     .map_err(|e| format!("Failed to emit patch_set event: {e}"))?;
     crate::cloud::schedule_push(app);
+    // A shared setup's guests render from its retained config, so it has to
+    // follow the setup rather than lag it (coalesced; see refresh_shared_configs).
+    crate::nudge::refresh_shared_configs(app);
     Ok(fixtures)
 }
 
@@ -675,6 +683,9 @@ fn commit_setups(app: &AppHandle, setups: &LuxSetups) -> Result<Vec<SetupSummary
     .emit(app)
     .map_err(|e| format!("Failed to emit setups_changed event: {e}"))?;
     crate::cloud::schedule_push(app);
+    // A shared setup's guests render from its retained config, so it has to
+    // follow the setup rather than lag it (coalesced; see refresh_shared_configs).
+    crate::nudge::refresh_shared_configs(app);
     Ok(summaries)
 }
 
@@ -684,6 +695,10 @@ fn commit_setups(app: &AppHandle, setups: &LuxSetups) -> Result<Vec<SetupSummary
 pub fn broadcast_synced_state(app: &AppHandle) {
     let setups = app.state::<LuxSetups>();
     setup::save(app, &setups);
+    // A pull can change a shared setup's patch, name, or universe from another
+    // device; guests render from the retained config, so it follows the pull.
+    // (Coalesced, so this and the nudge that scheduled the pull are one.)
+    crate::nudge::refresh_shared_configs(app);
     devices::set_active_universe(app, setups.active_universe());
     let active_id = setups.active_id().to_string();
     let _ = CmdEvent::SetupsChanged {

--- a/apps/desktop/src-tauri/src/nudge.rs
+++ b/apps/desktop/src-tauri/src/nudge.rs
@@ -52,6 +52,12 @@ use crate::buffer::LuxBuffer;
 use crate::lock::LockPolicy;
 use crate::setup::LuxSetups;
 
+/// Trailing-edge coalescing window for retained-config reconciles. Generous
+/// because the triggers are human-paced (a patch edit, a grant change) and
+/// arrive in bursts: a nudge, the pull it schedules, and the local commit that
+/// pull produces are all one logical change.
+const CONFIG_WINDOW: Duration = Duration::from_millis(750);
+
 /// Trailing-edge coalescing window for the retained state echo (≤5 Hz) — a
 /// remote surface needs truth, not every intermediate slider position.
 const ECHO_WINDOW: Duration = Duration::from_millis(200);
@@ -100,6 +106,8 @@ pub struct LuxNudge {
     local_input_at: Mutex<Option<Instant>>,
     /// Consecutive ctl-suspect connection deaths (see [`CTL_FAILURE_LIMIT`]).
     ctl_failures: AtomicU32,
+    /// A retained-config reconcile is queued (see [`refresh_shared_configs`]).
+    configs_pending: AtomicBool,
 }
 
 impl Default for LuxNudge {
@@ -109,6 +117,7 @@ impl Default for LuxNudge {
             presence: watch::channel(0).0,
             echo: Mutex::new(None),
             echo_pending: AtomicBool::new(false),
+            configs_pending: AtomicBool::new(false),
             peers: Mutex::new(HashMap::new()),
             outbox: Mutex::new(Outbox::default()),
             publish_pending: AtomicBool::new(false),
@@ -359,6 +368,131 @@ pub fn schedule_state_echo<R: Runtime>(app: &AppHandle<R>) {
     });
 }
 
+/// The setup ids a shared-control guest may currently render, from the
+/// caller's own grants (`GET /shares`). Pure so the reconcile below stays
+/// testable without a broker: given what is granted and what exists locally,
+/// exactly these setups should carry a retained config and every other local
+/// setup should carry none.
+fn shared_setup_ids(
+    granted: &[lux_wire::shares::Grant],
+    local: &[uuid::Uuid],
+) -> std::collections::HashSet<uuid::Uuid> {
+    let local: std::collections::HashSet<uuid::Uuid> = local.iter().copied().collect();
+    granted
+        .iter()
+        .filter_map(|g| uuid::Uuid::parse_str(&g.setup_id).ok())
+        .filter(|id| local.contains(id))
+        .collect()
+}
+
+/// Publish the retained compiled setup for every shared setup, and clear it for
+/// every other setup on the account.
+///
+/// Deliberately a full reconcile rather than incremental publish/clear calls,
+/// and it keeps no record of what it published last. A guest's whole view of a
+/// setup is this retained frame, so the failure that matters is a stale one
+/// outliving its grant — and any bookkeeping of "what did I publish" is exactly
+/// the thing that drifts when the app is closed while a grant is revoked from
+/// another device. Deriving the answer from current state every time cannot
+/// drift, and clearing a topic that holds nothing is a no-op.
+///
+/// The one case this cannot cover is a setup deleted locally: it is gone from
+/// the account, so nothing here names it. [`clear_config`] handles that at the
+/// deletion site, before the setup disappears.
+pub fn reconcile_configs<R: Runtime>(app: &AppHandle<R>, granted: &[lux_wire::shares::Grant]) {
+    let Some(echo) = app.state::<LuxNudge>().echo.lock_or_recover().clone() else {
+        return; // no connection; the next connect reconciles from scratch
+    };
+    for (setup_id, config) in config_plan(&app.state::<LuxSetups>().all(), granted) {
+        // `None` is a clear: an empty retained payload deletes the retained
+        // message, the same idiom the presence card uses.
+        let payload = match config.as_ref().map(serde_json::to_vec).transpose() {
+            Ok(payload) => payload.unwrap_or_default(),
+            Err(e) => {
+                log::warn!("could not compile setup {setup_id} for sharing: {e}");
+                continue;
+            }
+        };
+        let topic = lux_wire::ctl::config_topic(&echo.sub, &setup_id.to_string());
+        let client = echo.client.clone();
+        tauri::async_runtime::spawn(async move {
+            if let Err(e) = client.publish(&topic, QoS::AtMostOnce, true, payload).await {
+                log::debug!("config publish to {topic} failed (connection likely down): {e}");
+            }
+        });
+    }
+}
+
+/// The retained-config writes one reconcile implies: a compiled payload for
+/// every shared setup, `None` (clear) for every other setup on the account.
+///
+/// Split out from the publish loop because *this* is the part worth being sure
+/// about — which setups a guest can see — and it is a pure function of local
+/// setups plus current grants, so it can be checked without a broker.
+fn config_plan(
+    setups: &[crate::setup::Setup],
+    granted: &[lux_wire::shares::Grant],
+) -> Vec<(uuid::Uuid, Option<lux_wire::ctl::Config>)> {
+    let shared = shared_setup_ids(granted, &setups.iter().map(|s| s.id).collect::<Vec<_>>());
+    setups
+        .iter()
+        .map(|setup| {
+            let config = shared.contains(&setup.id).then(|| setup.compile());
+            (setup.id, config)
+        })
+        .collect()
+}
+
+/// Clear one setup's retained config. Called when a setup is deleted, while its
+/// id is still known — after that, [`reconcile_configs`] can no longer name it.
+pub fn clear_config<R: Runtime>(app: &AppHandle<R>, setup_id: uuid::Uuid) {
+    let Some(echo) = app.state::<LuxNudge>().echo.lock_or_recover().clone() else {
+        return;
+    };
+    let topic = lux_wire::ctl::config_topic(&echo.sub, &setup_id.to_string());
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = echo
+            .client
+            .publish(&topic, QoS::AtMostOnce, true, Vec::<u8>::new())
+            .await
+        {
+            log::debug!("config clear on {topic} failed (connection likely down): {e}");
+        }
+    });
+}
+
+/// Fetch the caller's grants and reconcile the retained configs against them.
+/// The entry point for anything that changes *who* can see a setup — a shares
+/// nudge, and the connect handshake, where a grant may have changed while this
+/// device was offline.
+/// Coalesced, so every caller can be naive: a cloud pull, the nudge that caused
+/// it, and the local commit it produces all land in one reconcile instead of
+/// three round trips.
+pub fn refresh_shared_configs(app: &AppHandle) {
+    let state = app.state::<LuxNudge>();
+    if state.echo.lock_or_recover().is_none() {
+        return;
+    }
+    if state.configs_pending.swap(true, Ordering::SeqCst) {
+        return; // one is already queued and will see this change too
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(CONFIG_WINDOW).await;
+        app.state::<LuxNudge>()
+            .configs_pending
+            .store(false, Ordering::SeqCst);
+        match crate::cloud::shares(&app).await {
+            Ok(shares) => reconcile_configs(&app, &shares.granted),
+            // Leave the retained configs exactly as they are. Publishing on a
+            // guess is worse than publishing late: the pull retries, and a
+            // grant that was revoked is already unreadable by the guest whose
+            // policy no longer covers it.
+            Err(e) => log::warn!("could not refresh shares for config publish: {e}"),
+        }
+    });
+}
+
 /// Queue a locally-entered overlay write (the color-picker path) for remote
 /// publish. Called from the command layer only — never from an apply path —
 /// which is the structural loop guard: remotely-applied frames re-enter the
@@ -549,14 +683,23 @@ async fn run_connection(
                         publish_presence(&client, app, sub, &session).await;
                         // Refresh the retained truth for whoever is watching.
                         schedule_state_echo(app);
+                        // …including shared-control guests, whose entire view
+                        // of a setup is its retained config. Grants can change
+                        // while this device is offline, so reconcile on every
+                        // connect rather than trusting what a past session
+                        // published.
+                        refresh_shared_configs(app);
                     }
                 }
                 Ok(Event::Incoming(Packet::Publish(publish))) => {
                     match route(&publish.topic, sub) {
                         Route::Nudge => {
-                            // Opaque frame — never parsed; any frame means "pull now".
+                            // Opaque frame — never parsed; any frame means "pull
+                            // now", and since shared control the pull covers who
+                            // can see a setup as well as what is in it.
                             log::debug!("nudge received; scheduling sync");
                             crate::cloud::schedule_sync(app);
+                            refresh_shared_configs(app);
                         }
                         Route::Frame { setup_id } => {
                             apply_frame(app, &publish.payload, setup_id, &session);
@@ -710,6 +853,82 @@ fn apply_frame(app: &AppHandle, payload: &[u8], frame_setup: &str, own_session: 
 mod tests {
     use super::*;
     use lux_wire::ctl::Frame;
+
+    #[test]
+    fn shared_setups_are_the_granted_ones_that_still_exist_here() {
+        use std::collections::HashSet;
+        let a = uuid::Uuid::from_u128(1);
+        let b = uuid::Uuid::from_u128(2);
+        let gone = uuid::Uuid::from_u128(3);
+        let grant = |id: uuid::Uuid| lux_wire::shares::Grant {
+            contact_sub: "c".into(),
+            contact_label: "c@example.com".into(),
+            setup_id: id.to_string(),
+            setup_name: None,
+            label: None,
+            created_at: 0,
+        };
+
+        // Two contacts on one setup is one setup, not two configs.
+        assert_eq!(
+            shared_setup_ids(&[grant(a), grant(a), grant(b)], &[a, b]),
+            HashSet::from([a, b])
+        );
+
+        // A grant naming a setup this device doesn't have — deleted elsewhere,
+        // or not pulled yet — publishes nothing. There is no setup to compile,
+        // and inventing an empty one would blank a guest's desk.
+        assert!(shared_setup_ids(&[grant(gone)], &[a]).is_empty());
+
+        // No grants: every local setup falls into the reconcile's clear set.
+        assert!(shared_setup_ids(&[], &[a, b]).is_empty());
+
+        // A malformed setup id is skipped, not panicked on.
+        let mut bad = grant(a);
+        bad.setup_id = "not-a-uuid".into();
+        assert!(shared_setup_ids(&[bad], &[a]).is_empty());
+    }
+
+    #[test]
+    fn the_plan_publishes_only_shared_setups_and_clears_every_other() {
+        let setup = |id: u128, name: &str| crate::setup::Setup {
+            id: uuid::Uuid::from_u128(id),
+            name: name.to_owned(),
+            universe: 1,
+            fixtures: Vec::new(),
+            updated_at: None,
+            dirty: false,
+        };
+        let grant = |id: u128| lux_wire::shares::Grant {
+            contact_sub: "c".into(),
+            contact_label: "c@example.com".into(),
+            setup_id: uuid::Uuid::from_u128(id).to_string(),
+            setup_name: None,
+            label: None,
+            created_at: 0,
+        };
+        let setups = vec![setup(1, "Shared"), setup(2, "Private")];
+
+        let plan = config_plan(&setups, &[grant(1)]);
+        assert_eq!(plan.len(), 2, "every local setup gets a decision");
+        let shared = plan.iter().find(|(id, _)| *id == setups[0].id).unwrap();
+        let private = plan.iter().find(|(id, _)| *id == setups[1].id).unwrap();
+        assert_eq!(
+            shared.1.as_ref().map(|c| c.name.as_str()),
+            Some("Shared"),
+            "a granted setup publishes its compiled config"
+        );
+        assert!(
+            private.1.is_none(),
+            "an ungranted setup is cleared, not skipped — a config from a \
+             revoked grant must not outlive it"
+        );
+
+        // Revoking the last grant turns the publish into a clear on the very
+        // next reconcile, with no memory of what was published before.
+        let after_revoke = config_plan(&setups, &[]);
+        assert!(after_revoke.iter().all(|(_, config)| config.is_none()));
+    }
 
     #[test]
     fn outbox_coalesces_channels_to_latest_value() {

--- a/apps/desktop/src-tauri/src/setup.rs
+++ b/apps/desktop/src-tauri/src/setup.rs
@@ -53,6 +53,54 @@ pub struct Setup {
 }
 
 impl Setup {
+    /// Compile this setup into the payload a surface that holds no copy of it
+    /// renders from — a shared-control guest today, a render node later
+    /// (`lux_wire::ctl::Config`, published retained on the setup's `config`
+    /// topic; see docs/shared-control.md).
+    ///
+    /// This is a lossy, deliberate projection, not a serialization. It carries
+    /// what it takes to *draw a desk*: which slots exist, what to call them,
+    /// and what kind of control each wants. It drops fixture ids, sync
+    /// metadata, and the local-only view state — a guest has no business
+    /// knowing any of it, and an embedded node has no use for it.
+    ///
+    /// Only patched slots appear. An unpatched setup compiles to empty lists,
+    /// which is not an empty desk: it means "no patch", and a surface renders
+    /// the plain universe, exactly as this app does locally.
+    pub fn compile(&self) -> lux_wire::ctl::Config {
+        let mut channels = Vec::new();
+        let mut fixtures = Vec::new();
+        for fixture in &self.fixtures {
+            fixtures.push(lux_wire::ctl::ConfigFixture {
+                name: fixture.name.clone(),
+                address: fixture.address,
+                count: fixture.channels.len() as u16,
+            });
+            for (offset, channel) in fixture.channels.iter().enumerate() {
+                channels.push(lux_wire::ctl::ConfigChannel {
+                    // 1-based DMX slot, matching `Frame::Channel`'s `ch` — the
+                    // number a guest will publish back.
+                    n: fixture.address.saturating_add(offset as u16),
+                    name: channel.label.clone(),
+                    // The variant name, which is exactly how the role rides
+                    // every other wire in this app. A consumer matches what it
+                    // knows and treats the rest as a plain fader.
+                    role: channel.role.as_ref().to_owned(),
+                });
+            }
+        }
+        // Slot order, not patch order: a surface draws a universe, and fixtures
+        // are patched in whatever order the user added them.
+        channels.sort_by_key(|c| c.n);
+        lux_wire::ctl::Config::new(
+            self.id.to_string(),
+            self.name.clone(),
+            self.universe,
+            channels,
+            fixtures,
+        )
+    }
+
     /// Whether this setup has changes the cloud doesn't have yet: explicit local
     /// edits, or a setup that has never been synced.
     fn needs_push(&self) -> bool {
@@ -681,6 +729,74 @@ fn reconcile(store: &mut SetupStore) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn compile_lists_patched_slots_in_universe_order() {
+        use crate::colors::LuxLabelColor::*;
+        let ch = |role, label: &str| ChannelDef {
+            role,
+            label: label.to_owned(),
+        };
+        // Patched out of order on purpose: a user adds fixtures in whatever
+        // order they like, and a surface draws a universe.
+        let setup = new_setup(
+            "Living room",
+            7,
+            vec![
+                Fixture {
+                    id: uuid::Uuid::nil(),
+                    name: "Back par".into(),
+                    address: 10,
+                    channels: vec![ch(Red, "R"), ch(Green, "G")],
+                },
+                Fixture {
+                    id: uuid::Uuid::nil(),
+                    name: "Front par".into(),
+                    address: 1,
+                    channels: vec![ch(Brightness, "Dim")],
+                },
+            ],
+        );
+
+        let config = setup.compile();
+        assert_eq!(config.v, lux_wire::ctl::VERSION);
+        assert_eq!(config.name, "Living room");
+        assert_eq!(config.universe, 7);
+        assert_eq!(config.setup_id, setup.id.to_string());
+
+        // Slots are 1-based and ordered, and each carries the address it was
+        // patched at — not its offset within its fixture.
+        let slots: Vec<(u16, &str, &str)> = config
+            .channels
+            .iter()
+            .map(|c| (c.n, c.name.as_str(), c.role.as_str()))
+            .collect();
+        assert_eq!(
+            slots,
+            vec![
+                (1, "Dim", "Brightness"),
+                (10, "R", "Red"),
+                (11, "G", "Green"),
+            ]
+        );
+
+        // Fixtures carry only what a heading needs.
+        assert_eq!(config.fixtures.len(), 2);
+        assert_eq!(config.fixtures[1].name, "Front par");
+        assert_eq!(config.fixtures[1].address, 1);
+        assert_eq!(config.fixtures[1].count, 1);
+    }
+
+    #[test]
+    fn compile_of_an_unpatched_setup_is_empty_not_absent() {
+        // Empty lists mean "no patch, render the plain universe" — the same
+        // thing this app does locally. A fixed parser reads the same field set
+        // either way, which is why these are empty rather than omitted.
+        let config = new_setup("Blank", 1, vec![]).compile();
+        assert!(config.channels.is_empty() && config.fixtures.is_empty());
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains(r#""channels":[]"#) && json.contains(r#""fixtures":[]"#));
+    }
 
     #[test]
     fn default_store_is_one_home_setup_with_rgbaw() {


### PR DESCRIPTION
P2a of shared control — the applier now publishes what a guest renders from. Ships dark: nothing reads these frames until the guest surface lands, and an account with no grants publishes nothing at all.

This is the load-bearing piece of P2. The guest surface renders from the retained `config` topic, so neither UI can be built or tested until something publishes it. It also puts the `ctl::Config` shape carved in #223 to its first real use.

## `Setup::compile()`

A lossy projection into `lux_wire::ctl::Config`, deliberately not a serialization. It carries what it takes to *draw a desk* — which slots exist, what to call them, what kind of control each wants — and drops fixture ids, sync metadata, and local view state. A guest has no business knowing any of it, and an embedded node has no use for it.

Slots are 1-based, matching `Frame::Channel`'s `ch` — the number a guest publishes back. They come out in universe order rather than patch order, because a surface draws a universe and fixtures are added in whatever order the user likes. An unpatched setup compiles to empty lists, which means "no patch, render the plain universe" (what this app already does locally), not "empty desk".

## The publisher reconciles rather than tracks

It publishes a compiled payload for every shared setup and **clears the topic for every other setup on the account**, deriving both sets from current state on every run. It deliberately keeps no record of what it published last.

The tempting design is incremental publish/clear against a `published` set. That set drifts in exactly the case that matters: the app is closed, a grant is revoked from your phone, the app reopens with no memory, and a stale config stays retained forever. A guest's entire view of a setup is that frame, so a stale one outliving its grant is the failure worth engineering against. Deriving the answer from current state cannot drift, and clearing a topic that holds nothing is a free no-op — the cost is a handful of publishes on human-paced events.

The one case a reconcile *can't* cover is a locally deleted setup: it is gone from the account, so nothing left names its topic. `delete_setup` clears it explicitly while the id is still known.

## Triggers

Connect (a grant can change while a device is offline), any nudge frame, patch commits, setup commits, and the post-pull broadcast. All of them go through one coalesced entry point with a 750 ms window, so a nudge, the pull it schedules, and the local commit that pull produces collapse into one reconcile instead of three round trips. That coalescing is what lets every call site stay naive.

`cloud::shares` becomes the async primitive with the existing `list_shares` wrapping it — the publisher runs on the nudge connection's task, where `block_on` would stall the whole user channel.

## Tests

The pure half is what's worth being sure about, so it's split out and covered directly: `config_plan` (which setups publish vs clear, including that revoking the last grant turns a publish into a clear on the very next reconcile), `shared_setup_ids` (grants naming setups this device doesn't have, duplicate grants on one setup, malformed ids), and `Setup::compile` (slot ordering, and the unpatched case pinned at the JSON level).

Gate green locally: 17 Rust suites, clippy, eslint, tsc.

## Next in P2

The owner's invite/manage UI in the setup dropdown, then the guest "Shared with you" list and control surface. Both constraints from #223 carry forward: guest presence cards go to `guest_presence_topic(owner, contact)` — the exact topic, no session suffix — and guest frames carry `src` so the owner's applier attributes them in its per-slot LTP.