### PR TITLE
ci: gate each commit once, not three times

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -13,6 +13,22 @@ name: desktop
 #
 # No job here depends on another: every one starts at once and the gate costs
 # the slowest of them, not their sum.
+#
+# Every job also carries the same guard, so a commit is gated once and not
+# twice. The release-please PR — and the release commit it becomes — hold no
+# code that main's tip was not already gated against, only version stamps
+# (whose own failure mode has a dedicated tripwire in release.yml), and
+# release.yml runs this entire workflow against the release tag before
+# anything ships. So both skip here and that `ci` run is their record. Merges
+# to main are PR-only, so anything else reaching main was gated as a PR first.
+# A job added below needs the guard too.
+#
+# The guard's first two terms are what keeps a release gating itself: either
+# says "another workflow called this one, never skip". github.workflow is the
+# CALLER's name under workflow_call (see the concurrency note below), and
+# release.yml's ci job pins a ref. Both are checked because the failure they
+# prevent — a release shipping ungated — is the one failure worth two seatbelts,
+# and because github.workflow fails open if this workflow is ever renamed.
 
 on:
   pull_request:
@@ -20,8 +36,9 @@ on:
     # the action_required state (GitHub holds runs for events its own token
     # caused, and pull_request branch filters can only match the BASE branch,
     # so the machine branches cannot be excluded here). release.yml approves
-    # those held runs right after pushing; the authoritative gate is its ci
-    # job at the release tag either way.
+    # those held runs right after pushing, and the per-job guard below skips
+    # their work: the release PR gets a concluded, near-free gate instead of
+    # either an "awaiting approval" banner or a full re-run of main's tip.
     paths:
       - 'apps/desktop/**'
       - 'apps/site/**'
@@ -84,6 +101,7 @@ jobs:
   # needs it), so a workflow file without its own permissions block silently
   # inherits a write-capable token. Every workflow must say what it wants.
   workflow-permissions:
+    if: "${{ github.workflow != 'desktop' || inputs.ref != '' || !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -100,6 +118,7 @@ jobs:
           exit "$fail"
 
   deny:
+    if: "${{ github.workflow != 'desktop' || inputs.ref != '' || !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -114,6 +133,7 @@ jobs:
           command: check advisories bans licenses sources
 
   tauri-versions:
+    if: "${{ github.workflow != 'desktop' || inputs.ref != '' || !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -134,6 +154,7 @@ jobs:
         run: bun run check:tauri-versions
 
   frontend:
+    if: "${{ github.workflow != 'desktop' || inputs.ref != '' || !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -164,6 +185,7 @@ jobs:
   # renamed crate, or a musl-hostile dependency is a red PR check instead of a
   # failed release run.
   lambda-build:
+    if: "${{ github.workflow != 'desktop' || inputs.ref != '' || !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -203,6 +225,7 @@ jobs:
   # each reports the moment it knows. They share their setup through a composite
   # action rather than a copy, so the two can never drift apart.
   rust-test:
+    if: "${{ github.workflow != 'desktop' || inputs.ref != '' || !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -228,6 +251,7 @@ jobs:
         run: sccache --show-stats
 
   rust-clippy:
+    if: "${{ github.workflow != 'desktop' || inputs.ref != '' || !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -256,6 +280,7 @@ jobs:
   # The product site + shared UI package: typecheck and production build, so a
   # PR can't land something the deploy workflow (site.yml) would choke on.
   site:
+    if: "${{ github.workflow != 'desktop' || inputs.ref != '' || !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,12 +48,13 @@ jobs:
 
       # Maintains the release PR (version bump + CHANGELOG + every version
       # stamp via extra-files, one generated commit) on the workflow's own
-      # GITHUB_TOKEN — no GitHub App, no minted tokens. GITHUB_TOKEN-authored
-      # pushes and PRs start no workflow runs, so the release PR carries no
-      # checks (desktop.yml ignores its branches outright); the authoritative
-      # gate is the `ci` job below, re-run against the exact release commit
-      # before anything ships. skip-github-release in the config keeps the
-      # action away from tagging — the cut step below owns that.
+      # GITHUB_TOKEN — no GitHub App, no minted tokens. Its branch pushes DO
+      # start desktop.yml runs, held in the action_required state and approved
+      # below; desktop.yml's per-job guard then skips their work, because the
+      # release PR carries nothing main's tip was not already gated against.
+      # The authoritative gate is the `ci` job below, run against the exact
+      # release commit before anything ships. skip-github-release in the config
+      # keeps the action away from tagging — the cut step below owns that.
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           config-file: release-please-config.json
@@ -91,7 +92,9 @@ jobs:
       # action_required state (GitHub holds workflow runs for events the token
       # caused; pull_request branch filters can't exclude a head branch, they
       # match the base). Approve the held run so the release PR carries a
-      # live green gate instead of an "awaiting approval" banner — but ONLY
+      # concluded gate instead of an "awaiting approval" banner — the run
+      # itself is near-free, since desktop.yml's per-job guard skips the work
+      # for this branch and the tag gate below is what actually rules — but ONLY
       # the branch tip's run: the PR's gate runs share one concurrency group,
       # so approving a superseded head's run alongside the live one lets the
       # loser cancel the winner. Stale held runs are deleted instead (their
@@ -246,10 +249,12 @@ jobs:
             | gh release edit "$TAG" --notes-file -
           echo "attached store notes to $TAG"
 
-  # The release gate: the same checks as the PR/main `desktop` workflow
-  # (tauri-versions, frontend build/typecheck/lint, cargo test --workspace),
-  # re-run against the exact release commit. Everything that ships — infra,
-  # Lambda code, the desktop bundle — is downstream of this job, so a red main
+  # The release gate: the whole `desktop` workflow (tauri-versions, frontend
+  # build/typecheck/lint, cargo test and cargo clippy across the workspace, the
+  # Lambda musl build, cargo-deny), run against the exact release commit — and
+  # the only gate that commit gets, since its push-triggered run skips itself
+  # rather than duplicate this one. Everything that ships — infra, Lambda code,
+  # the desktop bundle — is downstream of this job, so a red release commit
   # cannot release.
   ci:
     needs: release


### PR DESCRIPTION
A merge to main sets off two more full runs of this gate beyond the one the PR already had:

1. **The release-please PR.** It rebases its branch on every push to main, and release.yml un-holds the resulting gate run — **23 of the last 100 desktop runs**, ~9.4 runner-minutes each, all re-verifying a tree that differs from an already-green main only by version stamps.
2. **The release commit.** Merging that PR gates the same SHA twice, concurrently: its own push run and release.yml's `ci` job. Verified on v1.9.0 (`b4d199d`) — push run 29719176180 and the release run's `ci` ran the identical seven jobs, ~8 runner-minutes each, neither one saving the other any wall clock.

Neither run covers code main's tip was not already gated against. The release branch adds version stamps and a CHANGELOG, and the one failure mode the stamps introduce — a stamp drifting from the manifest — already has a purpose-built tripwire in release.yml ("Verify release-branch version stamps") that fails loudly in seconds, before the PR is mergeable.

So every job now carries the same guard: the release branch's PR and the release commit it becomes skip here, and release.yml's run against the tag is their record. The release PR still gets a concluded (skipped) gate rather than an "awaiting approval" banner, so the approval step keeps earning its keep — it just no longer un-holds ~9 minutes of duplicate work.

### The guard must never skip the release's own gate

That is the one dangerous direction, so it is checked twice:

- `github.workflow != 'desktop'` — under `workflow_call` this context holds the **caller's** name, so it is `release` whenever release.yml is running the gate. (Same quirk the concurrency group below already depends on.)
- `inputs.ref != ''` — release.yml's `ci` job pins the tag.

Either alone is sufficient. Both are there because the workflow-name check fails *open* if the workflow is ever renamed, while the ref check would fail *closed* if `tag_name` were ever empty.

The nine cases the guard was checked against — including a release `ci` invocation with an empty tag, a dependabot PR, a human writing a release-shaped subject line, and a revert of a release commit — behave as intended.

### What is deliberately not covered

If a `chore(main): release …` commit ever lands on main *without* release.yml cutting a release for it (`release_created` false — a replay of an already-released version), that commit's push run skips and no `ci` run replaces it. Merges to main are PR-only, so such a commit was gated as a PR before it merged; the residual gap is the version stamps that release-please adds on top, which is what the stamp tripwire covers.