### PR TITLE
chore(deps): drop three dependencies nothing uses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,15 +1971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
-name = "enttecopendmx"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439b5a6167b4d55c80838155742c65c5159f76ee4acd25324bdeb142828aa0c5"
-dependencies = [
- "libftd2xx 0.31.0",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,18 +3476,6 @@ dependencies = [
 
 [[package]]
 name = "libftd2xx"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b3be3aa1917532fb3918dde5fda1c82d7169d2bbd2e79353bac2cd3985e68a"
-dependencies = [
- "libftd2xx-ffi",
- "log",
- "paste",
- "static_assertions",
-]
-
-[[package]]
-name = "libftd2xx"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e09fe202b49276fc72160c27c8af5ff34e6ee3db78625bbfe3bd9c2b2e595af6"
@@ -3573,18 +3552,16 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 name = "lux"
 version = "1.9.0"
 dependencies = [
- "anyhow",
  "apple-native-keyring-store",
  "aws-cognito-srp",
  "aws-config",
  "aws-sdk-cognitoidentityprovider",
  "aws-smithy-http-client",
  "base64 0.22.1",
- "enttecopendmx",
  "gethostname",
  "keyring",
  "keyring-core",
- "libftd2xx 0.33.1",
+ "libftd2xx",
  "log",
  "lux-apple-id",
  "lux-engine",
@@ -3597,7 +3574,6 @@ dependencies = [
  "sha2 0.11.0",
  "specta",
  "strum",
- "strum_macros",
  "tauri",
  "tauri-build",
  "tauri-plugin-log",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,7 +23,6 @@ tauri = { version = "^2.9.3", features = ["devtools", "test", "tracing"] }
 workspace = true
 
 [dependencies]
-anyhow = "1.0.103"
 # Cognito accounts (sign-up / SRP sign-in / refresh) + secure refresh-token
 # storage. Cognito's auth ops are unauthenticated, so the client runs with
 # `.no_credentials()` — end users never need AWS keys.
@@ -46,7 +45,6 @@ serde_json.workspace = true
 serde.workspace = true
 strum = { version = "0.28.0", features = ["derive"] }
 specta = { version = "=2.0.0-rc.26", features = ["derive"] }
-strum_macros = "0.28.0"
 tauri = { version = "~2.11", features = [
     "isolation",
     "image-ico",
@@ -91,7 +89,6 @@ gethostname = "1.1.0"
 # target_os so Cargo resolves these only when building for desktop; the matching
 # code is behind `#[cfg(desktop)]`.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
-enttecopendmx = "0.1.1"
 libftd2xx = { version = "0.33.1", features = ["static"] }
 tauri = { version = "~2.11", features = ["tray-icon"] }
 tauri-plugin-positioner = { version = "2", features = ["tray-icon"] }


### PR DESCRIPTION
Answering "is the tree as clean as it can be" — mostly yes, but three dependencies were dead, and one of them was costing real build time.

## `enttecopendmx` — the one that matters

Never imported. The Enttec driver in this repo is our own `EnttecOpenDMX` in `devices/enttec_open_dmx_usb.rs`, written directly against `libftd2xx` (`Ftdi`, `FtdiCommon`, `DeviceInfo`, …). The crate stayed in the manifest after that reimplementation and brought **its own `libftd2xx 0.31`** along:

```
libftd2xx v0.31.0 └── enttecopendmx v0.1.1 └── lux     ← dead weight
libftd2xx v0.33.1 └── lux                            ← the one we use
```

So the desktop app was compiling and linking two copies of an FTDI **C-binding** crate, one of them for nothing. Now a single `libftd2xx 0.33.1`.

## The other two

- **`anyhow`** — zero references in the desktop app.
- **`strum_macros`** — redundant. `strum` is already declared with its `derive` feature, and `colors.rs` imports the derives from `strum::`, not `strum_macros::`.

## Numbers, honestly

Desktop dependency graph **1442 → 1434 crates**. That count understates the effect: one of the eight is a native-code build, which costs far more than a typical crate — but I haven't measured wall-clock, so I won't claim a number I don't have.

For context on the rest of the tree, `cargo tree -d` still reports ~88 duplicate groups. Almost all are ecosystem churn nobody here controls — `base64` 0.21/0.22, `getrandom` 0.2/0.3/0.4, `bitflags` 1/2, the `ed25519-dalek` 2/3 and `curve25519-dalek` 4/5 pairs, `png` 0.17/0.18. Those come from transitive deps at different upgrade stages and would need upstream movement, not manifest edits.

One duplicate did clear on its own: `hyper 0.14` is gone entirely, removed by the TLS work in #234. `http 0.2` survives, but it comes straight from the `aws-sdk-*` crates' own http-02x compat types, so it isn't ours to drop.

No source changes — nothing referenced any of these. Gate green locally: 17 Rust suites, clippy, eslint, tsc.