### PR TITLE
feat(shares): let a guest see a setup someone shared with them

### DIFF
--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -293,6 +293,62 @@ pub fn list_shares(app: &AppHandle) -> Result<lux_wire::shares::SharesResponse, 
     crate::account::block_on(async move { shares(&app).await })
 }
 
+async fn claim_share_req(
+    client: &Client,
+    base: &str,
+    token: String,
+    code: &str,
+) -> Result<lux_wire::shares::ClaimResponse, SyncError> {
+    let resp = client
+        .post(format!(
+            "{base}/{}/{}",
+            lux_wire::shares::SHARES_SEGMENT,
+            lux_wire::shares::CLAIM_SEGMENT
+        ))
+        .bearer_auth(token)
+        .json(&lux_wire::shares::ClaimRequest {
+            code: code.to_owned(),
+        })
+        .send()
+        .await
+        .map_err(|e| SyncError::Other(e.to_string()))?;
+    // A refused code is the ordinary outcome here (mistyped, expired, already
+    // used), and the server deliberately says the same thing for all of them —
+    // so surface its message rather than a status code.
+    if resp.status() == StatusCode::NOT_FOUND || resp.status() == StatusCode::CONFLICT {
+        let body = resp.json::<lux_wire::ErrorResponse>().await;
+        return Err(SyncError::Other(match body {
+            Ok(e) => e.error,
+            Err(_) => "that invite code is not valid".to_owned(),
+        }));
+    }
+    read_json(resp).await
+}
+
+/// Redeem an invite code, gaining control of one of someone else's setups.
+pub fn claim_share(
+    app: &AppHandle,
+    code: &str,
+) -> Result<lux_wire::shares::ClaimResponse, String> {
+    let (base, token) = {
+        let account = app.state::<LuxAccount>();
+        let base = account.sync_url().ok_or("cloud sync is not configured")?;
+        let token = account.current_id_token().ok_or("not signed in")?;
+        (base, token)
+    };
+    let app = app.clone();
+    let code = code.to_owned();
+    crate::account::block_on(async move {
+        let client = Client::new();
+        let mut result = claim_share_req(&client, &base, token, &code).await;
+        if matches!(result, Err(SyncError::Unauthorized)) {
+            let fresh = refresh(&app).await.map_err(|e| e.to_string())?;
+            result = claim_share_req(&client, &base, fresh, &code).await;
+        }
+        result.map_err(|e| e.to_string())
+    })
+}
+
 /// The async half of [`list_shares`], for callers already inside the runtime —
 /// the retained-config publisher runs on the nudge connection's task, where
 /// blocking on a worker thread would stall the whole user channel.

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -1,3 +1,4 @@
+use crate::guest::SharedSetup;
 use crate::lock::LockPolicy;
 use crate::{
     account::{AuthStatus, LuxAccount},
@@ -143,6 +144,18 @@ pub trait CmdMethods {
     // account ends every share it is part of, including ones other people
     // depend on.
     fn list_shares(&self, app_handle: AppHandle) -> Result<ShareTally, String>;
+    // Shared control, guest side: setups other people have shared with this
+    // account. `open_shared_desk` returns everything a surface needs to draw
+    // one — the owner's compiled setup plus their applier's last-known buffer —
+    // in a single call, because a guest holds no copy of either.
+    fn claim_share(&self, app_handle: AppHandle, code: String) -> Result<SharedSetup, String>;
+    fn list_shared_setups(&self, app_handle: AppHandle) -> Result<Vec<SharedSetup>, String>;
+    fn open_shared_desk(
+        &self,
+        app_handle: AppHandle,
+        owner_sub: String,
+        setup_id: String,
+    ) -> Result<Option<SharedDesk>, String>;
     // DMX output — the in-app device picker (the only output selector on mobile,
     // where there's no tray). Mirrors the desktop tray's device menu.
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String>;
@@ -194,6 +207,48 @@ pub struct ShareTally {
     pub granted_to: Vec<String>,
     /// People whose setups the caller can currently control.
     pub received_from: Vec<String>,
+}
+
+/// Everything a guest surface needs to draw one shared setup: the owner's
+/// compiled setup, flattened, plus their applier's last-known buffer so the
+/// faders open at the truth instead of at zero.
+///
+/// Returned whole rather than as separate calls because a guest has no copy of
+/// any of it — there is no local store to read a second time, and a surface
+/// that drew before the buffer arrived would show a dark desk that isn't.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SharedDesk {
+    pub owner_sub: String,
+    pub setup_id: String,
+    /// The setup's live name, from the compiled config.
+    pub name: String,
+    pub universe: u16,
+    pub channels: Vec<SharedChannel>,
+    pub fixtures: Vec<SharedFixture>,
+    /// The owner applier's last-applied buffer. Empty when it hasn't published
+    /// one — a surface should render zeros, not refuse to draw.
+    pub buffer: Vec<u8>,
+}
+
+/// One patched slot on a shared desk (`lux_wire::ctl::ConfigChannel`).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct SharedChannel {
+    /// 1-based DMX slot.
+    pub n: u16,
+    pub name: String,
+    /// Role name; a surface matches the ones it knows and treats the rest as a
+    /// plain fader, so an unfamiliar value is never an error.
+    pub role: String,
+}
+
+/// One fixture on a shared desk (`lux_wire::ctl::ConfigFixture`).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SharedFixture {
+    pub name: String,
+    pub address: u16,
+    pub count: u16,
 }
 
 #[derive(ttipc::Event)]
@@ -613,6 +668,66 @@ impl CmdMethods for CmdEndpoint {
         })
     }
 
+    fn claim_share(&self, app_handle: AppHandle, code: String) -> Result<SharedSetup, String> {
+        let claimed = crate::cloud::claim_share(&app_handle, &code)?;
+        // Pull straight away rather than waiting on the nudge: the claimer is
+        // watching this happen, and the grant is what makes the retained
+        // topics readable at all.
+        crate::nudge::refresh_shares(&app_handle);
+        Ok(SharedSetup {
+            owner_sub: claimed.owner_sub,
+            owner_label: claimed.owner_label,
+            setup_id: claimed.setup_id,
+            setup_name: claimed.setup_name,
+            // The owner's compiled setup arrives on its retained topic a moment
+            // after the subscribe; the list shows the row meanwhile.
+            renderable: false,
+        })
+    }
+
+    fn list_shared_setups(&self, app_handle: AppHandle) -> Result<Vec<SharedSetup>, String> {
+        Ok(app_handle.state::<crate::guest::LuxGuest>().shared_setups())
+    }
+
+    fn open_shared_desk(
+        &self,
+        app_handle: AppHandle,
+        owner_sub: String,
+        setup_id: String,
+    ) -> Result<Option<SharedDesk>, String> {
+        let guest = app_handle.state::<crate::guest::LuxGuest>();
+        let Some(config) = guest.config(&owner_sub, &setup_id) else {
+            // No compiled setup yet: the owner's applier may simply not be
+            // running. The surface says so rather than drawing an empty desk.
+            return Ok(None);
+        };
+        Ok(Some(SharedDesk {
+            owner_sub: owner_sub.clone(),
+            setup_id: setup_id.clone(),
+            name: config.name,
+            universe: config.universe,
+            channels: config
+                .channels
+                .into_iter()
+                .map(|c| SharedChannel {
+                    n: c.n,
+                    name: c.name,
+                    role: c.role,
+                })
+                .collect(),
+            fixtures: config
+                .fixtures
+                .into_iter()
+                .map(|f| SharedFixture {
+                    name: f.name,
+                    address: f.address,
+                    count: f.count,
+                })
+                .collect(),
+            buffer: guest.state(&owner_sub, &setup_id).unwrap_or_default(),
+        }))
+    }
+
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String> {
         Ok(devices::device_list(&app_handle))
     }
@@ -656,8 +771,8 @@ fn commit_patch(app: &AppHandle, setups: &LuxSetups) -> Result<Vec<Fixture>, Str
     .map_err(|e| format!("Failed to emit patch_set event: {e}"))?;
     crate::cloud::schedule_push(app);
     // A shared setup's guests render from its retained config, so it has to
-    // follow the setup rather than lag it (coalesced; see refresh_shared_configs).
-    crate::nudge::refresh_shared_configs(app);
+    // follow the setup rather than lag it (coalesced; see refresh_shares).
+    crate::nudge::refresh_shares(app);
     Ok(fixtures)
 }
 
@@ -684,8 +799,8 @@ fn commit_setups(app: &AppHandle, setups: &LuxSetups) -> Result<Vec<SetupSummary
     .map_err(|e| format!("Failed to emit setups_changed event: {e}"))?;
     crate::cloud::schedule_push(app);
     // A shared setup's guests render from its retained config, so it has to
-    // follow the setup rather than lag it (coalesced; see refresh_shared_configs).
-    crate::nudge::refresh_shared_configs(app);
+    // follow the setup rather than lag it (coalesced; see refresh_shares).
+    crate::nudge::refresh_shares(app);
     Ok(summaries)
 }
 
@@ -698,7 +813,7 @@ pub fn broadcast_synced_state(app: &AppHandle) {
     // A pull can change a shared setup's patch, name, or universe from another
     // device; guests render from the retained config, so it follows the pull.
     // (Coalesced, so this and the nudge that scheduled the pull are one.)
-    crate::nudge::refresh_shared_configs(app);
+    crate::nudge::refresh_shares(app);
     devices::set_active_universe(app, setups.active_universe());
     let active_id = setups.active_id().to_string();
     let _ = CmdEvent::SetupsChanged {

--- a/apps/desktop/src-tauri/src/guest.rs
+++ b/apps/desktop/src-tauri/src/guest.rs
@@ -1,0 +1,266 @@
+//! The guest half of shared control: what this device can *see* of a setup
+//! someone else shared with it (docs/shared-control.md).
+//!
+//! A guest holds no copy of the owner's setup and never syncs one. Everything
+//! it knows arrives on two retained topics in the owner's ctl space:
+//!
+//! - `…/setup/<id>/config` — the compiled setup, which is the guest surface's
+//!   entire source of truth for what the desk looks like.
+//! - `…/setup/<id>/state` — the owner applier's last-applied buffer, so a
+//!   guest's faders open at the truth rather than at zero.
+//!
+//! That is deliberately all of it. Nothing here writes to disk, nothing here
+//! joins the sync engine, and nothing survives sign-out — when a grant ends,
+//! the guest's view of it ends with the process at the latest, and usually
+//! sooner (the owner clears the retained config, and the authorizer stops
+//! granting receive at the next reconnect).
+//!
+//! This module is read-only by construction: it subscribes, parses, and
+//! stores. Publishing into an owner's space — presence and control frames —
+//! is a separate concern and lives with the surface that does it.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use tauri::{AppHandle, Manager, Runtime};
+
+use crate::lock::LockPolicy;
+
+/// Identifies one shared setup: whose space it lives in, and which setup.
+type Key = (String, String);
+
+/// One setup another account has shared with this one, as a surface sees it.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SharedSetup {
+    /// The owner's Cognito sub — the ctl topic space this grant addresses.
+    pub owner_sub: String,
+    /// How the owner appears in the list (their account email).
+    pub owner_label: String,
+    pub setup_id: String,
+    /// The name recorded when the grant was created. The live name rides the
+    /// compiled config; this is what the list shows before one arrives.
+    pub setup_name: Option<String>,
+    /// True once the owner's compiled config has arrived, which is what a
+    /// surface needs before it can draw anything. False means the owner's
+    /// applier has not published one — it may simply not be running.
+    pub renderable: bool,
+}
+
+/// What this device can currently see of other people's setups.
+///
+/// Held in memory only. A restart re-learns all of it from `GET /shares` plus
+/// the retained topics, which is the point: there is no local copy of someone
+/// else's setup to go stale, leak, or need cleaning up when a grant ends.
+#[derive(Default)]
+pub struct LuxGuest {
+    /// Grants received, from `GET /shares` — the authority on what may be
+    /// opened at all. The retained topics are the *content*; this is the
+    /// permission, and a config without a matching grant is ignored.
+    grants: Mutex<Vec<lux_wire::shares::ReceivedGrant>>,
+    /// Compiled setups, as published by each owner's applier.
+    configs: Mutex<HashMap<Key, lux_wire::ctl::Config>>,
+    /// Each shared setup's last-known buffer, from the owner's state echo.
+    states: Mutex<HashMap<Key, Vec<u8>>>,
+}
+
+impl LuxGuest {
+    /// The shared setups this device may open, newest grant first.
+    pub fn shared_setups(&self) -> Vec<SharedSetup> {
+        let configs = self.configs.lock_or_recover();
+        let mut shared: Vec<SharedSetup> = self
+            .grants
+            .lock_or_recover()
+            .iter()
+            .map(|g| SharedSetup {
+                owner_sub: g.owner_sub.clone(),
+                owner_label: g.owner_label.clone(),
+                setup_id: g.setup_id.clone(),
+                setup_name: g.setup_name.clone(),
+                renderable: configs.contains_key(&(g.owner_sub.clone(), g.setup_id.clone())),
+            })
+            .collect();
+        shared.sort_by(|a, b| (&a.owner_label, &a.setup_id).cmp(&(&b.owner_label, &b.setup_id)));
+        shared
+    }
+
+    /// The compiled setup for one shared setup, if its config has arrived.
+    pub fn config(&self, owner_sub: &str, setup_id: &str) -> Option<lux_wire::ctl::Config> {
+        self.configs
+            .lock_or_recover()
+            .get(&(owner_sub.to_owned(), setup_id.to_owned()))
+            .cloned()
+    }
+
+    /// The owner applier's last-known buffer for one shared setup.
+    pub fn state(&self, owner_sub: &str, setup_id: &str) -> Option<Vec<u8>> {
+        self.states
+            .lock_or_recover()
+            .get(&(owner_sub.to_owned(), setup_id.to_owned()))
+            .cloned()
+    }
+
+    /// Does a live grant cover this pair? The check every incoming payload
+    /// passes before it is stored — the authorizer is the real gate, but a
+    /// listener that trusted topics alone would keep rendering a setup whose
+    /// grant ended until the connection happened to drop.
+    fn granted(&self, owner_sub: &str, setup_id: &str) -> bool {
+        self.grants
+            .lock_or_recover()
+            .iter()
+            .any(|g| g.owner_sub == owner_sub && g.setup_id == setup_id)
+    }
+}
+
+/// Adopt the grants from a `GET /shares` pull: remember them, and forget
+/// everything belonging to a grant that is no longer in the list.
+///
+/// Forgetting is the half that matters. A revoked guest keeps its connection —
+/// and therefore its old policy — until the authorizer's refresh window
+/// expires, so the broker may still deliver on a topic it no longer has any
+/// business reading. Dropping the content the moment the grant leaves the list
+/// makes the surface honest well before the policy catches up.
+pub fn adopt_grants<R: Runtime>(app: &AppHandle<R>, received: &[lux_wire::shares::ReceivedGrant]) {
+    let guest = app.state::<LuxGuest>();
+    let live: Vec<Key> = received
+        .iter()
+        .map(|g| (g.owner_sub.clone(), g.setup_id.clone()))
+        .collect();
+    *guest.grants.lock_or_recover() = received.to_vec();
+    guest
+        .configs
+        .lock_or_recover()
+        .retain(|key, _| live.contains(key));
+    guest
+        .states
+        .lock_or_recover()
+        .retain(|key, _| live.contains(key));
+}
+
+/// Store an owner's compiled setup. An empty payload is the owner clearing it
+/// (the setup was deleted, or the last grant on it was revoked), which drops
+/// the surface's ability to render rather than leaving a stale desk up.
+pub fn receive_config<R: Runtime>(
+    app: &AppHandle<R>,
+    owner_sub: &str,
+    setup_id: &str,
+    payload: &[u8],
+) {
+    let guest = app.state::<LuxGuest>();
+    if !guest.granted(owner_sub, setup_id) {
+        log::debug!("ignoring a config for {owner_sub}/{setup_id}: no live grant");
+        return;
+    }
+    let key = (owner_sub.to_owned(), setup_id.to_owned());
+    if payload.is_empty() {
+        guest.configs.lock_or_recover().remove(&key);
+        return;
+    }
+    let config: lux_wire::ctl::Config = match serde_json::from_slice(payload) {
+        Ok(config) => config,
+        Err(e) => {
+            log::warn!("ignoring an unreadable compiled setup from {owner_sub}: {e}");
+            return;
+        }
+    };
+    if config.v != lux_wire::ctl::VERSION {
+        // The owner is on a newer app than this one — App Review lag makes
+        // that the normal case, not an error. Drop it and render nothing
+        // rather than guess at a shape we don't know.
+        log::info!(
+            "dropping a compiled setup from {owner_sub} with unknown version {}",
+            config.v
+        );
+        return;
+    }
+    guest.configs.lock_or_recover().insert(key, config);
+}
+
+/// Store an owner applier's last-applied buffer for a shared setup, so a guest
+/// surface opens showing what the fixtures are actually doing.
+pub fn receive_state<R: Runtime>(
+    app: &AppHandle<R>,
+    owner_sub: &str,
+    setup_id: &str,
+    payload: &[u8],
+) {
+    let guest = app.state::<LuxGuest>();
+    if !guest.granted(owner_sub, setup_id) {
+        return;
+    }
+    if payload.is_empty() {
+        guest
+            .states
+            .lock_or_recover()
+            .remove(&(owner_sub.to_owned(), setup_id.to_owned()));
+        return;
+    }
+    let frame: lux_wire::ctl::Frame = match serde_json::from_slice(payload) {
+        Ok(frame) => frame,
+        Err(e) => {
+            log::warn!("ignoring an unreadable state echo from {owner_sub}: {e}");
+            return;
+        }
+    };
+    if frame.version() != lux_wire::ctl::VERSION {
+        return;
+    }
+    // Only a full buffer is a state echo; a channel frame here would be a
+    // publisher doing something we don't model, not a partial update to merge.
+    if let lux_wire::ctl::Frame::Buffer { buffer, .. } = frame {
+        guest
+            .states
+            .lock_or_recover()
+            .insert((owner_sub.to_owned(), setup_id.to_owned()), buffer);
+    }
+}
+
+/// The topics a guest subscribes to for one grant: the owner's compiled setup
+/// and their applier's state echo, and nothing else. Exactly the two the
+/// authorizer grants receive on.
+pub fn subscriptions(received: &[lux_wire::shares::ReceivedGrant]) -> Vec<String> {
+    received
+        .iter()
+        .flat_map(|g| {
+            [
+                lux_wire::ctl::config_topic(&g.owner_sub, &g.setup_id),
+                lux_wire::ctl::state_topic(&g.owner_sub, &g.setup_id),
+            ]
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grant(owner: &str, setup: &str) -> lux_wire::shares::ReceivedGrant {
+        lux_wire::shares::ReceivedGrant {
+            owner_sub: owner.into(),
+            owner_label: format!("{owner}@example.com"),
+            setup_id: setup.into(),
+            setup_name: Some("Living room".into()),
+            created_at: 0,
+        }
+    }
+
+    #[test]
+    fn subscriptions_are_the_two_topics_the_authorizer_grants() {
+        let topics = subscriptions(&[grant("owner-1", "s-1")]);
+        assert_eq!(
+            topics,
+            vec![
+                "lux/ctl/user/owner-1/setup/s-1/config",
+                "lux/ctl/user/owner-1/setup/s-1/state",
+            ]
+        );
+        // Never the owner's frame topic: a guest publishes there, and receiving
+        // it would mean seeing other guests' input.
+        assert!(!topics.iter().any(|t| t.ends_with("/frame")));
+        // Never a wildcard — a guest's reach is two exact topics per grant.
+        assert!(!topics.iter().any(|t| t.contains('#') || t.contains('+')));
+
+        let two = subscriptions(&[grant("owner-1", "s-1"), grant("owner-2", "s-9")]);
+        assert_eq!(two.len(), 4);
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod error;
 mod fixture;
 mod lock;
 mod logger;
+mod guest;
 mod nudge;
 mod remote;
 mod settings;
@@ -77,7 +78,8 @@ pub async fn run() {
         .manage(default_channels)
         .manage(DmxOutput::default())
         .manage(cloud::LuxSync::default())
-        .manage(nudge::LuxNudge::default());
+        .manage(nudge::LuxNudge::default())
+        .manage(guest::LuxGuest::default());
     // Window positioning relative to monitors and the tray, backing the
     // frontend's @tauri-apps/plugin-positioner API. Desktop-only: mobile has
     // no movable windows and no tray.

--- a/apps/desktop/src-tauri/src/nudge.rs
+++ b/apps/desktop/src-tauri/src/nudge.rs
@@ -44,7 +44,7 @@ use tokio::sync::watch;
 use uuid::Uuid;
 
 use lux_engine::auth::jwt_sub;
-use lux_engine::ctl::{gate, route, RemoteApply, Route};
+use lux_engine::ctl::{gate, guest_route, route, GuestRoute, RemoteApply, Route};
 use lux_engine::tls::webpki_pem_bundle;
 
 use crate::account::LuxAccount;
@@ -106,7 +106,7 @@ pub struct LuxNudge {
     local_input_at: Mutex<Option<Instant>>,
     /// Consecutive ctl-suspect connection deaths (see [`CTL_FAILURE_LIMIT`]).
     ctl_failures: AtomicU32,
-    /// A retained-config reconcile is queued (see [`refresh_shared_configs`]).
+    /// A retained-config reconcile is queued (see [`refresh_shares`]).
     configs_pending: AtomicBool,
 }
 
@@ -443,6 +443,28 @@ fn config_plan(
         .collect()
 }
 
+/// Subscribe to the topics this device's received grants allow it to read.
+///
+/// Additive and idempotent: re-subscribing to a topic already held is a no-op
+/// at the broker, and a grant that ended simply stops being subscribed on the
+/// next connection. There is deliberately no unsubscribe — the authorizer stops
+/// delivering when it drops the grant from the policy, and
+/// [`crate::guest::adopt_grants`] has already forgotten the content, so an
+/// extra subscription buys an attacker nothing and costs a round trip.
+fn subscribe_shared<R: Runtime>(app: &AppHandle<R>, received: &[lux_wire::shares::ReceivedGrant]) {
+    let Some(echo) = app.state::<LuxNudge>().echo.lock_or_recover().clone() else {
+        return;
+    };
+    for topic in crate::guest::subscriptions(received) {
+        let client = echo.client.clone();
+        tauri::async_runtime::spawn(async move {
+            if let Err(e) = client.subscribe(&topic, QoS::AtMostOnce).await {
+                log::debug!("could not subscribe to {topic}: {e}");
+            }
+        });
+    }
+}
+
 /// Clear one setup's retained config. Called when a setup is deleted, while its
 /// id is still known — after that, [`reconcile_configs`] can no longer name it.
 pub fn clear_config<R: Runtime>(app: &AppHandle<R>, setup_id: uuid::Uuid) {
@@ -461,14 +483,18 @@ pub fn clear_config<R: Runtime>(app: &AppHandle<R>, setup_id: uuid::Uuid) {
     });
 }
 
-/// Fetch the caller's grants and reconcile the retained configs against them.
+/// Fetch the caller's shares and reconcile both halves of the feature against
+/// them: the retained configs this device publishes as an owner, and the
+/// grants it holds as a guest. One pull answers both, so they cannot disagree
+/// about what is shared.
+///
 /// The entry point for anything that changes *who* can see a setup — a shares
 /// nudge, and the connect handshake, where a grant may have changed while this
 /// device was offline.
 /// Coalesced, so every caller can be naive: a cloud pull, the nudge that caused
 /// it, and the local commit it produces all land in one reconcile instead of
 /// three round trips.
-pub fn refresh_shared_configs(app: &AppHandle) {
+pub fn refresh_shares(app: &AppHandle) {
     let state = app.state::<LuxNudge>();
     if state.echo.lock_or_recover().is_none() {
         return;
@@ -483,7 +509,11 @@ pub fn refresh_shared_configs(app: &AppHandle) {
             .configs_pending
             .store(false, Ordering::SeqCst);
         match crate::cloud::shares(&app).await {
-            Ok(shares) => reconcile_configs(&app, &shares.granted),
+            Ok(shares) => {
+                reconcile_configs(&app, &shares.granted);
+                crate::guest::adopt_grants(&app, &shares.received);
+                subscribe_shared(&app, &shares.received);
+            }
             // Leave the retained configs exactly as they are. Publishing on a
             // guess is worse than publishing late: the pull retries, and a
             // grant that was revoked is already unreadable by the guest whose
@@ -688,7 +718,7 @@ async fn run_connection(
                         // while this device is offline, so reconcile on every
                         // connect rather than trusting what a past session
                         // published.
-                        refresh_shared_configs(app);
+                        refresh_shares(app);
                     }
                 }
                 Ok(Event::Incoming(Packet::Publish(publish))) => {
@@ -699,7 +729,7 @@ async fn run_connection(
                             // can see a setup as well as what is in it.
                             log::debug!("nudge received; scheduling sync");
                             crate::cloud::schedule_sync(app);
-                            refresh_shared_configs(app);
+                            refresh_shares(app);
                         }
                         Route::Frame { setup_id } => {
                             apply_frame(app, &publish.payload, setup_id, &session);
@@ -710,10 +740,35 @@ async fn run_connection(
                         Route::Presence { session: card_session } => {
                             update_presence(app, &publish.payload, card_session, &session);
                         }
-                        Route::Config => {}
-                        Route::Unknown => {
-                            log::debug!("ignoring publish on unexpected topic {}", publish.topic);
+                        Route::Config => {
+                            // Our own compiled setup, echoed back by the `#`
+                            // subscribe. We published it; nothing to learn.
                         }
+                        // Not our own space — the other place a publish can
+                        // legitimately come from is an owner who shared a setup
+                        // with us.
+                        Route::Unknown => match guest_route(&publish.topic, sub) {
+                            Some(GuestRoute::Config { owner_sub, setup_id }) => {
+                                crate::guest::receive_config(
+                                    app,
+                                    owner_sub,
+                                    setup_id,
+                                    &publish.payload,
+                                );
+                            }
+                            Some(GuestRoute::State { owner_sub, setup_id }) => {
+                                crate::guest::receive_state(
+                                    app,
+                                    owner_sub,
+                                    setup_id,
+                                    &publish.payload,
+                                );
+                            }
+                            None => log::debug!(
+                                "ignoring publish on unexpected topic {}",
+                                publish.topic
+                            ),
+                        },
                     }
                 }
                 Ok(_) => {}

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -180,6 +180,34 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  claim_share(code: string): Promise<SharedSetup> {
+    return invoke("cmd.claim_share", { code });
+  },
+
+  /** @throws {string} */
+  list_shared_setups(): Promise<SharedSetup[]> {
+    return invoke("cmd.list_shared_setups");
+  },
+
+  /** @throws {string} */
+  open_shared_desk(ownerSub: string, setupId: string): Promise<{
+	ownerSub: string,
+	setupId: string,
+	/**  The setup's live name, from the compiled config. */
+	name: string,
+	universe: number,
+	channels: SharedChannel[],
+	fixtures: SharedFixture[],
+	/**
+	 *  The owner applier's last-applied buffer. Empty when it hasn't published
+	 *  one — a surface should render zeros, not refuse to draw.
+	 */
+	buffer: number[],
+} | null> {
+    return invoke("cmd.open_shared_desk", { owner_sub: ownerSub, setup_id: setupId });
+  },
+
+  /** @throws {string} */
   list_dmx_devices(): Promise<DmxDeviceInfo[]> {
     return invoke("cmd.list_dmx_devices");
   },
@@ -388,6 +416,69 @@ export type ShareTally = {
 	grantedTo: string[],
 	/**  People whose setups the caller can currently control. */
 	receivedFrom: string[],
+};
+
+/**  One patched slot on a shared desk (`lux_wire::ctl::ConfigChannel`). */
+export type SharedChannel = {
+	/**  1-based DMX slot. */
+	n: number,
+	name: string,
+	/**
+	 *  Role name; a surface matches the ones it knows and treats the rest as a
+	 *  plain fader, so an unfamiliar value is never an error.
+	 */
+	role: string,
+};
+
+/**
+ *  Everything a guest surface needs to draw one shared setup: the owner's
+ *  compiled setup, flattened, plus their applier's last-known buffer so the
+ *  faders open at the truth instead of at zero.
+ * 
+ *  Returned whole rather than as separate calls because a guest has no copy of
+ *  any of it — there is no local store to read a second time, and a surface
+ *  that drew before the buffer arrived would show a dark desk that isn't.
+ */
+export type SharedDesk = {
+	ownerSub: string,
+	setupId: string,
+	/**  The setup's live name, from the compiled config. */
+	name: string,
+	universe: number,
+	channels: SharedChannel[],
+	fixtures: SharedFixture[],
+	/**
+	 *  The owner applier's last-applied buffer. Empty when it hasn't published
+	 *  one — a surface should render zeros, not refuse to draw.
+	 */
+	buffer: number[],
+};
+
+/**  One fixture on a shared desk (`lux_wire::ctl::ConfigFixture`). */
+export type SharedFixture = {
+	name: string,
+	address: number,
+	count: number,
+};
+
+/**  One setup another account has shared with this one, as a surface sees it. */
+export type SharedSetup = {
+	/**  The owner's Cognito sub — the ctl topic space this grant addresses. */
+	ownerSub: string,
+	/**  How the owner appears in the list (their account email). */
+	ownerLabel: string,
+	setupId: string,
+	/**
+	 *  The name recorded when the grant was created. The live name rides the
+	 *  compiled config; this is what the list shows before one arrives.
+	 */
+	setupName: string | null,
+	/**
+	 *  True once the owner's compiled config has arrived, which is what a
+	 *  surface needs before it can draw anything. False means the owner's
+	 *  applier has not published one — it may simply not be running.
+	 */
+	renderable: boolean,
 };
 
 /**

--- a/crates/lux-engine/src/ctl.rs
+++ b/crates/lux-engine/src/ctl.rs
@@ -46,6 +46,62 @@ pub fn route<'t>(topic: &'t str, sub: &str) -> Route<'t> {
     Route::Unknown
 }
 
+/// An incoming publish from *another* account's ctl space — one this
+/// connection holds a shared-control grant in (docs/shared-control.md).
+///
+/// Separate from [`Route`] rather than folded into it because the two answer
+/// different questions. [`Route`] asks "what is this in my own space", where
+/// the sub is known up front. This asks "which owner and setup is this about",
+/// where the owner is what the topic is telling us. A guest also sees strictly
+/// less: frames and presence in an owner's space are not its business, and the
+/// authorizer never grants receive on them.
+#[derive(Debug, PartialEq, Eq)]
+pub enum GuestRoute<'t> {
+    /// The owner's compiled setup — a guest surface's entire source of truth
+    /// for what the desk looks like. An empty payload means the grant ended or
+    /// the setup is gone.
+    Config {
+        owner_sub: &'t str,
+        setup_id: &'t str,
+    },
+    /// The owner applier's retained state echo — what the fixtures are actually
+    /// doing, so a guest's faders open at the truth rather than at zero.
+    State {
+        owner_sub: &'t str,
+        setup_id: &'t str,
+    },
+}
+
+/// Classify a publish arriving from an owner's space. `own_sub` is this
+/// connection's own user, whose traffic belongs to [`route`] instead — so the
+/// two classifiers never both claim a topic.
+///
+/// Structural only: it reports what a topic *says*, not whether the grant
+/// behind it is live. The authorizer already decides what may be received, and
+/// the caller matches the pair against its own list of grants before acting.
+pub fn guest_route<'t>(topic: &'t str, own_sub: &str) -> Option<GuestRoute<'t>> {
+    let rest = topic.strip_prefix("lux/ctl/user/")?;
+    let (owner_sub, rest) = rest.split_once('/')?;
+    if owner_sub.is_empty() || owner_sub == own_sub {
+        return None; // our own space
+    }
+    let (setup_id, leaf) = rest.strip_prefix("setup/")?.split_once('/')?;
+    if setup_id.is_empty() {
+        return None;
+    }
+    match leaf {
+        "config" => Some(GuestRoute::Config {
+            owner_sub,
+            setup_id,
+        }),
+        "state" => Some(GuestRoute::State {
+            owner_sub,
+            setup_id,
+        }),
+        _ => None,
+    }
+}
+
 /// One applicable buffer mutation extracted from a gated ctl frame.
 #[derive(Debug, PartialEq, Eq)]
 pub enum RemoteApply {
@@ -86,6 +142,41 @@ pub fn gate(
 mod tests {
     use super::*;
     use lux_wire::ctl::Frame;
+
+    #[test]
+    fn guest_route_reads_the_owner_and_setup_off_the_topic() {
+        let me = "me-1";
+        assert_eq!(
+            guest_route("lux/ctl/user/owner-9/setup/s-1/config", me),
+            Some(GuestRoute::Config {
+                owner_sub: "owner-9",
+                setup_id: "s-1"
+            })
+        );
+        assert_eq!(
+            guest_route("lux/ctl/user/owner-9/setup/s-1/state", me),
+            Some(GuestRoute::State {
+                owner_sub: "owner-9",
+                setup_id: "s-1"
+            })
+        );
+
+        // Our own space belongs to `route`; the two never both claim a topic.
+        assert_eq!(guest_route("lux/ctl/user/me-1/setup/s-1/config", me), None);
+        assert_eq!(route("lux/ctl/user/me-1/setup/s-1/state", me), Route::State { setup_id: "s-1" });
+
+        // A guest is never granted receive on these, and must not act on one
+        // if a future policy change ever delivered it.
+        assert_eq!(guest_route("lux/ctl/user/owner-9/setup/s-1/frame", me), None);
+        assert_eq!(guest_route("lux/ctl/user/owner-9/presence/me-1", me), None);
+
+        // Malformed or foreign topics are not guessed at.
+        assert_eq!(guest_route("lux/sync/user/owner-9", me), None);
+        assert_eq!(guest_route("lux/ctl/user//setup/s-1/config", me), None);
+        assert_eq!(guest_route("lux/ctl/user/owner-9/setup//config", me), None);
+        assert_eq!(guest_route("lux/ctl/user/owner-9/setup/s-1", me), None);
+        assert_eq!(guest_route("nonsense", me), None);
+    }
 
     #[test]
     fn route_classifies_the_user_channel() {


### PR DESCRIPTION
P2c, first half. A guest can now redeem a code, list what has been shared with them, and fetch everything needed to draw one shared desk.

**Nothing here publishes into anyone's space.** Presence and control frames are the next change, deliberately split out so the code that can drive someone else's rig gets its own focused review. This half is read-only by construction: it subscribes, parses, and stores.

Backed by the production runbook from #229 — the guest policy this reads against is verified live, so the topics it subscribes to are the ones the authorizer actually grants.

## `guest_route`

A second classifier in `lux-engine`, for publishes arriving from *another* account's ctl space. Separate from `route` rather than folded into it because the two answer different questions: `route` asks "what is this in my own space", where the sub is known up front; this asks "which owner and setup is this about", where the topic is what tells us.

A guest also sees strictly less. Frames and presence in an owner's space are not its business and the authorizer never grants receive on them, so the classifier refuses to name them at all — if a future policy change ever delivered one, this still wouldn't act on it. Tested against both, plus the malformed shapes (empty owner, empty setup, missing leaf) and the overlap case that our own space belongs to `route`.

## `LuxGuest`

Grants, compiled setups, and last-known buffers — **in memory only**. That's the design, not an omission: a guest holds no copy of anyone else's setup, so there is nothing to go stale, leak, or clean up when a grant ends. A restart re-learns everything from `GET /shares` plus the retained topics.

**Content is dropped the moment a grant leaves the list**, which is the half worth arguing about. A revoked guest keeps its connection — and therefore its old policy — until the authorizer's refresh window expires, so the broker may still deliver on a topic it no longer has any business reading. Forgetting eagerly makes the surface honest well before the policy catches up. Every incoming payload is also checked against a live grant before being stored, so a topic alone is never enough.

Version skew is handled the way the rest of the ctl plane handles it: a config carrying an unknown `v` is logged and dropped rather than guessed at. With App Review lag, an owner on a newer app than the guest is the normal case, not an error.

## Commands

`claim_share`, `list_shared_setups`, and `open_shared_desk`. The last returns the compiled setup *and* the owner's last-known buffer in one call — a guest has no local store to read a second time, and a surface that drew before the buffer arrived would show a dark desk that isn't. When no config has arrived it returns `None` rather than an empty desk, so the surface can say "the owner's app isn't running" instead of lying.

`SharedDesk`/`SharedChannel`/`SharedFixture` mirror the `ctl::Config` shapes rather than deriving `specta::Type` on `lux-wire` — that crate is also compiled into four Lambdas, and this keeps specta out of them. Same pattern as `PairedDevice` mirroring `DeviceRecord`.

## One pull, both halves

`refresh_shared_configs` becomes `refresh_shares`: it now reconciles the retained configs this device publishes as an owner *and* the grants it holds as a guest, from a single `GET /shares`. They cannot disagree about what is shared, and it's one round trip instead of two.

Subscriptions are additive and idempotent, with no unsubscribe — the authorizer stops delivering when it drops a grant from the policy, and the content is already forgotten, so an extra subscription buys nothing and costs a round trip.

Gate green locally: 17 Rust suites, clippy, eslint, tsc, bindings regenerated.

## Next

The write side: guest presence on `guest_presence_topic(owner, contact)` (the exact topic, no session suffix — #223), `src`-attributed frames to the owner's frame topic, and the surface itself.