### PR TITLE
ci(desktop): run the workspace tests and the lint gate at once

### DIFF
--- a/.github/actions/setup-rust-desktop/action.yml
+++ b/.github/actions/setup-rust-desktop/action.yml
@@ -1,0 +1,61 @@
+name: Set up the Rust desktop toolchain
+description: >
+  System libraries, frontend bundle, Rust toolchain and compilation caches that
+  any job compiling the workspace needs. Defined once so the jobs that compile
+  it in parallel cannot drift apart. Requires the repository to be checked out
+  already.
+
+runs:
+  using: composite
+  steps:
+    # Tauri's Rust crates link the system webkitgtk/gtk stack on Linux, so the
+    # -dev packages must be present for the *-sys crates to compile.
+    - name: Install Tauri system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libwebkit2gtk-4.1-dev \
+          libgtk-3-dev \
+          libayatana-appindicator3-dev \
+          librsvg2-dev \
+          libxdo-dev \
+          libssl-dev \
+          build-essential \
+          curl wget file
+
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      with:
+        bun-version-file: apps/desktop/package.json
+
+    # tauri::generate_context! embeds ../dist at compile time, so the frontend
+    # must be built before anything compiles the desktop crate (incl. its
+    # tests). Every compiling job builds its own copy rather than downloading
+    # the frontend job's: ~7s here against ~25s to wait out that job and
+    # round-trip an artifact, which would also chain jobs that are otherwise
+    # free to start at once.
+    - name: Build frontend (for generate_context!)
+      shell: bash
+      working-directory: apps/desktop
+      run: |
+        bun install --frozen-lockfile
+        bun run build
+
+    - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+
+    # Compilation cache, content-addressed per crate: a Cargo.lock bump — which
+    # invalidates rust-cache's whole target/ — still hits for every unchanged
+    # crate (the common PR case with lux's large AWS-SDK + Tauri trees). Backed
+    # by the GitHub Actions cache, so it is also what keeps the cost of
+    # compiling the workspace in two jobs at once close to compiling it once:
+    # whichever job reaches a crate second reads the object instead of building
+    # it.
+    - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+    # sccache owns compilation caching now, so rust-cache just keeps the cargo
+    # registry/index warm — cache-targets: false skips the big target/ dir, so
+    # these frequent jobs' GHA-cache footprint stays small.
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        workspaces: "."
+        cache-targets: "false"

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -7,8 +7,12 @@ name: desktop
 #   - tauri-versions: @tauri-apps/* JS packages must share their minor with their
 #     Rust crate counterparts (the drift that broke the 0.8.0 release).
 #   - frontend: production build (also generates routeTree.gen.ts) + typecheck + lint.
-#   - rust: cargo test across the workspace, including tests/bindings.rs — the
+#   - rust-test: cargo test across the workspace, including tests/bindings.rs — the
 #     drift guard that fails when src/bindings.ts is stale.
+#   - rust-clippy: the workspace lint gate at -D warnings.
+#
+# No job here depends on another: every one starts at once and the gate costs
+# the slowest of them, not their sum.
 
 on:
   pull_request:
@@ -192,7 +196,13 @@ jobs:
         if: ${{ always() }}
         run: sccache --show-stats
 
-  rust:
+  # The test suite and the lint gate are two independent compilations of the
+  # same workspace, and neither one's result is an input to the other. Run
+  # sequentially they cost their sum and a lint error waits out the whole suite
+  # before it surfaces; as two jobs the gate costs the longer of the two and
+  # each reports the moment it knows. They share their setup through a composite
+  # action rather than a copy, so the two can never drift apart.
+  rust-test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -204,48 +214,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      # Tauri's Rust crates link the system webkitgtk/gtk stack on Linux, so the
-      # -dev packages must be present for the *-sys crates to compile.
-      - name: Install Tauri system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libxdo-dev \
-            libssl-dev \
-            build-essential \
-            curl wget file
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version-file: apps/desktop/package.json
-
-      # tauri::generate_context! embeds ../dist at compile time, so the frontend
-      # must be built before anything compiles the desktop crate (incl. its tests).
-      - name: Build frontend (for generate_context!)
-        working-directory: apps/desktop
-        run: |
-          bun install --frozen-lockfile
-          bun run build
-
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
-
-      # Compilation cache, content-addressed per crate: a Cargo.lock bump — which
-      # invalidates rust-cache's whole target/ — still hits for every unchanged
-      # crate (the common PR case with lux's large AWS-SDK + Tauri trees). Backed
-      # by the GitHub Actions cache.
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-
-      # sccache owns compilation caching now, so rust-cache just keeps the cargo
-      # registry/index warm — cache-targets: false skips the big target/ dir, so
-      # this frequent job's GHA-cache footprint stays small.
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: "."
-          cache-targets: "false"
+      - uses: ./.github/actions/setup-rust-desktop
 
       # Full workspace suite: desktop unit tests (incl. the cloud reconcile logic)
       # plus tests/bindings.rs, which regenerates the IPC bindings and fails if
@@ -254,7 +223,25 @@ jobs:
       - name: cargo test
         run: cargo test --workspace --locked
 
-      # Lint gate: deny-level workspace lints fail this step (notably
+      - name: sccache stats
+        if: ${{ always() }}
+        run: sccache --show-stats
+
+  rust-clippy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: ./.github/actions/setup-rust-desktop
+
+      # Lint gate: deny-level workspace lints fail this job (notably
       # clippy::unwrap_used — production code must not unwrap; see
       # [workspace.lints] in the root Cargo.toml). Default targets only, so
       # test code keeps idiomatic unwraps. `-D warnings` fails the build on any


### PR DESCRIPTION
`cargo test` and `cargo clippy` are two independent compilations of the same workspace, and neither one's result feeds the other — but they ran as two steps of one job, so the gate cost their sum and a lint error surfaced only after the whole suite had run.

They are now `rust-test` and `rust-clippy`. Neither depends on anything else in the workflow, so both start alongside the rest of the gate rather than behind it.

### What the old layout cost

`cargo clippy` ran strictly after `cargo test`, and it is not a rounding error — across the last five pushes to main it was consistently ~63% of the test step on top of it:

| run | `cargo test` | `cargo clippy` | sequential sum |
|---|---|---|---|
| 29720002061 (dependency update) | 262s | 148s | **410s** |
| 29718515702 | 138s | 90s | 228s |
| 29718071204 | 117s | 83s | 200s |
| 29718918586 | 104s | 67s | 171s |
| 29719176180 | 97s | 64s | 161s |

The `rust` job was the gate's long pole in every one of them, so that tail was the whole workflow's tail.

### What it costs split

Measured on this PR against the pre-split run of the same tree (29719176180), warm caches both times:

| | before | after |
|---|---|---|
| setup (apt, frontend bundle, toolchain, caches) | 44s | 65s / 61s |
| `cargo test` | 97s | 128s |
| `cargo clippy` | 64s | 95s |
| **gate wall clock** | **3m26s** | **3m14s** |

Each cargo step gets slower on its own — the clippy job now materializes the dependency rlibs `cargo test` used to leave in `target/` for it — but both land inside the natural run-to-run spread above, and the gate pays the longer leg instead of the sum. On a no-op tree like this one that is close to a wash; the win scales with how much Rust work there is, and on the dependency-update run at the top of that table the sum was 410s.

sccache is what keeps the second compile cheap. From this PR's run:

| job | compile requests | cache hits | misses | hit rate |
|---|---|---|---|---|
| `rust-test` | 1178 | 989 | 13 | 98.70% |
| `rust-clippy` | 1235 | 1062 | **0** | **100.00%** |

The clippy job rebuilt the entire dependency graph without compiling a single crate: they are the same rustc invocations the test job makes, so whichever job reaches a crate second reads the object instead of building it.

### Shared setup

Both jobs need the same five setup steps (webkitgtk/gtk `-dev` packages, the frontend bundle `generate_context!` embeds, toolchain, sccache, rust-cache), so those moved into `.github/actions/setup-rust-desktop` — one definition, no copy for the two jobs to drift apart on. Every comment explaining *why* a step is there moved with it.

Each compiling job still builds its own frontend bundle rather than downloading the `frontend` job's: ~6s here against ~25s to wait out that job and round-trip an artifact, which would also chain jobs that are otherwise free to start at once.

### Notes

`Swatinem/rust-cache` keys on the job name, so `rust-test` and `rust-clippy` each started with a cold registry cache on their first run and warm from the second on (both runs are in this PR's history; the table above uses the warm one). sccache's object cache is content-addressed and was unaffected.

No job name here is a required status check — the `main` ruleset requires only a squash PR — and nothing else in the repo referenced the `rust` job by name.