### PR TITLE
ci(release): build macOS beside the other artifacts, publish behind the backend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,12 @@ name: release
 # CHANGELOG + every derived version stamp via extra-files) from
 # conventional-commit history. Merging it lands the bumped manifest on main;
 # the release job below cuts the vX.Y.Z tag + GitHub Release itself and the
-# pipeline ships: gate at the tag, terraform apply, Lambda deploys + smokes,
-# then the macOS build attaches the .dmg + updater manifest and the iOS +
-# Mac App Store builds ship to TestFlight (both platforms, one app record).
-# Apple artifacts are also rebuildable on demand for an existing tag via
-# workflow_dispatch.
+# pipeline ships: gate at the tag, then every artifact builds at once — macOS,
+# iOS, Mac App Store, node — alongside the terraform apply and the Lambda
+# deploys. Publishing is what waits: the macOS bundle + updater manifest attach
+# only once the backend is green, and the TestFlight uploads (both platforms,
+# one app record) and node assets follow behind that. Apple artifacts are also
+# rebuildable on demand for an existing tag via workflow_dispatch.
 on:
   push:
     branches: [main]
@@ -261,22 +262,26 @@ jobs:
       # when a race let an earlier push's run cut the release.
       ref: ${{ needs.release.outputs.tag_name }}
 
-  # Builds, signs, and notarizes the macOS app and attaches it (plus the
-  # updater's latest.json) to the release — after the release job cuts one, or
-  # on a manual dispatch for an existing tag. On the release path this runs
-  # LAST, only after the Lambdas deployed and passed their smokes: the updater
-  # manifest publishing is what makes a release visible to users, so a release
-  # whose backend didn't ship never reaches them. Manual dispatch rebuilds an
-  # existing tag whose backend already shipped, so it skips those gates.
+  # Builds, signs, and notarizes the macOS app and stages the bundles as a
+  # workflow artifact — in parallel with the backend and the other build legs,
+  # since staging touches nothing anyone can see. This is the long pole of the
+  # whole pipeline, so it starts the moment the gate is green rather than
+  # waiting out the backend it doesn't depend on. Attaching the bundles (and
+  # the updater's latest.json) to the release is publish-macos's job, and that
+  # is what waits: publishing the updater manifest is what makes a release
+  # visible to users, so a release whose backend didn't ship never reaches
+  # them. Manual dispatch rebuilds an existing tag whose backend already
+  # shipped, so it skips those gates.
   build-macos:
-    needs: [release, deploy-lambdas]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (needs.release.outputs.release_created == 'true' && needs.deploy-lambdas.result == 'success')) }}
+    needs: [release, ci]
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (needs.release.outputs.release_created == 'true' && needs.ci.result == 'success')) }}
     runs-on: macos-latest
     timeout-minutes: 60
     permissions:
-      contents: write
-      id-token: write # AWS OIDC, to read the updater signing key
-      deployments: write # record the updater publish (API, not environment: — see the record step)
+      contents: read
+      id-token: write # AWS OIDC, to read the updater + Apple signing keys
+    outputs:
+      version: ${{ steps.tauri.outputs.appVersion }}
     env:
       TAG: ${{ github.event.inputs.tag || needs.release.outputs.tag_name }}
       RUSTC_WRAPPER: sccache
@@ -293,7 +298,9 @@ jobs:
       # Refuse loudly: partial rebuilds belong to `gh run rerun <id> --failed`
       # on the original release run (it never re-runs succeeded jobs), and a
       # deliberate macOS rebuild means deleting the release's macOS assets
-      # first. Assetless tags (a run that died before publishing) pass.
+      # first. Assetless tags (a run that died before publishing) pass. The
+      # check guards publish-macos but lives here, where refusing costs a
+      # checkout instead of a full signed-and-notarized build.
       - name: Refuse to rebuild served macOS artifacts (dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
@@ -372,23 +379,141 @@ jobs:
           printf '%s' "$s" | jq -r '.api_key' > "$RUNNER_TEMP/asc_api_key.p8"
           echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/asc_api_key.p8" >> "$GITHUB_ENV"
 
+      # Deliberately no tagName and no releaseId: with neither, the action
+      # builds and signs but uploads nothing ("skipping all uploads"), which is
+      # the whole point of splitting this job — the artifacts must exist before
+      # the backend is green, and be publishable only after. It still reports
+      # artifactPaths and appVersion, which is everything publish-macos needs.
       - uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
+        id: tauri
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ runner.temp }}/updater.key
         with:
           projectPath: apps/desktop
-          tagName: ${{ env.TAG }}
           args: --target universal-apple-darwin
+
+      # Stage the bundles under exactly the names the action's own uploader
+      # would have given them, so the published assets are unchanged: the .dmg
+      # keeps the filename tauri's CLI chose, while the updater tarball and its
+      # detached signature gain the version and arch the CLI leaves off.
+      # artifactPaths also lists the unpackaged lux.app directory — the suffix
+      # matching below picks the three shippable files out of it.
+      - name: Stage the signed bundles
+        env:
+          PATHS: ${{ steps.tauri.outputs.artifactPaths }}
+          VERSION: ${{ steps.tauri.outputs.appVersion }}
+        run: |
+          set -euo pipefail
+          pick() { jq -r --arg ext "$1" '[.[] | select(endswith($ext))] | first // ""' <<<"$PATHS"; }
+          dmg=$(pick .dmg)
+          tarball=$(pick .app.tar.gz)
+          sig=$(pick .app.tar.gz.sig)
+          [ -s "$dmg" ] && [ -s "$tarball" ] && [ -s "$sig" ] \
+            || { echo "::error::expected a .dmg, a .app.tar.gz and its .sig among $PATHS"; exit 1; }
+          out="$RUNNER_TEMP/macos"
+          mkdir -p "$out"
+          cp "$dmg" "$out/$(basename "$dmg")"
+          cp "$tarball" "$out/lux_${VERSION}_universal.app.tar.gz"
+          cp "$sig" "$out/lux_${VERSION}_universal.app.tar.gz.sig"
+          ls -l "$out"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: macos-bundles
+          path: ${{ runner.temp }}/macos
+          retention-days: 1
+
+      - name: sccache stats
+        if: ${{ always() }}
+        run: sccache --show-stats
+
+  # The publish half of the macOS build, and the gate the rest of the release
+  # waits behind. The signed, notarized bundles already exist; this attaches
+  # them to the release and writes the updater's latest.json last, only once
+  # the Lambdas have deployed and passed their smokes. That ordering is the
+  # load-bearing part: latest.json is the endpoint every installed copy polls,
+  # so a release whose backend didn't ship can never reach one.
+  publish-macos:
+    needs: [release, build-macos, deploy-lambdas]
+    if: ${{ always() && needs.build-macos.result == 'success' && (github.event_name == 'workflow_dispatch' || (needs.release.outputs.release_created == 'true' && needs.deploy-lambdas.result == 'success')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # attach the release assets
+      deployments: write # record the updater publish (API, not environment: — see the record step)
+    env:
+      TAG: ${{ github.event.inputs.tag || needs.release.outputs.tag_name }}
+      VERSION: ${{ needs.build-macos.outputs.version }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: macos-bundles
+          path: ${{ runner.temp }}/macos
+
+      # The tag names the release; the version stamps the bundles and the
+      # manifest. They reach this job from opposite ends of the pipeline —
+      # release-please's manifest versus the tauri config the build read — so
+      # a disagreement means a stamp drifted, and publishing across it would
+      # serve an updater manifest for a version nobody can download.
+      - name: Verify the built version matches the tag
+        run: |
+          test "v$VERSION" = "$TAG" \
+            || { echo "::error::built version $VERSION does not match release tag $TAG"; exit 1; }
+
+      - name: Attach the bundles to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/macos"
+          ls -l
+          gh release upload "$TAG" ./* --clobber -R "$GITHUB_REPOSITORY"
+
+      # tauri-action wrote this file back when it owned the upload; it is
+      # reproduced here because publishing now happens in a job that never
+      # builds. This is its output for a single universal darwin bundle: every
+      # darwin key — the bare ones and the newer -app suffixed ones — points at
+      # the one .app.tar.gz through its REST asset URL and carries that
+      # bundle's detached signature. Written last, because this file going up
+      # is what "released" means.
+      - name: Publish the updater manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          staged="$RUNNER_TEMP/macos"
+          tarball="lux_${VERSION}_universal.app.tar.gz"
+          id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" \
+            --jq ".assets[] | select(.name == \"$tarball\") | .id")
+          [ -n "$id" ] || { echo "::error::$tarball is not attached to $TAG"; exit 1; }
+          url="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/assets/$id"
+          jq -n --arg version "$VERSION" \
+                --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+                --arg signature "$(cat "$staged/$tarball.sig")" \
+                --arg url "$url" \
+            '{version: $version, notes: "", pub_date: $pub_date,
+              platforms: (["darwin-aarch64", "darwin-x86_64", "darwin-universal",
+                           "darwin-aarch64-app", "darwin-x86_64-app", "darwin-universal-app"]
+                          | map({key: ., value: {signature: $signature, url: $url}})
+                          | from_entries)}' > "$RUNNER_TEMP/latest.json"
+          jq '.platforms | keys' "$RUNNER_TEMP/latest.json"
+          # A manifest is worth exactly what the URL inside it resolves to, so
+          # fetch the bundle back through that URL before making it the served
+          # endpoint. Authenticated only to stay off the anonymous API rate
+          # limit that runner IPs share — the asset itself is public.
+          code=$(curl -sSL -o /dev/null -w '%{http_code}' \
+            -H 'Accept: application/octet-stream' -H "Authorization: Bearer $GH_TOKEN" "$url")
+          test "$code" = "200" || { echo "::error::the updater's asset URL answered $code"; exit 1; }
+          gh release upload "$TAG" "$RUNNER_TEMP/latest.json" --clobber -R "$GITHUB_REPOSITORY"
+          echo "published latest.json for $TAG"
 
       # Record what is live in the repo's Deployments view. Done via the API,
       # NOT a job-level `environment:` key — that key rewrites the OIDC subject
       # to repo:…:environment:…, which the role trusts (pinned to the main ref)
-      # would reject, breaking the AWS credentials above.
+      # would reject, breaking the AWS credentials the build job used.
       - name: Record updater deployment
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ env.TAG }}
         run: |
           set -euo pipefail
           body=$(jq -nc --arg ref "$GITHUB_SHA" --arg desc "$TAG" \
@@ -398,11 +523,6 @@ jobs:
             -f state=success -f environment=updater -f environment_url=https://github.com/johncarmack1984/lux/releases/latest \
             -f description="artifacts + latest.json published for $TAG" >/dev/null
           echo "recorded updater deployment $id ($TAG)"
-
-
-      - name: sccache stats
-        if: ${{ always() }}
-        run: sccache --show-stats
 
   # Apply the infra when a release is cut — i.e. when the release-please
   # version-bump PR is merged (release_created). This is the ONLY place
@@ -783,15 +903,15 @@ jobs:
           retention-days: 1
 
   # The .ipa already exists (build-ios staged it) — "publishing" is the altool
-  # push to App Store Connect. Gated on build-macos succeeding, which on the
-  # release path already sits behind deploy-lambdas + its smokes: TestFlight
-  # has no draft state, so this sequencing is what keeps a release whose
-  # backend or desktop didn't ship away from testers. On a workflow_dispatch
-  # rebuild the same order holds, and an already-uploaded build lands in the
-  # duplicate-tolerant path below.
+  # push to App Store Connect. Gated on publish-macos succeeding, which already
+  # sits behind deploy-lambdas + its smokes: TestFlight has no draft state, so
+  # this sequencing is what keeps a release whose backend or desktop didn't
+  # ship away from testers. On a workflow_dispatch rebuild the same order
+  # holds, and an already-uploaded build lands in the duplicate-tolerant path
+  # below.
   publish-ios:
-    needs: [release, build-ios, build-macos]
-    if: ${{ always() && needs.build-ios.result == 'success' && needs.build-macos.result == 'success' }}
+    needs: [release, build-ios, publish-macos]
+    if: ${{ always() && needs.build-ios.result == 'success' && needs.publish-macos.result == 'success' }}
     runs-on: macos-latest # xcrun altool is Apple's uploader — macOS only (the default Xcode is fine for uploads)
     timeout-minutes: 30
     permissions:
@@ -974,12 +1094,12 @@ jobs:
         run: sccache --show-stats
 
   # The macOS sibling of publish-ios: the .pkg already exists, "publishing" is
-  # the altool push to App Store Connect, behind the same build-macos gate (and
-  # transitively the backend deploys + smokes). Duplicate-tolerant so dispatch
-  # re-runs of an already-uploaded tag succeed.
+  # the altool push to App Store Connect, behind the same publish-macos gate
+  # (and transitively the backend deploys + smokes). Duplicate-tolerant so
+  # dispatch re-runs of an already-uploaded tag succeed.
   publish-mas:
-    needs: [release, build-mas, build-macos]
-    if: ${{ always() && needs.build-mas.result == 'success' && needs.build-macos.result == 'success' }}
+    needs: [release, build-mas, publish-macos]
+    if: ${{ always() && needs.build-mas.result == 'success' && needs.publish-macos.result == 'success' }}
     runs-on: macos-latest # xcrun altool is Apple's uploader — macOS only
     timeout-minutes: 30
     permissions:
@@ -1104,11 +1224,11 @@ jobs:
           retention-days: 1
 
   # The node sibling of publish-ios/publish-mas: the binaries already exist,
-  # "publishing" is attaching them as release assets. Behind build-macos on
+  # "publishing" is attaching them as release assets. Behind publish-macos on
   # purpose: the assetless-release resolver treats "release has assets" as
   # "finished", so nothing may attach assets before the macOS publish does.
   node-publish:
-    needs: [release, node-build, build-macos]
+    needs: [release, node-build, publish-macos]
     if: ${{ needs.release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
`build-macos` is the long pole of the release pipeline and sat at the end of a serial chain — `ci → terraform-apply → deploy-lambdas → build-macos` — so ~8 minutes of signing and notarizing waited out a backend it doesn't depend on. Only the *publish* depends on the backend, and only because the updater manifest going up is what makes a release reachable.

## The split

Same shape `build-ios`/`build-mas` and `node-build` already use:

- **`build-macos`** → `needs: [release, ci]`, runs beside the backend and the other Apple builds, stages the signed bundles as the `macos-bundles` workflow artifact. Drops `contents: write` and `deployments: write` (it no longer touches the release, and never sees a release token).
- **`publish-macos`** (new) → `needs: [release, build-macos, deploy-lambdas]`, attaches the bundles and writes `latest.json` last. Ubuntu, no AWS, no signing material.
- **`publish-ios` / `publish-mas` / `node-publish`** now gate on `publish-macos` — that is where the "nothing may attach assets before the macOS publish does" ordering moved.

Every invariant survives: `ci` gates everything, terraform applies before the Lambdas, and a release still cannot reach an installed copy before its backend is live — `latest.json` is written by a job that sits behind `deploy-lambdas` and its smokes.

## Timing

From v1.8.0's run (`29712642701`), which took **18m18s**:

| | start | end |
|---|---|---|
| `ci` done | | 02:32:50 |
| `build-mas` | 02:33:39 | 02:39:43 |
| `build-ios` | 02:32:53 | 02:39:45 |
| `build-macos` | **02:37:17** | **02:45:06** |
| last publish done | | 02:46:34 |

`build-macos` (7m49s) is the same size as its siblings and would have finished ~02:40:45 alongside them. Expected run: **~14 minutes**, roughly 4m30s saved.

## Reproducing `latest.json`

Without `tagName`, tauri-action is in build-only mode ("skipping all uploads") but still reports `artifactPaths` and `appVersion`, so `publish-macos` writes the manifest tauri-action used to write. For a single universal darwin bundle that is six keys — `darwin-{aarch64,x86_64,universal}` plus the `-app` suffixed forms — all pointing at the one `.app.tar.gz` through its REST asset URL, each carrying that bundle's detached signature.

Verified before pushing, not assumed:

- Generated a manifest from fixtures shaped like the real `artifactPaths` and diffed it against the live v1.8.0 `latest.json`: **structurally identical**, including key order. Only `pub_date` precision differs (`.000Z` vs `.927Z`, both RFC3339).
- Asset naming taken from tauri-action's `getAssetName`: the `.dmg` keeps the CLI's filename, the tarball and `.sig` gain version + arch — the exact names v1.8.0 serves.
- The staging guard refuses cleanly when an artifact is missing, and correctly does not mistake the `lux.app` directory for the tarball.
- `actionlint` clean (the one `SC2034` it reports is pre-existing on `main`, in the held-gate-approval step).

`publish-macos` also fetches the bundle back through the URL it just embedded and requires a 200 before uploading the manifest, and refuses to publish if the built version and the release tag disagree.

## Fixes an unreported bug: the release body is wiped on every release

Dropping `tagName` removes tauri-action's `getOrCreateRelease`, which for an existing non-draft release calls `updateRelease` with its own empty `releaseName`/`releaseBody`. The v1.8.0 log shows it plainly:

```
Found release with tag v1.8.0.
Updating name and body of existing release...
```

Consequences on `main` today:

- Every release from v1.3.2 to v1.8.0 has an **empty body** — the CHANGELOG section the `release` job wrote is gone.
- `store-notes` drafts correctly (`attached store notes to v1.8.0`, 02:29:49) and `build-macos` erases it eight minutes later. Since #196 moved the notes into the release body, **no release since 1.3.3 has submittable App Store notes** — `appstore.yml` would fail with `no store notes for <version>`, and `apps/desktop/store-notes/` stops at `1.3.3.md`.

After this change nothing rewrites the body, so the notes survive. Existing releases can be redrafted by re-running their `store-notes` job (it redrafts when the marker is absent).