### PR TITLE
chore(lint): forbid unreachable! and panics in Result fns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ unwrap_used = "deny"
 panic = "warn"
 todo = "warn"
 unimplemented = "warn"
+unreachable = "warn"
+# Also fail a Result-returning fn that hides a panic-macro or assert! behind its
+# Result — those paths should return an Err, not abort the process.
+panic_in_result_fn = "warn"
 # Numeric-cast hardening. This app is u8 channel values and usize buffer indices
 # crossing into the u16/u32 DMX, wire, and DynamoDB types, so a silent truncation
 # is a real defect. Every `as` that could lose data must become a checked


### PR DESCRIPTION
## What

Two panic-prevention lints, both **zero-violation** enable-at-zero locks:

- **`clippy::unreachable`** — completes the panic-macro floor. `panic`, `todo`, and `unimplemented` already warn; `unreachable!` was the missing fourth. Now all four std "never in production" macros are on the same footing.
- **`clippy::panic_in_result_fn`** — fails a `Result`-returning function that hides a panic-macro or `assert!` behind its `Result`. Those paths should return an `Err`, not abort the process — the app's degrade-and-log stance.

## Cost

**Zero violations today** — no code changes, pure forward-guards. `-D warnings` in CI keeps them enforced against regressions.

This effectively closes out the named clippy-hardening families that are worth enabling. Remaining, by prior analysis: `integer_division` (skip — intentional truncation), the `indexing_slicing` remainder (low value — keep module-scoped), and `cast_precision_loss` (blocked on a timestamp-representation decision).

## Verification

- `cargo clippy --workspace --locked -- -D warnings` — clean.
- `cargo test --workspace --locked` — all pass.
- `cargo fmt --all -- --check` — clean.

---

Follows #244 (numeric-cast), #245 (indexing_slicing parse-path), #246 (float-equality).
