### PR TITLE
fix(pairing): prefer IPv4 for the rendezvous so dual-stack ends line up

### DIFF
--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -407,8 +407,11 @@ impl LuxAccount {
         let Some(token) = self.current_id_token() else {
             return Err("not signed in".into());
         };
+        // Prefer IPv4 so we rendezvous on the same public network as the box (see
+        // [`pairing_client`] / lux_engine::net).
+        let client = pairing_client(&base);
         block_on(async move {
-            let response = reqwest::Client::new()
+            let response = client
                 .get(format!(
                     "{base}/{}/{}/{}",
                     lux_wire::apple::AUTH_SEGMENT,
@@ -446,8 +449,11 @@ impl LuxAccount {
         let Some(token) = self.current_id_token() else {
             return Err("not signed in".into());
         };
+        // Same IPv4 preference as the pending list, so the approve's same-egress
+        // check lands on the box's network key.
+        let client = pairing_client(&base);
         block_on(async move {
-            let response = reqwest::Client::new()
+            let response = client
                 .post(format!(
                     "{base}/{}/{}/{}",
                     lux_wire::apple::AUTH_SEGMENT,
@@ -887,6 +893,25 @@ fn clear_session() {
 // --- async bridge ------------------------------------------------------------
 
 /// Run an async Cognito call to completion from a synchronous ttipc command.
+/// A reqwest client that prefers IPv4 for the pairing rendezvous, matching the
+/// node so both ends land on the same public-network key (the shared NAT
+/// address; see `lux_engine::net`). Best-effort: if the host can't be
+/// pre-resolved we fall back to reqwest's default dual-stack DNS, so a lookup
+/// hiccup never blocks pairing.
+fn pairing_client(base_url: &str) -> reqwest::Client {
+    let mut builder = reqwest::Client::builder();
+    if let Ok(url) = reqwest::Url::parse(base_url) {
+        if let Some(host) = url.host_str() {
+            let port = url.port_or_known_default().unwrap_or(443);
+            let addrs = lux_engine::net::ipv4_first_addrs(host, port);
+            if !addrs.is_empty() {
+                builder = builder.resolve_to_addrs(host, &addrs);
+            }
+        }
+    }
+    builder.build().unwrap_or_else(|_| reqwest::Client::new())
+}
+
 /// A dedicated thread with its own current-thread runtime keeps this safe to
 /// call whether or not we're already inside the Tauri runtime; auth is
 /// infrequent (sign-in / sign-up / refresh), so the per-call runtime is fine.

--- a/apps/node/src/pairing.rs
+++ b/apps/node/src/pairing.rs
@@ -96,7 +96,7 @@ pub async fn pair_wait(
 ) -> Result<Granted, String> {
     let device_id = crate::config::load_or_create_device_id()?;
     let request = device_request(device_id);
-    let client = http_client()?;
+    let client = http_client(env)?;
     let mut net_backoff = 1u64;
 
     'register: loop {
@@ -228,13 +228,27 @@ async fn poll_once(
     serde_json::from_slice(&body).map_err(|e| format!("token poll {status}: unreadable body: {e}"))
 }
 
-fn http_client() -> Result<reqwest::Client, String> {
+fn http_client(env: &Endpoints) -> Result<reqwest::Client, String> {
     let certs = reqwest::Certificate::from_pem_bundle(webpki_pem_bundle())
         .map_err(|e| format!("webpki bundle: {e}"))?;
-    reqwest::Client::builder()
-        .tls_certs_only(certs)
-        .build()
-        .map_err(|e| e.to_string())
+    let mut builder = reqwest::Client::builder().tls_certs_only(certs);
+    // Prefer IPv4 for the rendezvous: the shared NAT address is the identity the
+    // approving app can reliably match on a dual-stack network (lux_engine::net).
+    // Best-effort — a resolution miss leaves reqwest's default dual-stack DNS.
+    if let Some((host, port)) = host_port(&env.apple_auth_url) {
+        let addrs = lux_engine::net::ipv4_first_addrs(&host, port);
+        if !addrs.is_empty() {
+            builder = builder.resolve_to_addrs(&host, &addrs);
+        }
+    }
+    builder.build().map_err(|e| e.to_string())
+}
+
+/// Host + port (defaulting 443) from a base URL, for a reqwest resolver override.
+fn host_port(base_url: &str) -> Option<(String, u16)> {
+    let url = reqwest::Url::parse(base_url).ok()?;
+    let host = url.host_str()?.to_owned();
+    Some((host, url.port_or_known_default().unwrap_or(443)))
 }
 
 /// `<appleAuthUrl>/auth/device/<segment>`.

--- a/crates/lux-engine/src/lib.rs
+++ b/crates/lux-engine/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod auth;
 pub mod ctl;
+pub mod net;
 pub mod sacn;
 pub mod tls;
 pub mod universe;

--- a/crates/lux-engine/src/net.rs
+++ b/crates/lux-engine/src/net.rs
@@ -1,0 +1,68 @@
+//! Outbound-address selection shared by the pairing rendezvous on both ends
+//! (the headless node and the app).
+//!
+//! The claim-code pairing flow (docs/claim-code-pairing.md) matches an unpaired
+//! box to the owner's account by *shared public network* — a NAT-proximity
+//! trick. IPv4 makes that easy: every device behind a home NAT egresses from the
+//! one public address. IPv6 does not: there's no NAT, so each device has its own
+//! /128, and the box and the owner's phone only share their **/64** (the auth
+//! service keys the rendezvous on the /64 to cope). But that only lines up when
+//! both ends chose the *same* address family; on a dual-stack network where one
+//! side happens onto IPv4 and the other onto IPv6 (e.g. WiFi with flaky IPv6 but
+//! a wired box on clean IPv6), their keys — an IPv4 NAT address vs an IPv6 /64 —
+//! can't be correlated and pairing silently never lists the box.
+//!
+//! So the two ends agree to **prefer IPv4** for pairing calls: the shared NAT
+//! address is the one identity every device on a household reliably presents.
+//! IPv6 is kept as a fallback (sorted after) so v6-only networks still connect
+//! and match on the /64. This is the outbound half of that agreement — resolve a
+//! host with IPv4 candidates first — used by both ends via reqwest's
+//! `resolve_to_addrs`.
+
+use std::net::SocketAddr;
+use std::net::ToSocketAddrs;
+
+/// Resolve `host:port`, IPv4 addresses first. Empty on resolution failure — the
+/// caller then keeps reqwest's default (dual-stack) DNS, so a transient lookup
+/// hiccup never turns into a hard pairing failure.
+pub fn ipv4_first_addrs(host: &str, port: u16) -> Vec<SocketAddr> {
+    let mut addrs: Vec<SocketAddr> = (host, port)
+        .to_socket_addrs()
+        .map(Iterator::collect)
+        .unwrap_or_default();
+    sort_ipv4_first(&mut addrs);
+    addrs
+}
+
+/// Stable partition: IPv4 before IPv6, order within each family preserved (so a
+/// multi-homed host keeps the resolver's own ordering among same-family addrs).
+fn sort_ipv4_first(addrs: &mut [SocketAddr]) {
+    addrs.sort_by_key(SocketAddr::is_ipv6);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn ipv4_sorts_ahead_of_ipv6_stably() {
+        let v6a = SocketAddr::from((Ipv6Addr::new(0x2603, 0x8003, 0x1cf0, 0x88a0, 0, 0, 0, 1), 443));
+        let v4a = SocketAddr::from((Ipv4Addr::new(76, 33, 40, 136), 443));
+        let v6b = SocketAddr::from((Ipv6Addr::LOCALHOST, 443));
+        let v4b = SocketAddr::from((Ipv4Addr::new(192, 168, 1, 85), 443));
+        let mut addrs = vec![v6a, v4a, v6b, v4b];
+        sort_ipv4_first(&mut addrs);
+        // Both IPv4 first, then both IPv6 — and relative order within each family
+        // is preserved (v4a before v4b, v6a before v6b).
+        assert_eq!(addrs, vec![v4a, v4b, v6a, v6b]);
+    }
+
+    #[test]
+    fn all_one_family_is_untouched() {
+        let only_v6 = SocketAddr::from((Ipv6Addr::LOCALHOST, 443));
+        let mut addrs = vec![only_v6];
+        sort_ipv4_first(&mut addrs);
+        assert_eq!(addrs, vec![only_v6]);
+    }
+}


### PR DESCRIPTION
## Why
The claim-code pairing rendezvous matches an unpaired box to the owner's account by **shared public network**. #233 fixed the IPv6 case (key on the /64, not the exact /128), so a box and phone that both use IPv6 on one LAN now match — and that's what recovered the live box.

The residual gap: that only lines up when **both ends pick the same address family**. On a dual-stack network they usually do (both default to IPv6), but not always — e.g. WiFi with flaky IPv6 (phone falls back to the IPv4 NAT) while a wired box has clean IPv6. Then the two keys — an IPv4 NAT address vs an IPv6 /64 — can't be correlated, and the box silently never appears in the app's pending list. `reqwest` ignores `/etc/gai.conf`, so there's no host-level lever to line them up either.

## What
Both ends now **prefer IPv4** for the pairing HTTP calls: the shared NAT address is the one identity every device on a household reliably presents. IPv6 is kept as a fallback (tried after) so v6-only networks still connect and match on the /64.

- New `lux_engine::net::ipv4_first_addrs(host, port)` — resolves a host with IPv4 candidates first (stable partition; unit-tested). Shared by both ends (the node and the app both depend on `lux-engine`).
- **Node** (`apps/node/src/pairing.rs`): the pairing client pins IPv4-first via reqwest `resolve_to_addrs`.
- **App** (`apps/desktop/src-tauri/src/account.rs`): a `pairing_client()` used for `pending` + `approve` (the two egress-gated calls) does the same.
- Best-effort throughout: a resolution miss just leaves reqwest's default dual-stack DNS, so a lookup hiccup never blocks pairing.

Because both ends change together, they stay consistent: IPv4 NAT when it exists (deterministic, cross-family-proof), IPv6 + the /64 match on v6-only networks.

## Scope / notes
- No wire or ttipc change — `bindings.ts` untouched (drift test passes), no new deps.
- Complements #233 (which stays as the IPv6 fallback path). Together they make the rendezvous robust across dual-stack quirks.
- Rollout note: during any window where one end is updated and the other isn't, they could momentarily land on different families — self-heals once both are current (the node re-registers forever). The already-shipped /64 match covers same-family-IPv6 pairs in the meantime.
