### PR TITLE
chore(lint): forbid float equality comparisons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,12 @@ cast_possible_truncation = "warn"
 cast_sign_loss = "warn"
 cast_possible_wrap = "warn"
 cast_lossless = "warn"
+# Float-equality hardening. The fixture engine mixes RGBAW as f32 (role-aware
+# blending, master scaling), where `==`/`!=` on the results is a classic bug —
+# rounding makes two "equal" colours compare unequal. Compare with a tolerance
+# instead. Zero sites today; this keeps it that way.
+float_cmp = "warn"
+float_cmp_const = "warn"
 
 # Dependencies shared across the desktop app and/or the Lambda services. Declared
 # once here; members opt in with `<dep>.workspace = true` (adding features as


### PR DESCRIPTION
## What

Enables `clippy::float_cmp` and `clippy::float_cmp_const` workspace-wide — the "no `==`/`!=` on floats" family.

The fixture engine mixes RGBAW channels as `f32` (role-aware blending, master scaling). Exact equality on those results is a classic bug: rounding leaves two colours that "should" be equal comparing unequal, so any `if mixed == target` branch silently misbehaves. The lints force a tolerance-based comparison instead.

## Cost

**Zero violations today** — this is a pure forward-guard, no code changes. It keeps the tree clean and makes a future float `==` fail the CI gate (`-D warnings`). Same shape as `cast_possible_wrap` in #244: enable-at-zero to lock the invariant.

## Verification

- `cargo clippy --workspace --locked -- -D warnings` — clean.
- `cargo test --workspace --locked` — all pass.
- `cargo fmt --all -- --check` — clean.

---

Part of the incremental clippy hardening (follows #244 numeric-cast, #245 indexing_slicing parse-path). Independent — merges cleanly on its own.
