### PR TITLE
feat(shares): invite, manage, and revoke from the setup that is shared

### DIFF
--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -325,6 +325,104 @@ async fn claim_share_req(
     read_json(resp).await
 }
 
+/// Mint an invite code for one of the caller's own setups.
+pub fn invite_to_setup(
+    app: &AppHandle,
+    setup_id: &str,
+    label: Option<String>,
+) -> Result<lux_wire::shares::InviteResponse, String> {
+    let (base, token) = share_call(app)?;
+    let body = lux_wire::shares::InviteRequest {
+        setup_id: setup_id.to_owned(),
+        label,
+    };
+    let app = app.clone();
+    crate::account::block_on(async move {
+        let client = Client::new();
+        let send = |token: String| {
+            let url = format!(
+                "{base}/{}/{}",
+                lux_wire::shares::SHARES_SEGMENT,
+                lux_wire::shares::INVITE_SEGMENT
+            );
+            let client = client.clone();
+            let body = &body;
+            async move {
+                let resp = client
+                    .post(url)
+                    .bearer_auth(token)
+                    .json(body)
+                    .send()
+                    .await
+                    .map_err(|e| SyncError::Other(e.to_string()))?;
+                typed_error_or_json(resp).await
+            }
+        };
+        let mut result = send(token).await;
+        if matches!(result, Err(SyncError::Unauthorized)) {
+            result = send(refresh(&app).await.map_err(|e| e.to_string())?).await;
+        }
+        result.map_err(|e| e.to_string())
+    })
+}
+
+/// End a share, from either end. `path` is the route tail naming the other
+/// party (`granted/<contact>/<setup>`, `received/<owner>/<setup>`) or the code
+/// (`invite/<codeRef>`) — the caller's own side always comes from the token.
+pub fn end_share(app: &AppHandle, path: &str) -> Result<(), String> {
+    let (base, token) = share_call(app)?;
+    let url = format!("{base}/{}/{path}", lux_wire::shares::SHARES_SEGMENT);
+    let app = app.clone();
+    crate::account::block_on(async move {
+        let client = Client::new();
+        let send = |token: String| {
+            let url = url.clone();
+            let client = client.clone();
+            async move {
+                let resp = client
+                    .delete(url)
+                    .bearer_auth(token)
+                    .send()
+                    .await
+                    .map_err(|e| SyncError::Other(e.to_string()))?;
+                typed_error_or_json::<lux_wire::shares::RevokeResponse>(resp).await
+            }
+        };
+        let mut result = send(token).await;
+        if matches!(result, Err(SyncError::Unauthorized)) {
+            result = send(refresh(&app).await.map_err(|e| e.to_string())?).await;
+        }
+        result.map(|_| ()).map_err(|e| e.to_string())
+    })
+}
+
+/// Base URL + a fresh token, or a reason the call cannot be made.
+fn share_call(app: &AppHandle) -> Result<(String, String), String> {
+    let account = app.state::<LuxAccount>();
+    let base = account.sync_url().ok_or("cloud sync is not configured")?;
+    let token = account.current_id_token().ok_or("not signed in")?;
+    Ok((base, token))
+}
+
+/// Read a share route's reply, surfacing the server's own message on the
+/// refusals it states plainly (a cap reached, a setup gone, a bad code) rather
+/// than flattening them to a status code.
+async fn typed_error_or_json<T: DeserializeOwned>(
+    resp: reqwest::Response,
+) -> Result<T, SyncError> {
+    if matches!(
+        resp.status(),
+        StatusCode::NOT_FOUND | StatusCode::CONFLICT | StatusCode::BAD_REQUEST
+    ) {
+        let body = resp.json::<lux_wire::ErrorResponse>().await;
+        return Err(SyncError::Other(match body {
+            Ok(e) => e.error,
+            Err(_) => "that request was refused".to_owned(),
+        }));
+    }
+    read_json(resp).await
+}
+
 /// Redeem an invite code, gaining control of one of someone else's setups.
 pub fn claim_share(
     app: &AppHandle,

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -144,6 +144,22 @@ pub trait CmdMethods {
     // account ends every share it is part of, including ones other people
     // depend on.
     fn list_shares(&self, app_handle: AppHandle) -> Result<ShareTally, String>;
+    // Shared control, owner side: mint a code for one of my setups, see who
+    // holds a grant on what, and end either a grant or an unclaimed code.
+    fn invite_to_setup(
+        &self,
+        app_handle: AppHandle,
+        setup_id: String,
+        label: Option<String>,
+    ) -> Result<InviteCode, String>;
+    fn list_granted_shares(&self, app_handle: AppHandle) -> Result<GrantedShares, String>;
+    fn revoke_share(
+        &self,
+        app_handle: AppHandle,
+        contact_sub: String,
+        setup_id: String,
+    ) -> Result<(), String>;
+    fn withdraw_invite(&self, app_handle: AppHandle, code_ref: String) -> Result<(), String>;
     // Shared control, guest side: setups other people have shared with this
     // account. `open_shared_desk` returns everything a surface needs to draw
     // one — the owner's compiled setup plus their applier's last-known buffer —
@@ -214,6 +230,52 @@ pub struct ShareTally {
     pub granted_to: Vec<String>,
     /// People whose setups the caller can currently control.
     pub received_from: Vec<String>,
+}
+
+/// A freshly minted invite code. The only time the code itself exists in
+/// readable form — the server stores nothing but its hash, so a code that is
+/// lost is withdrawn and re-minted rather than recovered.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct InviteCode {
+    pub code: String,
+    /// Handle for withdrawing this code before anyone claims it.
+    pub code_ref: String,
+    /// Epoch millis (an `f64` so it crosses to the webview as a plain number).
+    pub expires_at: f64,
+}
+
+/// One contact who can control one of the caller's setups.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct GrantedShare {
+    pub contact_sub: String,
+    /// The contact's account email, recorded when they claimed.
+    pub contact_label: String,
+    pub setup_id: String,
+    pub setup_name: Option<String>,
+    /// The owner's own private note from the invite, if they set one.
+    pub label: Option<String>,
+}
+
+/// One outstanding code the caller has handed out and nobody has claimed.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingShare {
+    pub code_ref: String,
+    pub setup_id: String,
+    pub setup_name: Option<String>,
+    pub label: Option<String>,
+    /// Epoch millis (an `f64`; see [`InviteCode`]).
+    pub expires_at: f64,
+}
+
+/// The owner's whole sharing picture: who holds a grant, and which codes are
+/// still out there unclaimed.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct GrantedShares {
+    pub granted: Vec<GrantedShare>,
+    pub pending: Vec<PendingShare>,
 }
 
 /// Everything a guest surface needs to draw one shared setup: the owner's
@@ -673,6 +735,81 @@ impl CmdMethods for CmdEndpoint {
             granted_to: names(granted),
             received_from: names(received),
         })
+    }
+
+    fn invite_to_setup(
+        &self,
+        app_handle: AppHandle,
+        setup_id: String,
+        label: Option<String>,
+    ) -> Result<InviteCode, String> {
+        let minted = crate::cloud::invite_to_setup(
+            &app_handle,
+            &setup_id,
+            label.filter(|l| !l.trim().is_empty()),
+        )?;
+        // Publish the compiled setup now: a code is useless until the guest
+        // has something to render, and this is the setup's first grant.
+        crate::nudge::refresh_shares(&app_handle);
+        Ok(InviteCode {
+            code: minted.code,
+            code_ref: minted.code_ref,
+            expires_at: minted.expires_at as f64,
+        })
+    }
+
+    fn list_granted_shares(&self, app_handle: AppHandle) -> Result<GrantedShares, String> {
+        let shares = crate::cloud::list_shares(&app_handle)?;
+        Ok(GrantedShares {
+            granted: shares
+                .granted
+                .into_iter()
+                .map(|g| GrantedShare {
+                    contact_sub: g.contact_sub,
+                    contact_label: g.contact_label,
+                    setup_id: g.setup_id,
+                    setup_name: g.setup_name,
+                    label: g.label,
+                })
+                .collect(),
+            pending: shares
+                .pending
+                .into_iter()
+                .map(|p| PendingShare {
+                    code_ref: p.code_ref,
+                    setup_id: p.setup_id,
+                    setup_name: p.setup_name,
+                    label: p.label,
+                    expires_at: p.expires_at as f64,
+                })
+                .collect(),
+        })
+    }
+
+    fn revoke_share(
+        &self,
+        app_handle: AppHandle,
+        contact_sub: String,
+        setup_id: String,
+    ) -> Result<(), String> {
+        crate::cloud::end_share(
+            &app_handle,
+            &format!(
+                "{}/{contact_sub}/{setup_id}",
+                lux_wire::shares::GRANTED_SEGMENT
+            ),
+        )?;
+        // Revoking the last grant on a setup clears its retained config, so the
+        // contact's surface goes dark rather than holding a stale desk.
+        crate::nudge::refresh_shares(&app_handle);
+        Ok(())
+    }
+
+    fn withdraw_invite(&self, app_handle: AppHandle, code_ref: String) -> Result<(), String> {
+        crate::cloud::end_share(
+            &app_handle,
+            &format!("{}/{code_ref}", lux_wire::shares::INVITE_SEGMENT),
+        )
     }
 
     fn claim_share(&self, app_handle: AppHandle, code: String) -> Result<SharedSetup, String> {

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -180,6 +180,26 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  invite_to_setup(setupId: string, label: string | null): Promise<InviteCode> {
+    return invoke("cmd.invite_to_setup", { setup_id: setupId, label });
+  },
+
+  /** @throws {string} */
+  list_granted_shares(): Promise<GrantedShares> {
+    return invoke("cmd.list_granted_shares");
+  },
+
+  /** @throws {string} */
+  revoke_share(contactSub: string, setupId: string): Promise<null> {
+    return invoke("cmd.revoke_share", { contact_sub: contactSub, setup_id: setupId });
+  },
+
+  /** @throws {string} */
+  withdraw_invite(codeRef: string): Promise<null> {
+    return invoke("cmd.withdraw_invite", { code_ref: codeRef });
+  },
+
+  /** @throws {string} */
   claim_share(code: string): Promise<SharedSetup> {
     return invoke("cmd.claim_share", { code });
   },
@@ -346,6 +366,39 @@ export type FixturePreset = {
 	channels: ChannelDef[],
 };
 
+/**  One contact who can control one of the caller's setups. */
+export type GrantedShare = {
+	contactSub: string,
+	/**  The contact's account email, recorded when they claimed. */
+	contactLabel: string,
+	setupId: string,
+	setupName: string | null,
+	/**  The owner's own private note from the invite, if they set one. */
+	label: string | null,
+};
+
+/**
+ *  The owner's whole sharing picture: who holds a grant, and which codes are
+ *  still out there unclaimed.
+ */
+export type GrantedShares = {
+	granted: GrantedShare[],
+	pending: PendingShare[],
+};
+
+/**
+ *  A freshly minted invite code. The only time the code itself exists in
+ *  readable form — the server stores nothing but its hash, so a code that is
+ *  lost is withdrawn and re-minted rather than recovered.
+ */
+export type InviteCode = {
+	code: string,
+	/**  Handle for withdrawing this code before anyone claims it. */
+	codeRef: string,
+	/**  Epoch millis (an `f64` so it crosses to the webview as a plain number). */
+	expiresAt: number | null,
+};
+
 export type LuxBuffer = {
 	buffer: number[],
 };
@@ -388,6 +441,16 @@ export type PendingDevice = {
 	version: string,
 	arch: string,
 	firstSeen: number | null,
+};
+
+/**  One outstanding code the caller has handed out and nobody has claimed. */
+export type PendingShare = {
+	codeRef: string,
+	setupId: string,
+	setupName: string | null,
+	label: string | null,
+	/**  Epoch millis (an `f64`; see [`InviteCode`]). */
+	expiresAt: number | null,
 };
 
 /**

--- a/apps/desktop/src/components/remote-indicator.tsx
+++ b/apps/desktop/src/components/remote-indicator.tsx
@@ -1,5 +1,7 @@
 import { useRef } from "react";
 import { Radio } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { createTauRPCProxy } from "@/bindings";
 import useAuth from "@/hooks/useAuth";
 import useRemotePeers from "@/hooks/useRemotePeers";
 import useSetups from "@/hooks/useSetups";
@@ -10,22 +12,41 @@ import useSetups from "@/hooks/useSetups";
  * Brief absences are held for 5s before the indicator disappears, so the user
  * channel's hourly re-auth reconnect never visibly flickers it.
  */
+const cmd = () => createTauRPCProxy().cmd;
+
 export default function RemoteIndicator() {
   const auth = useAuth();
   const peers = useRemotePeers();
   const setups = useSetups();
   const lastLive = useRef<{ name: string; at: number } | null>(null);
+  // A guest's presence card is keyed by their sub and carries their *device*
+  // name, so on its own the indicator would say "iPhone" for a person. The
+  // grant list is what turns that into who they are.
+  const { data: shares } = useQuery({
+    queryKey: ["grantedShares"],
+    queryFn: () => cmd().list_granted_shares(),
+    enabled: !!auth?.signedIn,
+    refetchInterval: 30000,
+  });
 
   if (!auth?.signedIn) return null;
 
   const active = setups?.find((s) => s.active);
   const live = active ? peers?.find((p) => p.setupId === active.id) : undefined;
-  if (live) lastLive.current = { name: live.name, at: Date.now() };
+  // A peer whose session matches a contact we granted this setup to is that
+  // contact, on whatever device they happen to be holding.
+  const guest = live
+    ? shares?.granted.find(
+        (g) => g.contactSub === live.session && g.setupId === active?.id,
+      )
+    : undefined;
+  const liveName = guest ? (guest.label ?? guest.contactLabel) : live?.name;
+  if (live && liveName) lastLive.current = { name: liveName, at: Date.now() };
   const held =
     !live && lastLive.current && Date.now() - lastLive.current.at < 5000
       ? lastLive.current
       : null;
-  const shown = live?.name ?? held?.name;
+  const shown = liveName ?? held?.name;
   if (!shown) return null;
 
   return (

--- a/apps/desktop/src/components/setup-switcher.tsx
+++ b/apps/desktop/src/components/setup-switcher.tsx
@@ -6,6 +6,7 @@ import {
   Pencil,
   Plus,
   RefreshCw,
+  Share2,
   Trash2,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -21,6 +22,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import ShareDialog from "@/components/share-dialog";
 
 const cmd = () => createTauRPCProxy().cmd;
 
@@ -52,6 +54,11 @@ export default function SetupSwitcher() {
   // trash arms on the first tap (turns destructive) and only deletes on the
   // second; it disarms itself after a moment or when the dropdown closes.
   const [armedDelete, setArmedDelete] = useState<string | null>(null);
+  // Sharing opens its own dialog rather than expanding inline: it manages
+  // people and outstanding codes, which is more than a row can hold.
+  const [sharing, setSharing] = useState<{ id: string; name: string } | null>(
+    null,
+  );
   const disarmTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(
     () => () => {
@@ -197,6 +204,15 @@ export default function SetupSwitcher() {
   );
 
   return (
+    <>
+      {sharing ? (
+        <ShareDialog
+          setupId={sharing.id}
+          setupName={sharing.name}
+          open
+          onOpenChange={(next) => !next && setSharing(null)}
+        />
+      ) : null}
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm" className="gap-1.5">
@@ -244,6 +260,15 @@ export default function SetupSwitcher() {
                     }
                   >
                     <Pencil className="size-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
+                    aria-label={`Share ${s.name}`}
+                    onClick={() => setSharing({ id: s.id, name: s.name })}
+                  >
+                    <Share2 className="size-3.5" />
                   </Button>
                   <Button
                     variant="ghost"
@@ -334,5 +359,6 @@ export default function SetupSwitcher() {
         </div>
       </PopoverContent>
     </Popover>
+    </>
   );
 }

--- a/apps/desktop/src/components/share-dialog.tsx
+++ b/apps/desktop/src/components/share-dialog.tsx
@@ -1,0 +1,237 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Copy, Loader2, UserPlus, X } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createTauRPCProxy, type InviteCode } from "@/bindings";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+const cmd = () => createTauRPCProxy().cmd;
+
+export const GRANTED_SHARES_QUERY_KEY = ["grantedShares"];
+
+const expiresLabel = (at: number | null) =>
+  at == null
+    ? ""
+    : ` · expires ${new Date(at).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+      })}`;
+
+/**
+ * Share one setup: mint a code to send, and manage who already has one.
+ *
+ * A code is a bearer credential handed to a human over their own channel, so
+ * this screen's job is to show it exactly once, clearly, and make it easy to
+ * get out of the app — and to make withdrawing it just as easy, because the
+ * only other way a mis-sent code stops working is waiting 48 hours.
+ */
+export default function ShareDialog({
+  setupId,
+  setupName,
+  open,
+  onOpenChange,
+}: {
+  setupId: string;
+  setupName: string;
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [minted, setMinted] = useState<InviteCode | null>(null);
+  const [label, setLabel] = useState("");
+  const [pending, setPending] = useState(false);
+
+  const { data: shares } = useQuery({
+    queryKey: GRANTED_SHARES_QUERY_KEY,
+    queryFn: () => cmd().list_granted_shares(),
+    enabled: open,
+  });
+  const refresh = () =>
+    queryClient.invalidateQueries({ queryKey: GRANTED_SHARES_QUERY_KEY });
+
+  // Only this setup's rows — the dialog is scoped to the setup it opened from.
+  const contacts = shares?.granted.filter((g) => g.setupId === setupId) ?? [];
+  const outstanding = shares?.pending.filter((p) => p.setupId === setupId) ?? [];
+
+  const mint = async () => {
+    setPending(true);
+    try {
+      setMinted(await cmd().invite_to_setup(setupId, label.trim() || null));
+      setLabel("");
+      await refresh();
+    } catch (e) {
+      toast.error(String(e));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const copy = async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+      toast.success("Code copied — send it however you like");
+    } catch {
+      // Clipboard access can be refused; the code is on screen either way,
+      // which is why it is rendered large enough to read aloud or retype.
+      toast.error("Couldn't copy — the code is above, ready to select");
+    }
+  };
+
+  const revoke = async (contactSub: string, who: string) => {
+    try {
+      await cmd().revoke_share(contactSub, setupId);
+      await refresh();
+      toast.success(`${who} can no longer control ${setupName}`);
+    } catch (e) {
+      toast.error(String(e));
+    }
+  };
+
+  const withdraw = async (codeRef: string) => {
+    try {
+      await cmd().withdraw_invite(codeRef);
+      await refresh();
+      if (minted?.codeRef === codeRef) setMinted(null);
+      toast.success("Code withdrawn — it will no longer work");
+    } catch (e) {
+      toast.error(String(e));
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setMinted(null);
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Share {setupName}</DialogTitle>
+          <DialogDescription>
+            Anyone with a code can control this setup&rsquo;s lights from their
+            own account. They can&rsquo;t see your other setups or change the
+            patch.
+          </DialogDescription>
+        </DialogHeader>
+
+        {minted ? (
+          <div className="flex flex-col gap-2 rounded-md border p-3">
+            <p className="text-xs text-muted-foreground">
+              Send this to one person. It works once, and expires in 48 hours.
+            </p>
+            <p className="select-all text-center font-mono text-lg tracking-wider">
+              {minted.code}
+            </p>
+            <div className="flex gap-2">
+              <Button size="sm" className="flex-1" onClick={() => copy(minted.code)}>
+                <Copy className="size-4" /> Copy
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setMinted(null)}>
+                Done
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <Input
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void mint();
+              }}
+              // The owner's own note, never shown to the contact — it exists so
+              // the list below reads as people rather than email addresses.
+              placeholder="Who's it for? (optional)"
+              className="h-9"
+              maxLength={120}
+            />
+            <Button size="sm" onClick={mint} disabled={pending}>
+              {pending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <>
+                  <UserPlus className="size-4" /> New code
+                </>
+              )}
+            </Button>
+          </div>
+        )}
+
+        {contacts.length > 0 && (
+          <ul className="flex flex-col gap-1">
+            {contacts.map((c) => (
+              <li
+                key={c.contactSub}
+                className="flex items-center justify-between gap-2 rounded-md border px-3 py-2"
+              >
+                <span className="flex min-w-0 flex-col">
+                  <span className="truncate text-sm">
+                    {c.label ?? c.contactLabel}
+                  </span>
+                  {c.label ? (
+                    <span className="truncate text-xs text-muted-foreground">
+                      {c.contactLabel}
+                    </span>
+                  ) : null}
+                </span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => revoke(c.contactSub, c.label ?? c.contactLabel)}
+                >
+                  Remove
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {outstanding.length > 0 && (
+          <div className="flex flex-col gap-1">
+            <p className="text-xs font-medium text-muted-foreground">
+              Unclaimed codes
+            </p>
+            {outstanding.map((p) => (
+              <div
+                key={p.codeRef}
+                className="flex items-center justify-between gap-2 rounded-md border px-3 py-2"
+              >
+                <span className="truncate text-sm text-muted-foreground">
+                  {p.label ?? "No note"}
+                  {/* `f64` crosses as `number | null` (a non-finite value has
+                      no JSON form), so the expiry is shown only when it is
+                      actually a date. */}
+                  {expiresLabel(p.expiresAt)}
+                </span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  aria-label="Withdraw this code"
+                  onClick={() => withdraw(p.codeRef)}
+                >
+                  <X className="size-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {contacts.length === 0 && outstanding.length === 0 && !minted && (
+          <p className="text-sm text-muted-foreground">
+            Nobody has access to this setup yet.
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
P2b — the owner's half, and the last code in the shared-control brick. Minting and revoking no longer need `curl`.

A share button on each setup row opens a dialog scoped to that setup: mint a code, see who holds a grant, remove them, and withdraw codes nobody claimed. Its own dialog rather than an inline row — it manages people and outstanding codes, and a row can't hold that.

## The code is the product here

A claim code is a bearer credential handed to a human over their own channel, so getting it cleanly out of the app is the entire job of that screen. It's shown once, large, monospaced, and `select-all`, with a copy button. Copying **degrades rather than fails**: clipboard access can be refused, and the code is readable on screen either way, so the error says so instead of implying the code is lost.

Withdrawing is given equal visual weight to minting. The only other way a mis-sent code stops working is waiting out its 48 hours, and that asymmetry is worth designing against — the item family from #223 exists specifically so an owner can take a code back.

The owner's private note is what the manage list shows, falling back to the contact's email. That's the point of the note: the list should read as people, not addresses.

## The live indicator names guests now

Worth calling out because it's the bit that makes the rig pass feel finished. A guest's presence card is keyed by their sub and carries their *device* name, so on its own the indicator said "iPhone" where it meant a person. Matching the card's session against the grant list resolves it to whatever the owner already knows them by — their note, or their email.

That works because #223 put the contact's sub in the guest presence topic, and #231 made the indicator read identity from the topic rather than the card body. Neither was done for this, but both are why it's three lines.

## Lifecycle

Minting and revoking each refresh shares, so a setup's compiled config is published as its first grant lands and cleared when its last one goes. A code is useless until the guest has something to render, and a revoked guest should go dark rather than sit on a stale desk.

## One thing found while wiring

`f64` crosses to the webview as `number | null` — specta can't promise a non-finite float has a JSON form. Nothing had consumed an `f64` timestamp before (`PairedDevice.pairedAt` is exported but unused), so this is the first place it shows. Handled rather than fought: the expiry renders only when it's actually a date.

Gate green locally: 17 Rust suites, clippy, eslint, tsc, bindings regenerated.

## The brick after this

Everything is in place for the live rig pass — mint a code on the Mac, send it, redeem it on the other phone, drive the fixtures, watch presence appear, revoke. The only follow-up I'd flag is the iOS share sheet: this ships clipboard-only on both platforms, which #223 called an acceptable v1.