### PR TITLE
fix(apple-auth): install crypto provider before building test clients

### DIFF
--- a/services/apple-auth/src/apple.rs
+++ b/services/apple-auth/src/apple.rs
@@ -492,16 +492,25 @@ PaNjgYD9H87aiu72kVM4feGqzpehRANCAAQE52G8sprGOcAIUFXU8WtoNLLD3Q80
     const SERVICES_ID: &str = "com.johncarmack.lux.signin";
 
     async fn auth() -> AppleAuth {
+        install_ring();
         seeded(AppleAuth::new(AUDIENCE.into(), None)).await
     }
 
     async fn auth_web() -> AppleAuth {
+        install_ring();
         seeded(AppleAuth::new(AUDIENCE.into(), Some(SERVICES_ID.into()))).await
     }
 
-    async fn seeded(auth: AppleAuth) -> AppleAuth {
-        // Prod installs ring in main() before any client exists; tests mirror it.
+    /// Prod installs ring in `main()` before any client exists; tests mirror
+    /// it — and MUST call this *before* `AppleAuth::new`, which builds a reqwest
+    /// client that panics without a process crypto provider. (This is a global
+    /// one-shot; ordering across parallel tests is why it can't hide inside a
+    /// helper that runs after construction.)
+    fn install_ring() {
         let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    async fn seeded(auth: AppleAuth) -> AppleAuth {
         auth.seed_key(
             KID,
             DecodingKey::from_rsa_pem(PUBLIC_PEM).expect("test key parses"),
@@ -601,7 +610,7 @@ PaNjgYD9H87aiu72kVM4feGqzpehRANCAAQE52G8sprGOcAIUFXU8WtoNLLD3Q80
 
     #[test]
     fn client_secret_is_a_signed_es256_jwt() {
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        install_ring();
         let auth = AppleAuth::new(AUDIENCE.into(), None);
         let key = SiwaKey {
             key_id: "ABC123DEFG".into(),

--- a/services/apple-auth/src/web.rs
+++ b/services/apple-auth/src/web.rs
@@ -376,11 +376,15 @@ mod tests {
 
     #[test]
     fn authorize_url_has_form_post_and_encoded_params() {
+        // Use a real generated nonce, not a literal: the test only checks the
+        // URL's structure/encoding (never the nonce value), and a hard-coded
+        // crypto value trips CodeQL for no reason.
+        let nonce = rand_token().expect("randomness");
         let url = authorize_url(
             "com.johncarmack.lux.signin",
             "https://auth.lux.johncarmack.com/auth/apple/web/callback",
             "st ate",
-            "nonce1",
+            &nonce,
         );
         assert!(url.starts_with("https://appleid.apple.com/auth/authorize?"));
         assert!(url.contains("client_id=com.johncarmack.lux.signin"));


### PR DESCRIPTION
Fixes the `rust-test` failure on `main` (the push run for #248).

`apple.rs`'s test helpers constructed `AppleAuth` — which builds a reqwest client, so it needs a process-wide rustls crypto provider — *before* installing ring. The install had moved into `seeded()`, which runs after its `AppleAuth::new(...)` argument is evaluated. Since the provider is a global one-shot, whether a test panicked depended on parallel test ordering: it passed locally and on the #248 PR, then panicked (`No rustls crypto provider is configured`) on the push-to-main run.

Install ring before every `AppleAuth::new`. Verified deterministic: the previously-failing test passes in isolation, and the full suite passes both single-threaded and parallel. Production is unaffected — `main()` installs the provider at startup.

Also clears CodeQL alert #2 (`rust/hard-coded-cryptographic-value`): the authorize-URL test passed a literal `"nonce1"` to the nonce parameter even though it only asserts on URL structure — swapped for a generated value.