### PR TITLE
chore(lint): enable numeric-cast clippy family

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,18 @@ unwrap_used = "deny"
 panic = "warn"
 todo = "warn"
 unimplemented = "warn"
+# Numeric-cast hardening. This app is u8 channel values and usize buffer indices
+# crossing into the u16/u32 DMX, wire, and DynamoDB types, so a silent truncation
+# is a real defect. Every `as` that could lose data must become a checked
+# `try_from`, an infallible `From`/`into` widening, or a locally proven `expect` —
+# never an `#[allow]`. `-D warnings` in CI makes these blocking. (`cast_precision_loss`
+# is deliberately not enabled yet: its only sites are i64 epoch-millis widened to
+# the `f64` the TS bindings require by design, so clearing it means changing the
+# timestamp representation, not the cast.)
+cast_possible_truncation = "warn"
+cast_sign_loss = "warn"
+cast_possible_wrap = "warn"
+cast_lossless = "warn"
 
 # Dependencies shared across the desktop app and/or the Lambda services. Declared
 # once here; members opt in with `<dep>.workspace = true` (adding features as

--- a/apps/desktop/src-tauri/src/channels.rs
+++ b/apps/desktop/src-tauri/src/channels.rs
@@ -66,7 +66,8 @@ impl Default for LuxChannels {
             ("White", LuxLabelColor::White),
             ("Brightness", LuxLabelColor::Brightness),
         ];
-        let channels: Vec<Channel> = (1..=UNIVERSE_SIZE as u32)
+        let universe_end = u32::try_from(UNIVERSE_SIZE).expect("UNIVERSE_SIZE (512) fits u32");
+        let channels: Vec<Channel> = (1..=universe_end)
             .map(|channel_number| {
                 let (label, label_color) = rgbaw
                     .get((channel_number - 1) as usize)

--- a/apps/desktop/src-tauri/src/devices/discovery.rs
+++ b/apps/desktop/src-tauri/src/devices/discovery.rs
@@ -35,7 +35,7 @@ pub struct ArtNetNode {
 impl ArtNetNode {
     /// 15-bit Art-Net Port-Address of output port A.
     pub fn port_address(&self) -> u16 {
-        ((self.net as u16) << 8) | ((self.sub as u16) << 4) | self.sw_out as u16
+        (u16::from(self.net) << 8) | (u16::from(self.sub) << 4) | u16::from(self.sw_out)
     }
 
     /// sACN/E1.31 universe of output port A. DMXKing maps sACN universe N to

--- a/apps/desktop/src-tauri/src/fixture.rs
+++ b/apps/desktop/src-tauri/src/fixture.rs
@@ -41,7 +41,10 @@ pub struct Fixture {
 impl Fixture {
     /// Last DMX slot this fixture occupies (1-based, inclusive).
     fn end(&self) -> u16 {
-        self.address + self.channels.len() as u16 - 1
+        // A validated fixture spans ≤512 consecutive slots, so its channel count
+        // fits u16; saturate rather than wrap if that invariant is ever violated.
+        let count = u16::try_from(self.channels.len()).unwrap_or(u16::MAX);
+        self.address.saturating_add(count).saturating_sub(1)
     }
 }
 
@@ -143,7 +146,8 @@ fn validate_placement(address: u16, len: usize, others: &[Fixture]) -> Result<()
             "fixture spans slots {address}..={end}, past the {UNIVERSE_SIZE}-channel universe"
         ));
     }
-    let end = end as u16;
+    // `end <= UNIVERSE_SIZE` (checked just above), so it fits u16.
+    let end = u16::try_from(end).expect("fixture end within universe bounds fits u16");
     for other in others {
         // Inclusive ranges [address, end] and [other.address, other.end()] overlap.
         if address <= other.end() && other.address <= end {

--- a/apps/desktop/src-tauri/src/setup.rs
+++ b/apps/desktop/src-tauri/src/setup.rs
@@ -74,13 +74,15 @@ impl Setup {
             fixtures.push(lux_wire::ctl::ConfigFixture {
                 name: fixture.name.clone(),
                 address: fixture.address,
-                count: fixture.channels.len() as u16,
+                count: u16::try_from(fixture.channels.len()).unwrap_or(u16::MAX),
             });
             for (offset, channel) in fixture.channels.iter().enumerate() {
                 channels.push(lux_wire::ctl::ConfigChannel {
                     // 1-based DMX slot, matching `Frame::Channel`'s `ch` — the
                     // number a guest will publish back.
-                    n: fixture.address.saturating_add(offset as u16),
+                    n: fixture
+                        .address
+                        .saturating_add(u16::try_from(offset).unwrap_or(u16::MAX)),
                     name: channel.label.clone(),
                     // The variant name, which is exactly how the role rides
                     // every other wire in this app. A consumer matches what it
@@ -222,7 +224,7 @@ impl SetupStore {
                 id: s.id,
                 name: s.name.clone(),
                 universe: s.universe,
-                fixture_count: s.fixtures.len() as u32,
+                fixture_count: u32::try_from(s.fixtures.len()).unwrap_or(u32::MAX),
                 active: s.id == self.active_setup_id,
             })
             .collect()
@@ -287,7 +289,7 @@ impl LuxSetups {
             id: active.id,
             name: active.name.clone(),
             universe: active.universe,
-            fixture_count: active.fixtures.len() as u32,
+            fixture_count: u32::try_from(active.fixtures.len()).unwrap_or(u32::MAX),
             active: true,
         }
     }

--- a/apps/node/src/pairing.rs
+++ b/apps/node/src/pairing.rs
@@ -114,8 +114,8 @@ pub async fn pair_wait(
         };
         announce(&auth);
 
-        let deadline = Instant::now() + Duration::from_secs(auth.expires_in as u64);
-        let mut interval = (auth.interval.max(1) as u64).min(MAX_INTERVAL_SECS);
+        let deadline = Instant::now() + Duration::from_secs(u64::from(auth.expires_in));
+        let mut interval = u64::from(auth.interval.max(1)).min(MAX_INTERVAL_SECS);
 
         loop {
             tokio::time::sleep(Duration::from_secs(interval)).await;

--- a/crates/lux-engine/src/sacn.rs
+++ b/crates/lux-engine/src/sacn.rs
@@ -111,17 +111,19 @@ fn build_packet(
     sequence: u8,
 ) -> [u8; PACKET_LEN] {
     let mut p = [0u8; PACKET_LEN];
+    // PACKET_LEN (638) fits u16; the E1.31 PDU flags-and-length fields are u16.
+    let packet_len = u16::try_from(PACKET_LEN).expect("PACKET_LEN (638) fits u16");
 
     // ---- Root layer (ACN root, 38 bytes) ----
     p[0..2].copy_from_slice(&0x0010u16.to_be_bytes()); // preamble size
                                                        // [2..4] post-amble size = 0
     p[4..16].copy_from_slice(b"ASC-E1.17\0\0\0"); // ACN packet identifier
-    p[16..18].copy_from_slice(&(0x7000u16 | (PACKET_LEN as u16 - 16)).to_be_bytes()); // flags+length
+    p[16..18].copy_from_slice(&(0x7000u16 | (packet_len - 16)).to_be_bytes()); // flags+length
     p[18..22].copy_from_slice(&4u32.to_be_bytes()); // VECTOR_ROOT_E131_DATA
     p[22..38].copy_from_slice(cid);
 
     // ---- Framing layer (77 bytes) ----
-    p[38..40].copy_from_slice(&(0x7000u16 | (PACKET_LEN as u16 - 38)).to_be_bytes()); // flags+length
+    p[38..40].copy_from_slice(&(0x7000u16 | (packet_len - 38)).to_be_bytes()); // flags+length
     p[40..44].copy_from_slice(&2u32.to_be_bytes()); // VECTOR_E131_DATA_PACKET
     let name = source_name.as_bytes();
     let n = name.len().min(63); // 64-byte field, null-terminated
@@ -133,7 +135,7 @@ fn build_packet(
     p[113..115].copy_from_slice(&universe.to_be_bytes());
 
     // ---- DMP layer (523 bytes) ----
-    p[115..117].copy_from_slice(&(0x7000u16 | (PACKET_LEN as u16 - 115)).to_be_bytes()); // flags+length
+    p[115..117].copy_from_slice(&(0x7000u16 | (packet_len - 115)).to_be_bytes()); // flags+length
     p[117] = 0x02; // VECTOR_DMP_SET_PROPERTY
     p[118] = 0xa1; // address type & data type
                    // [119..121] first property address = 0

--- a/services/apple-auth/src/device.rs
+++ b/services/apple-auth/src/device.rs
@@ -85,7 +85,7 @@ pub async fn authorize(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error>
         &req.version,
         &req.arch,
         &egress,
-        EXPIRES_SECS as i64,
+        i64::from(EXPIRES_SECS),
     )
     .await
     {
@@ -214,7 +214,7 @@ pub async fn list(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
                 name: s("name")?,
                 hostname: s("hostname")?,
                 setup_id: s("setupId")?,
-                universe: n("universe")? as u16,
+                universe: u16::try_from(n("universe")?).ok()?,
                 paired_at: n("pairedAt")?,
             })
         })
@@ -437,7 +437,7 @@ fn now_millis() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
         .unwrap_or(0)
 }
 

--- a/services/apple-auth/src/store.rs
+++ b/services/apple-auth/src/store.rs
@@ -187,7 +187,7 @@ fn now_millis() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
         .unwrap_or(0)
 }
 
@@ -349,7 +349,7 @@ pub async fn get_pair(ctx: &Ctx, pair_ref: &str) -> Result<Option<Pair>, String>
         bound_username: opt_s("boundUsername"),
         bound_sub: opt_s("boundSub"),
         setup_id: opt_s("setupId"),
-        universe: opt_n("universe").map(|v| v as u16),
+        universe: opt_n("universe").and_then(|v| u16::try_from(v).ok()),
         created_at: num("createdAt")?,
         expires_at: num("expiresAt")?,
         redeemed_at: opt_n("redeemedAt"),
@@ -436,7 +436,7 @@ pub async fn approve_pair(
         .expression_attribute_values(":u", s(username))
         .expression_attribute_values(":sub", s(sub))
         .expression_attribute_values(":setup", s(setup_id))
-        .expression_attribute_values(":uni", n(universe as i64))
+        .expression_attribute_values(":uni", n(i64::from(universe)))
         .expression_attribute_values(":name", s(device_name))
         .expression_attribute_values(":now", n(now))
         .build()
@@ -455,7 +455,7 @@ pub async fn approve_pair(
         ("name".into(), s(device_name)),
         ("hostname".into(), s(&pair.hostname)),
         ("setupId".into(), s(setup_id)),
-        ("universe".into(), n(universe as i64)),
+        ("universe".into(), n(i64::from(universe))),
         ("pairedAt".into(), n(now)),
     ]);
     let put_registry = Put::builder()

--- a/services/sync-api/src/main.rs
+++ b/services/sync-api/src/main.rs
@@ -353,7 +353,7 @@ pub(crate) fn now_millis() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
         .unwrap_or(0)
 }
 

--- a/services/sync-api/src/shares.rs
+++ b/services/sync-api/src/shares.rs
@@ -62,12 +62,12 @@ const CODE_LEN: usize = 10;
 /// 10%, costing roughly a bit — immaterial against a single-use 48-hour code,
 /// but the property is free to keep.)
 fn mint_code() -> Result<String, String> {
-    let span = CODE_ALPHABET.len() as u16;
+    let span = CODE_ALPHABET.len();
     let ceiling = (256 / span) * span; // largest whole multiple of the alphabet
     let mut body = String::with_capacity(CODE_LEN);
     while body.len() < CODE_LEN {
         for b in random::<CODE_LEN>()? {
-            if (b as u16) < ceiling {
+            if (b as usize) < ceiling {
                 body.push(CODE_ALPHABET[b as usize % CODE_ALPHABET.len()] as char);
                 if body.len() == CODE_LEN {
                     break;

--- a/services/sync-api/src/store.rs
+++ b/services/sync-api/src/store.rs
@@ -101,7 +101,9 @@ pub async fn list(ddb: &Client, table: &str, sub: &str) -> Result<ListSetupsResp
         setups.push(SetupRecord {
             id: id.to_owned(),
             name: s(item, "name").unwrap_or_default(),
-            universe: n(item, "universe").unwrap_or(1) as u16,
+            universe: n(item, "universe")
+                .and_then(|v| u16::try_from(v).ok())
+                .unwrap_or(1),
             fixtures: s(item, "fixtures")
                 .and_then(|raw| serde_json::from_str(&raw).ok())
                 .unwrap_or(Value::Array(vec![])),


### PR DESCRIPTION
## What

Enables the numeric-cast clippy family workspace-wide and clears every site:

- `cast_possible_truncation`
- `cast_sign_loss`
- `cast_possible_wrap` (no current sites — locks the invariant going forward)
- `cast_lossless`

This is the first family in the incremental clippy hardening; it steps the lint floor up from the four-lint baseline (`unwrap_used`/`panic`/`todo`/`unimplemented`) toward real cast correctness. A DMX/color app is full of `u8` channel values and `usize` buffer indices crossing into the `u16`/`u32` DMX, wire, and DynamoDB types, so a silent truncation is a genuine defect class.

## How each site was resolved

Every flagged cast is an explicit decision — no `#[allow]` anywhere:

- **Infallible widenings → `From`/`into`:** Art-Net port-address assembly (`u8→u16`), node re-register backoff timers (`u32→u64`), DynamoDB universe writes (`u16→i64`), the `EXPIRES_SECS` pair TTL, and the share-code rejection-sampling comparison (moved to `usize`).
- **Bounded values → checked `try_from`:** DynamoDB `universe` **reads** now drop a malformed record (`.ok()?`) or fall back to universe 1 rather than wrap a garbage value; fixture spans, setup counts, and epoch-millis conversions saturate where overflow is physically unreachable.
- **Locally proven → `expect`:** `UNIVERSE_SIZE` (512) and `PACKET_LEN` (638) are compile-time constants; the fixture `end` is already range-checked against the universe one line above.

## Not changed

- **No wire or binding changes.** `Setup::compile` still emits identical `ConfigFixture`/`ConfigChannel` values — the lux-wire golden tests are unmoved and `bindings.ts` is byte-identical (drift guard passes).
- **`cast_precision_loss` is intentionally deferred.** Its only four sites are `i64` epoch-millis widened to the `f64` the TS bindings require by design (the DTO comments already document the `f64` choice; specta exports no `bigint`). Satisfying it without a suppression means changing the timestamp *representation*, not the cast — a separate, representation-level decision, tracked as a follow-up.

## Verification

- `cargo clippy --workspace --locked -- -D warnings` — clean.
- `cargo test --workspace --locked` — all suites pass, including `bindings_match_generator` and the lux-wire golden tests.
- `cargo fmt --all -- --check` — clean.
