### PR TITLE
fix(presets): scope preset activation per fixture

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -6,7 +6,8 @@ name: desktop
 # surfaces. Catching it on the PR (a few minutes) closes that gap:
 #   - tauri-versions: @tauri-apps/* JS packages must share their minor with their
 #     Rust crate counterparts (the drift that broke the 0.8.0 release).
-#   - frontend: production build (also generates routeTree.gen.ts) + typecheck + lint.
+#   - frontend: production build (also generates routeTree.gen.ts) + typecheck +
+#     lint + `bun test` front-end unit tests (e.g. the preset engine).
 #   - rust-test: cargo test across the workspace, including tests/bindings.rs — the
 #     drift guard that fails when src/bindings.ts is stale.
 #   - rust-clippy: the workspace lint gate at -D warnings.
@@ -180,6 +181,10 @@ jobs:
       - run: bun run typecheck
 
       - run: bun run lint
+
+      # Front-end unit tests (the preset engine, and whatever joins it). Pure
+      # logic, no browser — bun's own runner, no extra dependency.
+      - run: bun test
 
   # Build the three Lambda services exactly as the release deploy job will
   # (static musl, release profile, same package names) — so a broken link, a

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint src",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "check:tauri-versions": "bun scripts/check-tauri-versions.mjs",
     "tauri": "tauri"

--- a/apps/desktop/src/components/button-row.tsx
+++ b/apps/desktop/src/components/button-row.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import useBuffer from "@/hooks/useBuffer";
 import {
   togglePreset,
-  useActivePresetId,
+  useIsPresetActive,
   usePresetReconcile,
 } from "@/lib/preset-toggle";
 
@@ -27,6 +27,38 @@ const presets = [
   },
 ];
 
+/** Both built-in presets write the whole universe, so they share one lane. */
+const SETUP_SCOPE = { kind: "setup" } as const;
+
+/**
+ * One preset button. Its own `useIsPresetActive` subscription keeps the pressed
+ * state per-preset (and a hook out of the parent's render loop).
+ */
+function PresetButton({
+  id,
+  children,
+  writes,
+  disabled,
+}: (typeof presets)[number] & { disabled: boolean }) {
+  const active = useIsPresetActive(id);
+  return (
+    <Button
+      variant={active ? "secondary" : "link"}
+      size="sm"
+      aria-pressed={active}
+      disabled={disabled}
+      onClick={() => {
+        trace(`frontend toggling ${children}`);
+        togglePreset(id, writes(), SETUP_SCOPE).catch((e) =>
+          toast.error(String(e)),
+        );
+      }}
+    >
+      {children}
+    </Button>
+  );
+}
+
 /**
  * The preset row, shown on both control surfaces (fixtures + universe).
  * Presets toggle: engaging one remembers the frame it replaced, pressing it
@@ -35,27 +67,11 @@ const presets = [
 function ButtonRow() {
   const buffer = useBuffer();
   usePresetReconcile(buffer);
-  const activeId = useActivePresetId();
   return (
     <div className="flex shrink-0 justify-center gap-2 py-2">
-      {presets.map(({ id, children, writes }) => {
-        const active = activeId === id;
-        return (
-          <Button
-            key={id}
-            variant={active ? "secondary" : "link"}
-            size="sm"
-            aria-pressed={active}
-            disabled={!buffer}
-            onClick={() => {
-              trace(`frontend toggling ${children}`);
-              togglePreset(id, writes()).catch((e) => toast.error(String(e)));
-            }}
-          >
-            {children}
-          </Button>
-        );
-      })}
+      {presets.map((preset) => (
+        <PresetButton key={preset.id} {...preset} disabled={!buffer} />
+      ))}
     </div>
   );
 }

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -8,7 +8,7 @@ import ColorTrigger from "@/components/color-picker/color-trigger";
 import useThrottle from "@/hooks/useThrottle";
 import { setChannelValue } from "@/lib/actions";
 import { emittersToRgb, mixToEmitters } from "@/lib/color-mix";
-import { togglePreset, useActivePresetId } from "@/lib/preset-toggle";
+import { togglePreset, useIsPresetActive } from "@/lib/preset-toggle";
 
 /**
  * Reading light: tungsten/amber at full, master at 40%. Expressed as a picker
@@ -96,13 +96,16 @@ export default function FixtureColor({
   // wheel path) so the toggle store can track exactly what it set; the swatch
   // and wheel follow via the buffer round-trip like any out-of-band change.
   const presetId = `reading-light-${fixture.id}`;
-  const readingLightActive = useActivePresetId() === presetId;
+  const readingLightActive = useIsPresetActive(presetId);
   const onReadingLight = () => {
     const writes = new Map<number, number>();
     for (const [addr, value] of emitterWrites(READING_LIGHT)) {
       if (addr) writes.set(addr, value);
     }
-    togglePreset(presetId, writes).catch(() => {});
+    togglePreset(presetId, writes, {
+      kind: "fixture",
+      fixtureId: fixture.id,
+    }).catch(() => {});
   };
 
   // Glow tracks the dimmer when present, else the brightest color channel.

--- a/apps/desktop/src/lib/preset-engine.test.ts
+++ b/apps/desktop/src/lib/preset-engine.test.ts
@@ -1,0 +1,183 @@
+import { test, expect, describe } from "bun:test";
+import {
+  planToggle,
+  reconcile,
+  isPresetActive,
+  scopeKey,
+  type ActiveMap,
+  type PresetScope,
+} from "@/lib/preset-engine";
+
+// A small stand-in universe (6 channels) keeps the fixtures below readable.
+// Fixture A owns 1..3, fixture B owns 4..6 — disjoint, as the patch validator
+// guarantees. A "full-setup" preset writes the whole thing.
+const SETUP: PresetScope = { kind: "setup" };
+const FIX_A: PresetScope = { kind: "fixture", fixtureId: "A" };
+const FIX_B: PresetScope = { kind: "fixture", fixtureId: "B" };
+
+/** Build a sparse address→value map from a plain object. */
+const w = (o: Record<number, number>): Map<number, number> =>
+  new Map(Object.entries(o).map(([k, v]) => [Number(k), v]));
+
+const READING_A = w({ 1: 255, 2: 128, 3: 10 });
+const READING_B = w({ 4: 255, 5: 128, 6: 10 });
+const BLACKOUT = w({ 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 });
+const FULL = w({ 1: 255, 2: 255, 3: 255, 4: 255, 5: 255, 6: 255 });
+
+const EMPTY: ActiveMap = new Map();
+const zeros = () => [0, 0, 0, 0, 0, 0];
+
+/** Apply a toggle and hand back the resulting frame + active map together. */
+function toggle(
+  active: ActiveMap,
+  id: string,
+  writes: Map<number, number>,
+  scope: PresetScope,
+  base: number[],
+) {
+  const { frame, next } = planToggle(active, id, writes, scope, base);
+  return { frame, active: next };
+}
+
+describe("fixture presets are independent per fixture", () => {
+  test("engaging a preset on B leaves A's marker and A's channels untouched", () => {
+    let frame = zeros();
+    let active = EMPTY;
+
+    ({ frame, active } = toggle(active, "reading-A", READING_A, FIX_A, frame));
+    ({ frame, active } = toggle(active, "reading-B", READING_B, FIX_B, frame));
+
+    // Both markers stay lit — this is the bug John reported.
+    expect(isPresetActive(active, "reading-A")).toBe(true);
+    expect(isPresetActive(active, "reading-B")).toBe(true);
+
+    // A's channels still carry the reading light; B's now do too.
+    expect(frame.slice(0, 3)).toEqual([255, 128, 10]);
+    expect(frame.slice(3, 6)).toEqual([255, 128, 10]);
+  });
+
+  test("toggling B off restores only B and never disturbs A", () => {
+    let frame = zeros();
+    let active = EMPTY;
+    ({ frame, active } = toggle(active, "reading-A", READING_A, FIX_A, frame));
+    ({ frame, active } = toggle(active, "reading-B", READING_B, FIX_B, frame));
+
+    // Press B again to release it.
+    ({ frame, active } = toggle(active, "reading-B", READING_B, FIX_B, frame));
+
+    expect(isPresetActive(active, "reading-A")).toBe(true);
+    expect(isPresetActive(active, "reading-B")).toBe(false);
+    expect(frame.slice(0, 3)).toEqual([255, 128, 10]); // A untouched
+    expect(frame.slice(3, 6)).toEqual([0, 0, 0]); // B back to its snapshot
+  });
+
+  test("each fixture snapshots its own prior state independently", () => {
+    // A starts at a manual look, B at zero.
+    const base = [50, 60, 70, 0, 0, 0];
+    let frame = base.slice();
+    let active = EMPTY;
+    ({ frame, active } = toggle(active, "reading-A", READING_A, FIX_A, frame));
+    ({ frame, active } = toggle(active, "reading-B", READING_B, FIX_B, frame));
+    // Release A — it must return to A's manual look, not to zero.
+    ({ frame } = toggle(active, "reading-A", READING_A, FIX_A, frame));
+    expect(frame.slice(0, 3)).toEqual([50, 60, 70]);
+    expect(frame.slice(3, 6)).toEqual([255, 128, 10]); // B still lit
+  });
+});
+
+describe("a fixture change toggles the full-setup preset off (John's rule)", () => {
+  test("engaging a fixture preset over Blackout toggles Blackout off; other fixtures stay at 0", () => {
+    let frame = zeros();
+    let active = EMPTY;
+    ({ frame, active } = toggle(active, "blackout", BLACKOUT, SETUP, frame));
+    ({ frame, active } = toggle(active, "reading-A", READING_A, FIX_A, frame));
+
+    // Reconcile is what runs off the buffer write in the app. Blackout wrote
+    // fixture A's channels; the reading light changed them, so Blackout drops.
+    active = reconcile(active, frame);
+    expect(isPresetActive(active, "blackout")).toBe(false);
+    expect(isPresetActive(active, "reading-A")).toBe(true);
+    // Fixtures 2/3 (addresses 4..6) keep the 0 Blackout left — never restored.
+    expect(frame).toEqual([255, 128, 10, 0, 0, 0]);
+  });
+
+  test("moving a single fader while Blackout is up toggles Blackout off, rest unchanged", () => {
+    let frame = zeros();
+    let active = EMPTY;
+    ({ frame, active } = toggle(active, "blackout", BLACKOUT, SETUP, frame));
+    // A fader nudge on one channel (fixture B here).
+    frame[4] = 90;
+    active = reconcile(active, frame);
+    expect(isPresetActive(active, "blackout")).toBe(false);
+    expect(frame).toEqual([0, 0, 0, 0, 90, 0]); // reconcile never restores
+  });
+
+  test("a full-setup preset overrides everything and clears fixture markers", () => {
+    let frame = zeros();
+    let active = EMPTY;
+    ({ frame, active } = toggle(active, "reading-A", READING_A, FIX_A, frame));
+    ({ frame, active } = toggle(active, "blackout", BLACKOUT, SETUP, frame));
+    active = reconcile(active, frame);
+    expect(frame).toEqual([0, 0, 0, 0, 0, 0]);
+    expect(isPresetActive(active, "blackout")).toBe(true);
+    expect(isPresetActive(active, "reading-A")).toBe(false);
+  });
+
+  test("two full-setup presets share one lane — the second replaces the first", () => {
+    let frame = zeros();
+    let active = EMPTY;
+    ({ frame, active } = toggle(active, "blackout", BLACKOUT, SETUP, frame));
+    ({ frame, active } = toggle(active, "full-bright", FULL, SETUP, frame));
+    expect(isPresetActive(active, "blackout")).toBe(false);
+    expect(isPresetActive(active, "full-bright")).toBe(true);
+    expect(frame).toEqual([255, 255, 255, 255, 255, 255]);
+  });
+});
+
+describe("toggling a preset off from its button restores the prior frame", () => {
+  test("Blackout on, then off (untouched) returns the lights to their prior state", () => {
+    // A live look before anyone touches Blackout.
+    const prior = [10, 20, 30, 40, 50, 60];
+    let frame = prior.slice();
+    let active = EMPTY;
+    ({ frame, active } = toggle(active, "blackout", BLACKOUT, SETUP, frame));
+    expect(frame).toEqual([0, 0, 0, 0, 0, 0]);
+    expect(isPresetActive(active, "blackout")).toBe(true);
+
+    // "Several hours later" — nothing else moved a channel, so Blackout is
+    // still active — pressing it again restores exactly the prior look.
+    ({ frame, active } = toggle(active, "blackout", BLACKOUT, SETUP, frame));
+    expect(frame).toEqual(prior);
+    expect(isPresetActive(active, "blackout")).toBe(false);
+  });
+});
+
+describe("reconcile mechanics", () => {
+  test("an external change to a fixture's channel deactivates that fixture's preset only", () => {
+    let frame = zeros();
+    let active = EMPTY;
+    ({ frame, active } = toggle(active, "reading-A", READING_A, FIX_A, frame));
+    ({ frame, active } = toggle(active, "reading-B", READING_B, FIX_B, frame));
+
+    // A fader (or remote) nudges one of A's channels away from what A wrote.
+    frame[0] = 200;
+    active = reconcile(active, frame);
+    expect(isPresetActive(active, "reading-A")).toBe(false);
+    expect(isPresetActive(active, "reading-B")).toBe(true);
+  });
+
+  test("reconcile returns the same reference when nothing is dropped", () => {
+    let frame = zeros();
+    let active = EMPTY;
+    ({ frame, active } = toggle(active, "reading-A", READING_A, FIX_A, frame));
+    expect(reconcile(active, frame)).toBe(active);
+  });
+});
+
+describe("scopeKey", () => {
+  test("setup collapses to one lane; fixtures key by id", () => {
+    expect(scopeKey(SETUP)).toBe(scopeKey({ kind: "setup" }));
+    expect(scopeKey(FIX_A)).not.toBe(scopeKey(FIX_B));
+    expect(scopeKey(FIX_A)).toBe(scopeKey({ kind: "fixture", fixtureId: "A" }));
+  });
+});

--- a/apps/desktop/src/lib/preset-engine.ts
+++ b/apps/desktop/src/lib/preset-engine.ts
@@ -1,0 +1,125 @@
+//! The preset state machine, as pure data — no React, no Tauri, no buffer I/O.
+//!
+//! Presets are momentary looks, not destinations: engaging one remembers the
+//! channels it replaces, and toggling it off puts them back. Two kinds share
+//! this machine, and the whole point of the scoping here is that they don't
+//! step on each other:
+//!
+//!   - **Full-setup** presets (Blackout, Full Bright) write the entire universe.
+//!     They share a single lane (`{ kind: "setup" }`): engaging one replaces the
+//!     other, exactly as before.
+//!   - **Fixture** presets (Reading Light) write one fixture's channels. Each
+//!     fixture is its own lane (`{ kind: "fixture", fixtureId }`), so Reading
+//!     Light on fixture A and on fixture B are independent — engaging one never
+//!     disturbs the other's channels or its active marker. Fixtures own disjoint
+//!     address ranges (the patch validator guarantees it), so fixture lanes
+//!     never collide.
+//!
+//! **Deactivation is strict and per-preset.** A preset is dropped the moment any
+//! channel it wrote no longer matches — whether the change came from a fader, a
+//! remote command, or another preset. So engaging Reading Light on fixture A
+//! while Blackout is up toggles Blackout *off* (Blackout's channels on fixture A
+//! changed); the fixtures the fixture preset didn't touch keep the value
+//! Blackout left them at, because reconcile only clears the marker — it never
+//! restores. The one way to get a preset's remembered frame back is to toggle
+//! that preset off from its own button (see `planToggle`), which is only
+//! possible while it is still active, i.e. before anything else has changed it.
+//!
+//! Everything here is pure: inputs are copied, never mutated, so the same call
+//! is safe to make from a React render or a test. The active set is UI-side
+//! state; the backend only ever sees the frames these functions produce.
+
+/** Which lane a preset lives in. Setup presets share one lane; fixtures each own one. */
+export type PresetScope =
+  | { kind: "setup" }
+  | { kind: "fixture"; fixtureId: string };
+
+/** The map key for a lane. Setup collapses to one key; fixtures key by id. */
+export function scopeKey(scope: PresetScope): string {
+  return scope.kind === "setup" ? "setup" : `fixture:${scope.fixtureId}`;
+}
+
+export type ActivePreset = {
+  id: string;
+  scope: PresetScope;
+  /** Prior value of each address the preset wrote (restore target). */
+  snapshot: Map<number, number>;
+  /** What the preset wrote (1-based address → value); divergence deactivates. */
+  expected: Map<number, number>;
+};
+
+/** The engaged presets, keyed by lane (`scopeKey`). At most one per lane. */
+export type ActiveMap = ReadonlyMap<string, ActivePreset>;
+
+/**
+ * Plan engaging preset `id` in `scope`, or toggling it off if it is already the
+ * one engaged in that lane. Returns the frame to commit and the next active map.
+ *
+ * Only the target lane is touched: the outgoing preset *in that lane* (if any)
+ * is undone first, so switching within a lane composes undo + engage into one
+ * frame and toggling off always returns to a state the user actually set. Other
+ * lanes — and their contributions to `base` — are left exactly as they are, so
+ * a fixture preset never disturbs another fixture or the full-setup look.
+ */
+export function planToggle(
+  active: ActiveMap,
+  id: string,
+  writes: Map<number, number>,
+  scope: PresetScope,
+  base: number[],
+): { frame: number[]; next: ActiveMap } {
+  const key = scopeKey(scope);
+  const prev = active.get(key) ?? null;
+
+  // Start from the live frame and undo only this lane's outgoing preset.
+  const frame = base.slice();
+  for (const [addr, value] of prev?.snapshot ?? []) frame[addr - 1] = value;
+
+  const next = new Map(active);
+  if (prev?.id === id) {
+    // Same preset in this lane → toggle it off; its channels are already restored.
+    next.delete(key);
+    return { frame, next };
+  }
+
+  // Engage: snapshot the addresses we're about to write (post-undo, so restore
+  // returns to "this lane absent"), then lay the preset down.
+  const snapshot = new Map<number, number>();
+  for (const addr of writes.keys()) snapshot.set(addr, frame[addr - 1] ?? 0);
+  for (const [addr, value] of writes) frame[addr - 1] = value;
+  next.set(key, { id, scope, snapshot, expected: writes });
+  return { frame, next };
+}
+
+/**
+ * Drop any preset whose look the live `buffer` no longer shows: a preset is
+ * cleared the moment one of the channels it wrote diverges, whatever moved it —
+ * a fader, a remote command, or another preset engaged on top. This clears the
+ * *marker* only; it never writes, so the divergent state stands (that's what
+ * makes "engage Blackout, then raise one fixture" leave the rest at 0). Because
+ * each preset watches only its own channels, a change to one fixture never
+ * clears another's marker. Returns the same map reference when nothing is
+ * dropped, so callers can skip a re-render on identity.
+ */
+export function reconcile(active: ActiveMap, buffer: number[]): ActiveMap {
+  const drop: string[] = [];
+  for (const [key, p] of active) {
+    for (const [addr, value] of p.expected) {
+      if (buffer[addr - 1] !== value) {
+        drop.push(key);
+        break;
+      }
+    }
+  }
+
+  if (drop.length === 0) return active;
+  const next = new Map(active);
+  for (const key of drop) next.delete(key);
+  return next;
+}
+
+/** Whether a preset with this `id` is engaged in any lane. */
+export function isPresetActive(active: ActiveMap, id: string): boolean {
+  for (const p of active.values()) if (p.id === id) return true;
+  return false;
+}

--- a/apps/desktop/src/lib/preset-toggle.ts
+++ b/apps/desktop/src/lib/preset-toggle.ts
@@ -2,29 +2,27 @@ import { useEffect, useSyncExternalStore } from "react";
 import { createTauRPCProxy } from "@/bindings";
 import { queryClient } from "@/lib/query-client";
 import { BUFFER_QUERY_KEY } from "@/hooks/useBuffer";
+import {
+  planToggle,
+  reconcile,
+  isPresetActive,
+  type ActiveMap,
+  type PresetScope,
+} from "@/lib/preset-engine";
 
 /**
- * Presets are momentary looks, not destinations: engaging one remembers the
- * channels it replaces, and toggling it off puts them back. The active preset
- * is a UI-side notion — the backend only ever sees buffer writes — so the
- * store also watches the live buffer and quietly drops the active state when
- * anything else (a fader, the wheel, a remote command) moves a channel the
- * preset set, rather than offering a restore that would clobber it.
+ * The React + Tauri adapter around the pure preset engine (`preset-engine.ts`):
+ * it holds the live active set, drives it from real buffer reads/writes, and
+ * exposes the store hooks the UI subscribes to. All the scoping and layering
+ * rules — why a fixture preset never disturbs another fixture, why a full-setup
+ * marker survives a layered fixture — live in the engine and its tests; this
+ * file only does I/O.
  *
- * Snapshots are sparse (only the addresses the preset wrote) and every toggle
- * starts from a fresh backend read, so concurrent changes to unrelated
- * channels — another surface, the Discord bot — survive both engage and
- * restore.
+ * The active set is UI-side; the backend only ever sees buffer writes. Every
+ * toggle starts from a fresh backend read so concurrent changes to unrelated
+ * channels — another surface, the Discord bot — survive both engage and restore.
  */
-type ActivePreset = {
-  id: string;
-  /** Prior value of each address the preset wrote (restore target). */
-  snapshot: Map<number, number>;
-  /** What the preset wrote (1-based address → value); divergence deactivates. */
-  expected: Map<number, number>;
-};
-
-let active: ActivePreset | null = null;
+let active: ActiveMap = new Map();
 const listeners = new Set<() => void>();
 
 function notify() {
@@ -50,56 +48,42 @@ async function applyBuffer(frame: number[]) {
 }
 
 /**
- * Engage the preset `id`, or toggle it off if it is already the active one.
- *
- * Either way the outgoing preset (if any) is undone first, so switching
- * directly between presets composes undo + engage into a single frame:
- * toggling off always returns to a state the user actually set, never to
- * another preset's output. The active mark is only set once the backend
+ * Engage the preset `id` in `scope`, or toggle it off if it is already the one
+ * engaged in that lane. The active mark is only advanced once the backend
  * commits, so a failed write leaves both the lights and the toggle untouched.
  */
-export async function togglePreset(id: string, writes: Map<number, number>) {
-  const previous = active;
+export async function togglePreset(
+  id: string,
+  writes: Map<number, number>,
+  scope: PresetScope,
+) {
   const base = (await createTauRPCProxy().sync.sync_buffer()).buffer.slice();
-  for (const [address, value] of previous?.snapshot ?? []) {
-    base[address - 1] = value;
-  }
-  if (previous?.id === id) {
-    active = null;
-    notify();
-    await applyBuffer(base);
-    return;
-  }
-  const snapshot = new Map<number, number>();
-  for (const address of writes.keys()) {
-    snapshot.set(address, base[address - 1] ?? 0);
-  }
-  const frame = base.slice();
-  for (const [address, value] of writes) frame[address - 1] = value;
+  const { frame, next } = planToggle(active, id, writes, scope, base);
   await applyBuffer(frame);
-  active = { id, snapshot, expected: writes };
+  // Reconcile against the frame we just wrote so any preset this one changed —
+  // e.g. Blackout when a fixture preset is engaged over it — drops its marker
+  // in the same update, not a tick later when the buffer read lands.
+  active = reconcile(next, frame);
   notify();
 }
 
-/** The id of the engaged preset, or null. Re-renders on engage/clear. */
-export function useActivePresetId(): string | null {
-  return useSyncExternalStore(subscribe, () => active?.id ?? null);
+/** Whether a preset with this `id` is engaged. Re-renders on any change. */
+export function useIsPresetActive(id: string): boolean {
+  return useSyncExternalStore(subscribe, () => isPresetActive(active, id));
 }
 
 /**
- * Drop the active preset when the live buffer no longer matches what it
- * wrote. Mount next to a `useBuffer()` read (ButtonRow does, on both
+ * Drop any active preset whose look the live buffer no longer shows (see
+ * `reconcile`). Mount next to a `useBuffer()` read (ButtonRow does, on both
  * surfaces) — running it from several components is harmless.
  */
 export function usePresetReconcile(buffer: number[] | null) {
   useEffect(() => {
-    if (!active || !buffer) return;
-    for (const [address, value] of active.expected) {
-      if (buffer[address - 1] !== value) {
-        active = null;
-        notify();
-        return;
-      }
+    if (!buffer) return;
+    const next = reconcile(active, buffer);
+    if (next !== active) {
+      active = next;
+      notify();
     }
   }, [buffer]);
 }

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -18,5 +18,5 @@
     "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src", "vite.config.ts"],
-  "exclude": ["node_modules", "src-tauri", "dist"]
+  "exclude": ["node_modules", "src-tauri", "dist", "src/**/*.test.ts"]
 }

--- a/justfile
+++ b/justfile
@@ -18,9 +18,9 @@ device := env_var_or_default("LUX_IOS_DEVICE", ```
 default:
     @just --list
 
-# Front-end gate: production build, typecheck, lint (matches the PR gate).
+# Front-end gate: production build, typecheck, lint, unit tests (matches the PR gate).
 check:
-    cd apps/desktop && bun run build && bun run typecheck && bun run lint
+    cd apps/desktop && bun run build && bun run typecheck && bun run lint && bun test
 
 # Run the desktop app in dev.
 dev:


### PR DESCRIPTION
Applying a preset to one fixture un-applied presets on the others. The preset engine held a single global active-preset slot, so engaging any preset first undid whatever was active and overwrote the one marker — the reported cross-fixture deactivation, and the reason only one fixture's "Reading light" could ever show pressed.

Splits the engine into a pure core (`preset-engine.ts`, no React/Tauri) plus a thin adapter, and re-keys the active state by **lane**: full-setup presets (Blackout, Full Bright) share one lane; each fixture is its own lane. Fixtures own disjoint address ranges, so fixture lanes never collide.

Behavior (per the two rules that were nailed down):
- **Per-fixture independence** — engaging a preset on fixture A never touches fixture B's channels or its marker.
- **Strict global toggle-off** — a preset's marker clears the moment any channel it wrote changes (a fader, a remote command, or another preset engaged on top); reconcile clears the marker only, it never restores, so the divergent state stands. Toggling a preset off from its own button — while it is still active — restores the frame it replaced.

The UI active-state indicators subscribe per preset, so a fixture's pressed state tracks that fixture.

Adds the repo's first front-end unit-test lane: `bun test` wired into the `frontend` CI job and `just check`, with `preset-engine.test.ts` covering the independence, layering, strict-reconcile, and restore semantics. Test files are excluded from the app `tsc` build (they use `bun:test`).