### PR TITLE
chore(lint): enforce indexing_slicing on the Art-Net parser

### DIFF
--- a/apps/desktop/src-tauri/src/devices/discovery.rs
+++ b/apps/desktop/src-tauri/src/devices/discovery.rs
@@ -12,6 +12,12 @@
 //! universe. Packet offsets follow Art-Net 4 and are validated against a real
 //! eDMX1 PRO (see the Python prototype this was ported from).
 
+// Parse-path hardening: this module reads attacker-shaped UDP packets, so raw
+// slice indexing is denied here (the first step of the incremental
+// `indexing_slicing` rollout). Every offset below indexes a fixed-size array
+// proven long enough, or goes through `.get()`.
+#![warn(clippy::indexing_slicing)]
+
 use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
 use std::time::{Duration, Instant};
 
@@ -56,23 +62,30 @@ fn build_artpoll() -> [u8; 14] {
 
 /// Parse an `ArtPollReply`. Returns `None` for anything that isn't one.
 fn parse_reply(data: &[u8]) -> Option<ArtNetNode> {
-    if data.len() < 200 || &data[0..8] != b"Art-Net\0" {
+    // Pin the read window to a compile-time length: every offset below then
+    // indexes a known-200-byte array rather than an attacker-sized slice, so a
+    // short or truncated packet is rejected here instead of panicking. SwOut[0]
+    // at offset 190 is the last field read.
+    let data: &[u8; 200] = data.get(..200)?.try_into().ok()?;
+    if !data.starts_with(b"Art-Net\0") {
         return None;
     }
     if u16::from_le_bytes([data[8], data[9]]) != 0x2100 {
         return None;
     }
     let cstr = |b: &[u8]| {
-        let end = b.iter().position(|&c| c == 0).unwrap_or(b.len());
-        String::from_utf8_lossy(&b[..end]).into_owned()
+        // Bytes up to the first NUL (or all of them if unterminated) — the
+        // first `split` segment, which is always present.
+        let name = b.split(|&c| c == 0).next().unwrap_or(b);
+        String::from_utf8_lossy(name).into_owned()
     };
     Some(ArtNetNode {
         ip: Ipv4Addr::new(data[10], data[11], data[12], data[13]),
         firmware: (data[16], data[17]),
         net: data[18] & 0x7f,
         sub: data[19] & 0x0f,
-        short_name: cstr(&data[26..44]),
-        long_name: cstr(&data[44..108]),
+        short_name: cstr(data.get(26..44)?),
+        long_name: cstr(data.get(44..108)?),
         output: data[174] & 0x80 != 0, // PortTypes[0] bit7 = "can output from network"
         sw_out: data[190] & 0x0f,      // SwOut[0] low nibble
     })
@@ -118,7 +131,7 @@ pub fn discover(timeout: Duration) -> Vec<ArtNetNode> {
             last_poll = Instant::now();
         }
         if let Ok((n, _)) = socket.recv_from(&mut buf) {
-            if let Some(node) = parse_reply(&buf[..n]) {
+            if let Some(node) = buf.get(..n).and_then(parse_reply) {
                 if !nodes.iter().any(|x| x.ip == node.ip) {
                     nodes.push(node);
                     last_new = Instant::now();


### PR DESCRIPTION
## What

Enables `clippy::indexing_slicing`, **scoped to the Art-Net discovery module**, and clears its 17 sites. This is the first, highest-value step of an incremental rollout of that lint — `discovery.rs` is the one place in the workspace that indexes **bytes read straight off a UDP socket**, so it's where the lint actually prevents an out-of-bounds panic on a hostile or truncated packet.

The lint prices at **46 sites workspace-wide**; the remaining 29 are provably-safe internal buffer/packet writes (fixed-size arrays, min-clamped ranges, range-checked indices) where the lint is closer to noise. Those are deferred to a later pass rather than forced now — the scope call was made deliberately (untrusted-parse first).

## How

`parse_reply` pins its read window to a `&[u8; 200]` up front:

```rust
let data: &[u8; 200] = data.get(..200)?.try_into().ok()?;
```

After that, every field offset is a **proven-in-bounds index into a known-length array**, not a slice into attacker-sized input, and a short/truncated packet is rejected at that line instead of relying on a separate length guard. The rest follows:

- magic-bytes check → `data.starts_with(b"Art-Net\0")`
- the two name fields → `data.get(26..44)?` / `data.get(44..108)?`
- the NUL-trim in `cstr` → `split(|&c| c == 0).next()` instead of range-indexing
- the receive loop → `buf.get(..n).and_then(parse_reply)`

A module-scoped `#![warn(clippy::indexing_slicing)]` locks it in: raw slice indexing in this parser now fails CI (`-D warnings`), so the hardening can't silently regress.

## Not changed

- **Behavior is identical for every real packet.** The old `data.len() < 200` guard already made these accesses safe; this makes that safety machine-checked. No `#[allow]` anywhere.
- The lint is **not** enabled workspace-wide, so the other 29 sites are untouched.
- Test-fixture packet-building (`#[cfg(test)]`) keeps its idiomatic constant-index writes — CI lints default targets only, matching the repo's existing test-code policy.

## Verification

- `cargo clippy --workspace --locked -- -D warnings` — clean.
- `cargo test --workspace --locked` — all pass, including `rejects_non_replies` (short/non-reply rejection preserved) and `parses_real_edmx_reply_shape` (offset parsing preserved).
- `cargo fmt --all -- --check` — clean.

---

Independent of #244 (numeric-cast family); either can merge first.
