### PR TITLE
ci: keep preReleaseVersion in appstore-submit's build poll

### DIFF
--- a/scripts/appstore-submit.ts
+++ b/scripts/appstore-submit.ts
@@ -106,12 +106,15 @@ console.log(`app ${appId} (${bundleId}), submitting ${version}`);
 
 // --- wait for both builds to process -------------------------------------
 
-// Builds carry no platform attribute — join through preReleaseVersion.
+// Builds carry no platform attribute — join through preReleaseVersion, which
+// must stay listed in `fields[builds]`: a sparse fieldset of only attributes
+// omits the relationship, so the join would silently resolve nothing and the
+// poll would spin until it timed out.
 async function processedBuilds(): Promise<Map<Platform, string>> {
   const r = expect<any>(
     await asc(
       `/v1/builds?filter[app]=${appId}&filter[version]=${version}` +
-        `&fields[builds]=version,processingState&include=preReleaseVersion` +
+        `&fields[builds]=version,processingState,preReleaseVersion&include=preReleaseVersion` +
         `&fields[preReleaseVersions]=platform`
     ),
     "build list"


### PR DESCRIPTION
## Problem

The `appstore.yml` submit workflow (`scripts/appstore-submit.ts`) times out and fails. `processedBuilds()` polls for the release's builds with:

    /v1/builds?...&fields[builds]=version,processingState&include=preReleaseVersion

A JSON:API sparse fieldset that lists only attributes (`version,processingState`) drops the object's **relationships**, so each build comes back without its `preReleaseVersion` linkage. The build→platform join then resolves nothing, `byPlatform` stays empty, and the poll runs the full 35‑minute `BUILD_POLL_TIMEOUT` before throwing — before any version is attached or submitted.

The builds are `VALID` the whole time; the query, not the builds, is the problem. This surfaced on the first real `appstore.yml` dispatch — earlier versions were submitted through the manual API flow, so this poll had never actually run.

## Fix

Add `preReleaseVersion` to the fieldset so the relationship is returned:

    fields[builds]=version,processingState,preReleaseVersion

A raw `/v1/builds?...&include=preReleaseVersion` with no `fields[builds]` restriction already returns the linkage; this restores it under the sparse fieldset. A comment on `processedBuilds()` records the constraint so the fieldset isn't trimmed back later.

## Verification

The patched script resolved both trains immediately (`IOS`, `MAC_OS`) and filed both platforms for review with release‑on‑approval.
