### PR TITLE
feat(shares): let a guest drive a setup someone shared with them

### DIFF
--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -156,6 +156,13 @@ pub trait CmdMethods {
         owner_sub: String,
         setup_id: String,
     ) -> Result<Option<SharedDesk>, String>;
+    fn close_shared_desk(&self, app_handle: AppHandle) -> Result<(), String>;
+    // Guest control writes. These publish to the *owner's* frame topic and
+    // never touch this device's own buffer — a guest moving a fader on someone
+    // else's desk must not move their own fixtures.
+    fn set_shared_channel(&self, app_handle: AppHandle, channel_number: u16, value: u8)
+        -> Result<(), String>;
+    fn set_shared_buffer(&self, app_handle: AppHandle, buffer: Vec<u8>) -> Result<(), String>;
     // DMX output — the in-app device picker (the only output selector on mobile,
     // where there's no tray). Mirrors the desktop tray's device menu.
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String>;
@@ -701,7 +708,7 @@ impl CmdMethods for CmdEndpoint {
             // running. The surface says so rather than drawing an empty desk.
             return Ok(None);
         };
-        Ok(Some(SharedDesk {
+        let desk = Ok(Some(SharedDesk {
             owner_sub: owner_sub.clone(),
             setup_id: setup_id.clone(),
             name: config.name,
@@ -725,7 +732,32 @@ impl CmdMethods for CmdEndpoint {
                 })
                 .collect(),
             buffer: guest.state(&owner_sub, &setup_id).unwrap_or_default(),
-        }))
+        }));
+        // Bind the publish target and announce this guest on the owner's desk
+        // only once there is something to draw — a surface that couldn't render
+        // shouldn't claim to be live on it.
+        crate::guest::open_desk(&app_handle, &owner_sub, &setup_id);
+        desk
+    }
+
+    fn close_shared_desk(&self, app_handle: AppHandle) -> Result<(), String> {
+        crate::guest::close_desk(&app_handle);
+        Ok(())
+    }
+
+    fn set_shared_channel(
+        &self,
+        app_handle: AppHandle,
+        channel_number: u16,
+        value: u8,
+    ) -> Result<(), String> {
+        crate::guest::publish_channel(&app_handle, channel_number, value);
+        Ok(())
+    }
+
+    fn set_shared_buffer(&self, app_handle: AppHandle, buffer: Vec<u8>) -> Result<(), String> {
+        crate::guest::publish_overlay(&app_handle, buffer);
+        Ok(())
     }
 
     fn list_dmx_devices(&self, app_handle: AppHandle) -> Result<Vec<DmxDeviceInfo>, String> {

--- a/apps/desktop/src-tauri/src/guest.rs
+++ b/apps/desktop/src-tauri/src/guest.rs
@@ -15,16 +15,28 @@
 //! sooner (the owner clears the retained config, and the authorizer stops
 //! granting receive at the next reconnect).
 //!
-//! This module is read-only by construction: it subscribes, parses, and
-//! stores. Publishing into an owner's space — presence and control frames —
-//! is a separate concern and lives with the surface that does it.
+//! **Writing is deliberately its own path.** A guest's controls publish to the
+//! *owner's* frame topic and never touch this device's own buffer, and the
+//! local input path never targets an owner's space. They share no state and no
+//! function — moving a fader on someone else's desk must not move your own
+//! fixtures, and moving your own must never reach into their rig. That
+//! separation is structural rather than conditional, because the failure would
+//! be silent and would be pointed at real lights.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::time::Duration;
 
+use rumqttc::QoS;
 use tauri::{AppHandle, Manager, Runtime};
 
 use crate::lock::LockPolicy;
+
+/// Trailing-edge coalescing window for a guest's control frames — the same
+/// 40 ms the owner's own publishes use, so a drag costs the same ~25 Hz
+/// whichever desk it is on.
+const PUBLISH_WINDOW: Duration = Duration::from_millis(40);
 
 /// Identifies one shared setup: whose space it lives in, and which setup.
 type Key = (String, String);
@@ -62,6 +74,15 @@ pub struct LuxGuest {
     configs: Mutex<HashMap<Key, lux_wire::ctl::Config>>,
     /// Each shared setup's last-known buffer, from the owner's state echo.
     states: Mutex<HashMap<Key, Vec<u8>>>,
+    /// The shared desk this device currently has open, if any. Also the guard
+    /// on every publish: with nothing open there is no target, so a stray call
+    /// cannot reach anyone's rig.
+    open: Mutex<Option<Key>>,
+    /// Control writes accumulated between flushes. Separate from the local
+    /// outbox on purpose (see the module docs) — they must never drain into
+    /// each other's topic.
+    outbox: Mutex<crate::nudge::Outbox>,
+    publish_pending: AtomicBool,
 }
 
 impl LuxGuest {
@@ -215,6 +236,142 @@ pub fn receive_state<R: Runtime>(
     }
 }
 
+/// Where a guest's control frames go: the open desk's owner's frame topic, or
+/// nothing at all when no desk is open.
+///
+/// A pure function so the property that matters can be asserted directly — a
+/// guest's writes land in the *owner's* namespace and never in this device's
+/// own, whatever the surface above it does.
+fn publish_target(open: Option<&Key>) -> Option<String> {
+    open.map(|(owner_sub, setup_id)| lux_wire::ctl::frame_topic(owner_sub, setup_id))
+}
+
+/// Open a shared desk: remember it as the publish target, and announce this
+/// guest on the owner's desk with a retained presence card.
+///
+/// The card goes on [`lux_wire::ctl::guest_presence_topic`] — one exact topic
+/// per guest, which is what lets the authorizer grant it without a wildcard.
+/// It is explicit publish/clear rather than a Last Will: a connection has one
+/// will and it is already spoken for by this device's own presence, so an
+/// ungraceful drop leaves the card until [`close_desk`] or the next sign-out.
+/// The card carries a timestamp so a surface can render staleness.
+pub fn open_desk<R: Runtime>(app: &AppHandle<R>, owner_sub: &str, setup_id: &str) {
+    let guest = app.state::<LuxGuest>();
+    if !guest.granted(owner_sub, setup_id) {
+        log::warn!("refusing to open {owner_sub}/{setup_id}: no live grant");
+        return;
+    }
+    // Leaving one desk for another clears the first card, so a guest is never
+    // shown as live on two of an owner's setups at once.
+    close_desk(app);
+    *guest.open.lock_or_recover() = Some((owner_sub.to_owned(), setup_id.to_owned()));
+
+    let Some(echo) = crate::nudge::connection(app) else {
+        return;
+    };
+    let card = lux_wire::ctl::PresenceCard::new(
+        echo.session.clone(),
+        setup_id.to_owned(),
+        crate::nudge::device_name(),
+    );
+    let topic = lux_wire::ctl::guest_presence_topic(owner_sub, &echo.sub);
+    let Ok(payload) = serde_json::to_vec(&card) else {
+        return;
+    };
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = echo
+            .client
+            .publish(topic.clone(), QoS::AtMostOnce, true, payload)
+            .await
+        {
+            log::debug!("guest presence publish to {topic} failed: {e}");
+        }
+    });
+}
+
+/// Leave the open desk: stop publishing there and clear the presence card so
+/// the owner's surface stops showing this guest as live.
+pub fn close_desk<R: Runtime>(app: &AppHandle<R>) {
+    let guest = app.state::<LuxGuest>();
+    let Some((owner_sub, _)) = guest.open.lock_or_recover().take() else {
+        return;
+    };
+    // Anything still queued was for the desk being left; it must not follow
+    // the guest to the next one.
+    guest.outbox.lock_or_recover().drain();
+    let Some(echo) = crate::nudge::connection(app) else {
+        return;
+    };
+    let topic = lux_wire::ctl::guest_presence_topic(&owner_sub, &echo.sub);
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = echo
+            .client
+            .publish(topic.clone(), QoS::AtMostOnce, true, Vec::<u8>::new())
+            .await
+        {
+            log::debug!("guest presence clear on {topic} failed: {e}");
+        }
+    });
+}
+
+/// Queue one slot write on the open shared desk.
+pub fn publish_channel<R: Runtime>(app: &AppHandle<R>, ch: u16, val: u8) {
+    let guest = app.state::<LuxGuest>();
+    if guest.open.lock_or_recover().is_none() {
+        return;
+    }
+    guest.outbox.lock_or_recover().push_channel(ch, val);
+    schedule_flush(app);
+}
+
+/// Queue an overlay write (the colour-picker path) on the open shared desk.
+pub fn publish_overlay<R: Runtime>(app: &AppHandle<R>, bytes: Vec<u8>) {
+    let guest = app.state::<LuxGuest>();
+    if guest.open.lock_or_recover().is_none() {
+        return;
+    }
+    guest.outbox.lock_or_recover().push_overlay(bytes);
+    schedule_flush(app);
+}
+
+/// Drain the guest outbox to the open desk's owner, trailing-edge coalesced.
+/// Frames carry `src` so the owner's applier can attribute them in its per-slot
+/// merge — and so this device drops its own frames when they echo back.
+fn schedule_flush<R: Runtime>(app: &AppHandle<R>) {
+    let state = app.state::<LuxGuest>();
+    if state.publish_pending.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(PUBLISH_WINDOW).await;
+        let guest = app.state::<LuxGuest>();
+        guest.publish_pending.store(false, Ordering::SeqCst);
+
+        // Re-read the target *after* the window: a guest who closed the desk
+        // mid-drag must not have the tail of that drag delivered.
+        let target = publish_target(guest.open.lock_or_recover().as_ref());
+        let (Some(topic), Some(echo)) = (target, crate::nudge::connection(&app)) else {
+            guest.outbox.lock_or_recover().drain();
+            return;
+        };
+        let frames = guest.outbox.lock_or_recover().drain();
+        for frame in frames {
+            let Ok(payload) = serde_json::to_vec(&frame.with_src(&echo.session)) else {
+                continue;
+            };
+            if let Err(e) = echo
+                .client
+                .publish(topic.clone(), QoS::AtMostOnce, false, payload)
+                .await
+            {
+                log::debug!("guest ctl publish failed (connection likely down): {e}");
+                return;
+            }
+        }
+    });
+}
+
 /// The topics a guest subscribes to for one grant: the owner's compiled setup
 /// and their applier's state echo, and nothing else. Exactly the two the
 /// authorizer grants receive on.
@@ -242,6 +399,24 @@ mod tests {
             setup_name: Some("Living room".into()),
             created_at: 0,
         }
+    }
+
+    #[test]
+    fn a_guests_writes_land_in_the_owners_namespace_and_never_its_own() {
+        let me = "me-1";
+        let open = ("owner-9".to_owned(), "s-1".to_owned());
+
+        let topic = publish_target(Some(&open)).expect("an open desk has a target");
+        assert_eq!(topic, "lux/ctl/user/owner-9/setup/s-1/frame");
+        // The property worth pinning: a guest's control writes address the
+        // owner's space. Publishing into our own would silently drive this
+        // device's fixtures instead of the ones the user is looking at.
+        assert!(!topic.contains(me));
+        assert!(topic.starts_with(&lux_wire::ctl::user_prefix("owner-9")));
+
+        // Nothing open, nothing to publish to — the guard that keeps a stray
+        // call from reaching anyone's rig.
+        assert_eq!(publish_target(None), None);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/nudge.rs
+++ b/apps/desktop/src-tauri/src/nudge.rs
@@ -206,13 +206,13 @@ pub struct RemotePeer {
 /// channels) matches local chronology — an overlay clears the pending channel
 /// writes it covers, and later channel writes land after it at the applier.
 #[derive(Debug, Default, PartialEq, Eq)]
-struct Outbox {
+pub(crate) struct Outbox {
     overlay: Option<Vec<u8>>,
     channels: BTreeMap<u16, u8>,
 }
 
 impl Outbox {
-    fn push_overlay(&mut self, bytes: Vec<u8>) {
+    pub(crate) fn push_overlay(&mut self, bytes: Vec<u8>) {
         // The overlay supersedes any pending channel writes inside its range.
         self.channels.retain(|ch, _| usize::from(*ch) > bytes.len());
         match &mut self.overlay {
@@ -224,13 +224,13 @@ impl Outbox {
         }
     }
 
-    fn push_channel(&mut self, ch: u16, val: u8) {
+    pub(crate) fn push_channel(&mut self, ch: u16, val: u8) {
         self.channels.insert(ch, val);
     }
 
     /// Everything pending as publishable frames, in apply order, leaving the
     /// outbox empty.
-    fn drain(&mut self) -> Vec<lux_wire::ctl::Frame> {
+    pub(crate) fn drain(&mut self) -> Vec<lux_wire::ctl::Frame> {
         let mut frames = Vec::with_capacity(1 + self.channels.len());
         if let Some(bytes) = self.overlay.take() {
             frames.push(lux_wire::ctl::Frame::buffer(bytes));
@@ -242,12 +242,13 @@ impl Outbox {
     }
 }
 
-/// The live connection's handle for publishing the retained state echo.
+/// The live connection's handle for publishing the retained state echo — and,
+/// for a shared-control guest, control frames into an owner's space.
 #[derive(Clone)]
-struct EchoHandle {
-    client: AsyncClient,
-    sub: String,
-    session: String,
+pub(crate) struct EchoHandle {
+    pub(crate) client: AsyncClient,
+    pub(crate) sub: String,
+    pub(crate) session: String,
 }
 
 /// Start (or restart) the listener for the signed-in user. Called after
@@ -326,6 +327,12 @@ pub fn stop(app: &AppHandle) {
 /// Ask the live connection to republish its presence card — called when the
 /// active setup changes, so remote surfaces learn the new binding without a
 /// reconnect. No-op when no connection is up.
+/// The live connection, if there is one — the guest publisher's handle into
+/// the same socket everything else on this channel uses.
+pub(crate) fn connection<R: Runtime>(app: &AppHandle<R>) -> Option<EchoHandle> {
+    app.state::<LuxNudge>().echo.lock_or_recover().clone()
+}
+
 pub fn presence_changed<R: Runtime>(app: &AppHandle<R>) {
     app.state::<LuxNudge>().presence.send_modify(|g| *g += 1);
 }
@@ -808,7 +815,7 @@ async fn publish_presence(client: &AsyncClient, app: &AppHandle, sub: &str, sess
 }
 
 /// This device's human-readable name for presence cards.
-fn device_name() -> String {
+pub(crate) fn device_name() -> String {
     gethostname::gethostname().to_string_lossy().into_owned()
 }
 

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -208,6 +208,21 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  close_shared_desk(): Promise<null> {
+    return invoke("cmd.close_shared_desk");
+  },
+
+  /** @throws {string} */
+  set_shared_channel(channelNumber: number, value: number): Promise<null> {
+    return invoke("cmd.set_shared_channel", { channel_number: channelNumber, value });
+  },
+
+  /** @throws {string} */
+  set_shared_buffer(buffer: number[]): Promise<null> {
+    return invoke("cmd.set_shared_buffer", { buffer });
+  },
+
+  /** @throws {string} */
   list_dmx_devices(): Promise<DmxDeviceInfo[]> {
     return invoke("cmd.list_dmx_devices");
   },

--- a/apps/desktop/src/components/shared-desk.tsx
+++ b/apps/desktop/src/components/shared-desk.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { ArrowLeft, Link2, Loader2 } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createTauRPCProxy, type SharedDesk, type SharedSetup } from "@/bindings";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
+import { cn, lightColorVariants } from "@/lib/utils";
+
+const cmd = () => createTauRPCProxy().cmd;
+
+/**
+ * Roles cross the wire as plain strings so an owner on a newer app can add one
+ * without breaking an older guest. Anything this build doesn't style renders as
+ * a plain fader rather than an error.
+ */
+const STYLED_ROLES = [
+  "Red",
+  "Green",
+  "Blue",
+  "Amber",
+  "White",
+  "Brightness",
+  "Generic",
+] as const;
+type StyledRole = (typeof STYLED_ROLES)[number];
+const styledRole = (role: string): StyledRole =>
+  (STYLED_ROLES as readonly string[]).includes(role)
+    ? (role as StyledRole)
+    : "Generic";
+
+export const SHARED_SETUPS_QUERY_KEY = ["sharedSetups"];
+
+/** Which desk is open, if any. */
+type Open = { ownerSub: string; setupId: string };
+
+/**
+ * Setups other people have shared with this account, and the desk for one of
+ * them.
+ *
+ * A guest holds no copy of anyone's setup: the channel list comes from the
+ * owner's compiled config and the opening fader positions from their applier's
+ * last-known buffer, both fetched fresh when a desk opens. Moving a fader here
+ * publishes to the *owner's* rig and never touches this device's own fixtures.
+ */
+export default function SharedDeskView() {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState<Open | null>(null);
+
+  const { data: shared } = useQuery({
+    queryKey: SHARED_SETUPS_QUERY_KEY,
+    queryFn: () => cmd().list_shared_setups(),
+    // Grants arrive by nudge-driven refresh on the backend; poll so the list
+    // reflects them without needing an event to reach the webview (which iOS
+    // drops).
+    refetchInterval: 5000,
+  });
+
+  // Leaving the view is leaving the desk — the owner's surface should stop
+  // showing this guest as live the moment they navigate away or quit.
+  useEffect(() => () => void cmd().close_shared_desk(), []);
+
+  if (open) {
+    return (
+      <Desk
+        open={open}
+        onBack={() => {
+          void cmd().close_shared_desk();
+          setOpen(null);
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-3xl flex-col gap-4 px-4 py-4">
+      <RedeemForm
+        onClaimed={(claimed) => {
+          void queryClient.invalidateQueries({ queryKey: SHARED_SETUPS_QUERY_KEY });
+          toast.success(`${claimed.ownerLabel} shared a setup with you`);
+        }}
+      />
+
+      {shared?.length ? (
+        <ul className="flex flex-col gap-2">
+          {shared.map((s) => (
+            <li key={`${s.ownerSub}:${s.setupId}`}>
+              <button
+                type="button"
+                onClick={() => setOpen({ ownerSub: s.ownerSub, setupId: s.setupId })}
+                className="flex w-full items-center justify-between rounded-md border px-3 py-2 text-left hover:bg-accent"
+              >
+                <span className="flex flex-col">
+                  <span className="text-sm font-medium">
+                    {s.setupName ?? "Shared setup"}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {s.ownerLabel}
+                  </span>
+                </span>
+                {/* A grant without a config means the owner's app isn't
+                    running — there is nothing to draw, and saying so beats
+                    opening an empty desk. */}
+                <span className="text-xs text-muted-foreground">
+                  {s.renderable ? "Open" : "Offline"}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Nothing has been shared with you yet. When someone sends you an invite
+          code, enter it above.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Redeem an invite code someone sent over their own channel. */
+function RedeemForm({ onClaimed }: { onClaimed: (s: SharedSetup) => void }) {
+  const [code, setCode] = useState("");
+  const [pending, setPending] = useState(false);
+
+  const claim = async () => {
+    if (!code.trim() || pending) return;
+    setPending(true);
+    try {
+      onClaimed(await cmd().claim_share(code.trim()));
+      setCode("");
+    } catch (e) {
+      // The server says the same thing for unknown, expired, and already-used
+      // codes, so this is the whole story the UI has — and all it should tell.
+      toast.error(String(e));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Link2 className="size-4 shrink-0 text-muted-foreground" />
+      <Input
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") void claim();
+        }}
+        // Case, dashes, and stray spaces are all normalized server-side, so
+        // whatever the messaging app did to the code is fine.
+        placeholder="Invite code (LUX-XXXXX-XXXXX)"
+        className="h-9"
+        autoCapitalize="characters"
+        autoCorrect="off"
+        spellCheck={false}
+      />
+      <Button size="sm" onClick={claim} disabled={!code.trim() || pending}>
+        {pending ? <Loader2 className="size-4 animate-spin" /> : "Redeem"}
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * The desk for one shared setup. Fader positions are local UI state seeded from
+ * the owner's last-known buffer — there is no local buffer behind this view,
+ * and every move goes straight out to the owner.
+ */
+function Desk({ open, onBack }: { open: Open; onBack: () => void }) {
+  const [values, setValues] = useState<Record<number, number>>({});
+  const seeded = useRef(false);
+
+  const { data: desk, isPending } = useQuery({
+    queryKey: ["sharedDesk", open.ownerSub, open.setupId],
+    queryFn: () => cmd().open_shared_desk(open.ownerSub, open.setupId),
+  });
+
+  useEffect(() => {
+    if (!desk || seeded.current) return;
+    seeded.current = true;
+    const seed: Record<number, number> = {};
+    for (const ch of desk.channels) seed[ch.n] = desk.buffer[ch.n - 1] ?? 0;
+    setValues(seed);
+  }, [desk]);
+
+  const drag = (n: number, next: number) => {
+    setValues((v) => ({ ...v, [n]: next }));
+    // Coalesced to ~25 Hz on the backend, the same as a local drag.
+    void cmd().set_shared_channel(n, next);
+  };
+
+  const header = (title: string, subtitle?: string) => (
+    <div className="flex items-center gap-2">
+      <Button variant="ghost" size="sm" onClick={onBack}>
+        <ArrowLeft className="size-4" />
+      </Button>
+      <span className="flex flex-col">
+        <span className="text-sm font-medium">{title}</span>
+        {subtitle ? (
+          <span className="text-xs text-muted-foreground">{subtitle}</span>
+        ) : null}
+      </span>
+    </div>
+  );
+
+  if (isPending) {
+    return <div className="px-4 py-4">{header("Opening…")}</div>;
+  }
+
+  if (!desk) {
+    return (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-4 py-4">
+        {header("Not available")}
+        <p className="text-sm text-muted-foreground">
+          The owner&rsquo;s app isn&rsquo;t running, so there&rsquo;s nothing to
+          control yet. This page will work as soon as it is.
+        </p>
+      </div>
+    );
+  }
+
+  const unpatched = desk.channels.length === 0;
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-3xl flex-col gap-3 px-4 py-4">
+      {header(desk.name, `Universe ${desk.universe}`)}
+      {unpatched ? (
+        <p className="text-sm text-muted-foreground">
+          This setup has no fixtures patched, so there are no named controls to
+          show.
+        </p>
+      ) : (
+        <ul className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
+          {desk.channels.map((ch) => (
+            <li key={ch.n} className="flex items-center gap-3">
+              <span
+                className={cn(
+                  "shrink-0 text-xs tabular-nums",
+                  // An unfamiliar role falls through to the neutral style
+                  // rather than breaking the row.
+                  lightColorVariants({ labelColor: styledRole(ch.role) }),
+                )}
+              >
+                {ch.n}
+              </span>
+              <span className="w-24 shrink-0 truncate text-right text-sm text-muted-foreground">
+                {ch.name}
+              </span>
+              <span className="w-10 shrink-0 text-xs tabular-nums text-muted-foreground">
+                {(values[ch.n] ?? 0).toString().padStart(3, "0")}
+              </span>
+              <Slider
+                aria-label={`${ch.name} (channel ${ch.n})`}
+                value={[values[ch.n] ?? 0]}
+                onValueChange={([next]) => drag(ch.n, next)}
+                max={255}
+                step={1}
+                className="flex-1"
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export type { SharedDesk };

--- a/apps/desktop/src/components/view-menu.tsx
+++ b/apps/desktop/src/components/view-menu.tsx
@@ -1,10 +1,5 @@
 import { Link, useLocation } from "@tanstack/react-router";
-import {
-  Check,
-  ChevronsUpDown,
-  Lightbulb,
-  SlidersVertical,
-} from "lucide-react";
+import { Check, ChevronsUpDown, Lightbulb, SlidersVertical, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -16,6 +11,7 @@ import {
 const VIEWS = [
   { to: "/", label: "Fixtures", icon: Lightbulb },
   { to: "/universe", label: "Universe", icon: SlidersVertical },
+  { to: "/shared", label: "Shared with you", icon: Users },
 ] as const;
 
 /**

--- a/apps/desktop/src/routes/shared.tsx
+++ b/apps/desktop/src/routes/shared.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import SharedDeskView from "@/components/shared-desk";
+
+export const Route = createFileRoute("/shared")({
+  component: SharedDeskView,
+});


### PR DESCRIPTION
P2c, second half — the end of the guest surface. A shared desk can now be opened, seen, and moved: presence appears on the owner's desk, and fader moves publish into the owner's space as `src`-attributed frames their applier merges per slot, exactly as it already does for their own devices.

This is the change that can drive someone else's rig, which is why #230 split the read side off first.

## The property this PR is really about

**Guest writes are a separate path from local input, not a retarget of one.** They share no state and no function. A guest's controls publish to the *owner's* frame topic and never touch this device's buffer; local input never addresses an owner's space.

Moving a fader on someone else's desk must not move your own fixtures — and the reverse would be worse. Both failures would be silent, and both would be pointed at real lights. So the separation is structural rather than a conditional inside a shared function, and `publish_target` is pulled out as a pure function specifically so the property can be asserted directly rather than argued about:

```
a_guests_writes_land_in_the_owners_namespace_and_never_its_own
```

The publish target is also re-read *after* the coalescing window, so a guest who closes a desk mid-drag doesn't have the tail of that drag delivered.

## Presence

Rides `guest_presence_topic(owner, contact)` — the exact topic from #223, which is what lets the authorizer grant it with no wildcard at all.

Explicit publish/clear rather than a Last Will: a connection has one will and this device's own presence already holds it. So an ungraceful drop leaves a stale card until the guest returns or signs out — the documented v1 compromise, and the reason the card carries a timestamp. Leaving one desk for another clears the first card, so a guest is never shown live on two of an owner's setups at once, and anything still queued for the desk being left is dropped rather than following them to the next one.

## The surface

`/shared`, in the View menu. Redeem a code, see what's been shared, open one.

It holds **no local buffer**. Fader positions are UI state seeded from the owner's last-known buffer, so the desk opens at what the fixtures are actually doing rather than at zero. Two cases the UI is deliberate about:

- A grant whose config hasn't arrived shows "the owner's app isn't running" rather than an empty desk — a guest seeing a blank desk would reasonably assume the rig was dark.
- A role this build doesn't style falls through to a plain fader. Roles cross the wire as strings so an owner on a newer app can add one without breaking an older guest, and that only helps if the guest actually tolerates it.

The redeem field normalizes nothing client-side, because the server already does — case, dashes, and stray spaces are all handled there, and the failure message is deliberately identical for unknown, expired, and already-used codes, so the UI passes it through rather than inventing detail it doesn't have.

Gate green locally: 17 Rust suites, clippy, eslint, tsc, bindings regenerated.

## What's left in the brick

- **P2b, the owner's invite/manage UI** — minting and revoking currently need `curl`. The routes are verified (#229), so this is UI work over a proven backend.
- **Owner-side guest labelling.** An owner's desk will show a guest's presence card by device name; turning that into "Chelsea is live" needs the contact label from `GET /shares`, which belongs with the manage UI.
- **The live rig pass.** Everything below it is now in place.