### PR TITLE
fix(buffer): stop the buffer read from driving the rig

### DIFF
--- a/apps/desktop/src-tauri/src/sync.rs
+++ b/apps/desktop/src-tauri/src/sync.rs
@@ -1,4 +1,3 @@
-use crate::lock::LockPolicy;
 use crate::{
     buffer::{Buffer, LuxBuffer},
     channels::LuxChannels,
@@ -21,11 +20,24 @@ pub enum SyncEvent {
 pub struct SyncEndpoint;
 
 impl SyncMethods for SyncEndpoint {
+    /// Read the live buffer. **A read, and only a read.**
+    ///
+    /// This used to round-trip through `LuxBuffer::set`, which is the write
+    /// path: it renders to the DMX output and republishes the retained state
+    /// echo. Every caller here wants the current value — the mount-time query
+    /// behind `useBuffer`, the preset toggle's base snapshot — so those were
+    /// side effects nobody asked for, on a code path that runs whenever a
+    /// surface opens.
+    ///
+    /// That is worse than wasted work. A device that has been asleep holds a
+    /// stale buffer, so opening the app pushed *that* onto the rig: rendering
+    /// it over sACN, and overwriting the retained echo every other surface
+    /// reads as truth. With one person driving it usually went unnoticed,
+    /// because the stale buffer was their own last state. It stops being
+    /// survivable the moment someone else is at the desk.
     fn sync_buffer(&self, app_handle: AppHandle) -> Result<LuxBuffer, String> {
         log::trace!("sync_buffer");
-        let mut state = app_handle.state::<LuxBuffer>().inner().clone();
-        let buffer = state.buffer.lock_or_recover().clone();
-        state.set(buffer, app_handle.clone())
+        Ok(app_handle.state::<LuxBuffer>().inner().clone())
     }
     fn sync_channels(&self, app_handle: AppHandle) -> Result<LuxChannels, String> {
         log::trace!("sync_channels");


### PR DESCRIPTION
Found from the live rig pass: Chelsea's changes looked great, then opening the phone took the lights to black.

## What happened

`sync_buffer` looks like a getter and is used as one — the mount-time query behind `useBuffer`, and the preset toggle's base snapshot. It wasn't one:

```rust
fn sync_buffer(&self, app_handle) -> Result<LuxBuffer, String> {
    let buffer = state.buffer.lock_or_recover().clone();
    state.set(buffer, app_handle.clone())   // ← the write path
}
```

`LuxBuffer::set` runs `commit`, which renders to the DMX output **and** republishes the retained state echo. So every call to what reads like a getter pushed this device's buffer onto the rig and onto the topic every other surface treats as truth.

A device that has been asleep holds a stale buffer. Opening the app rendered it over sACN and clobbered the retained echo. Reflection from the applier's echo arrives once the connection is up — later than the frontend's mount — so the stale value won the race and then *became* the truth. That is why it didn't look like a preset: nothing chose those values, they were just whatever that device last held.

## Why it surfaced now rather than earlier

With one person driving, the stale buffer was their own last state, so re-imposing it usually looked like nothing happened. Shared control didn't introduce the bug, it removed the coincidence that hid it: someone else's work is on the rig, this device's is not, and opening the app replaces theirs with a buffer nobody chose.

Worth noting this is the same root cause as the simulator live-fire incident — launching the sim "rendered its persisted teal buffer to the real rig". That was read at the time as a property of the simulator. It wasn't; it was this function, and it applies to every surface.

## The fix

`sync_buffer` reads. All three callers use the returned value and none wanted the side effects.

`sync_channels` has the same read-shaped-write structure but only emits a UI event — no render, no retained publish — so it's left alone rather than widening a change that moves lights. Worth revisiting separately.

## Testing

Gate green locally: 17 Rust suites, clippy, eslint, tsc. I have not added a regression test: observing "did not render" and "did not publish retained" needs a DMX device and a broker, and this workspace has no Tauri mock-app harness today. The honest guard is that the function is now structurally a read.

**This needs a rig check before it's believed.** The failing sequence is the test: drive the rig from one device, leave a second asleep holding a different buffer, then open it — the lights should not move.