### PR TITLE
feat(desktop): web Sign in with Apple client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,6 +3616,7 @@ dependencies = [
 name = "lux-apple-id"
 version = "0.1.0"
 dependencies = [
+ "block2",
  "objc2",
  "objc2-app-kit",
  "objc2-authentication-services",

--- a/apps/desktop/src-tauri/endpoints.prod.json
+++ b/apps/desktop/src-tauri/endpoints.prod.json
@@ -1,5 +1,6 @@
 {
   "appleAuthUrl": "https://z3z752gt7cz6sd4a55xzu53bgi0cfsrm.lambda-url.us-west-1.on.aws/",
+  "appleWebEnabled": true,
   "cognitoAppClientId": "2t2l4fn537ttb3vul39olt3of3",
   "cognitoDeviceClientId": "l6ocppn3jr96bulq87mvg7qem",
   "cognitoRegion": "us-west-1",

--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -93,6 +93,11 @@ pub struct LuxAccount {
     /// Base URL of the lux-apple-auth Function URL; `None` keeps Sign in with
     /// Apple dark (endpoints field absent/empty).
     apple_auth_url: Option<String>,
+    /// Whether the backend advertises the web (browser) Sign in with Apple flow
+    /// — the `.dmg`/dev fallback where the native sheet is impossible. Set from
+    /// the `appleWebEnabled` endpoints field (true once the Services ID + its
+    /// domain are provisioned).
+    apple_web_enabled: bool,
     session: Arc<Mutex<Session>>,
 }
 
@@ -109,6 +114,10 @@ pub struct AuthStatus {
     /// Whether native Sign in with Apple is available in this build (platform
     /// carries the entitlement AND the backend URL is configured).
     pub apple: bool,
+    /// Whether the web (browser) Sign in with Apple fallback is available — the
+    /// Developer ID `.dmg` and dev, where the native sheet is impossible. The
+    /// UI shows one Apple button and dispatches on whichever is true.
+    pub apple_web: bool,
 }
 
 /// Tokens returned by a Cognito auth flow. `refresh` is `None` on a refresh
@@ -148,6 +157,7 @@ impl LuxAccount {
             config,
             sync_url: base_url(&endpoints.sync_url),
             apple_auth_url: base_url(&endpoints.apple_auth_url),
+            apple_web_enabled: endpoints.apple_web_enabled,
             session: Arc::new(Mutex::new(Session::default())),
         }
     }
@@ -196,18 +206,33 @@ impl LuxAccount {
             email: session.email.clone(),
             provider: session.signed_in().then_some(session.provider),
             apple: self.apple_sign_in_available(),
+            apple_web: self.apple_web_sign_in_available(),
         }
     }
 
     /// Native Sign in with Apple, on THIS build: the backend must be
     /// configured, accounts must be configured, and the binary must carry the
-    /// applesignin entitlement — iOS and the Mac App Store flavor today. The
-    /// Developer ID .dmg stays dark until it embeds a provisioning profile
-    /// with the entitlement.
+    /// applesignin entitlement — iOS and the Mac App Store flavor only. Native
+    /// is impossible off the App Store (Apple forbids the entitlement for
+    /// Developer ID), so the `.dmg`/dev use the web fallback below instead.
     fn apple_sign_in_available(&self) -> bool {
         let entitled =
             cfg!(target_os = "ios") || (cfg!(target_os = "macos") && cfg!(feature = "mas"));
         entitled && self.config.is_some() && self.apple_auth_url.is_some()
+    }
+
+    /// The web (browser) Sign in with Apple fallback: no entitlement needed, so
+    /// it's offered exactly where the native sheet can't run — macOS builds
+    /// without the entitlement (the Developer ID `.dmg`, and dev) — when the
+    /// backend advertises it. iOS/MAS always prefer the native sheet.
+    fn apple_web_sign_in_available(&self) -> bool {
+        let native_entitled =
+            cfg!(target_os = "ios") || (cfg!(target_os = "macos") && cfg!(feature = "mas"));
+        cfg!(target_os = "macos")
+            && !native_entitled
+            && self.apple_web_enabled
+            && self.config.is_some()
+            && self.apple_auth_url.is_some()
     }
 
     fn config(&self) -> Result<Config, String> {
@@ -310,6 +335,93 @@ impl LuxAccount {
 
         // The session's email (the local store's cloud-binding key) comes from
         // our own id token — the sheet only carries one on first authorization.
+        let email =
+            email_from_id_token(&tokens.id_token).ok_or("sign-in response carried no email")?;
+        save_session(&StoredSession {
+            refresh_token: tokens.refresh_token.clone(),
+            email: email.clone(),
+            provider: Provider::Apple,
+        });
+        self.apply(
+            Tokens {
+                id: tokens.id_token,
+                access: tokens.access_token,
+                refresh: Some(tokens.refresh_token),
+            },
+            Some(email),
+            Some(Provider::Apple),
+        );
+        Ok(self.status())
+    }
+
+    /// The web (browser) Sign in with Apple fallback, for builds where the
+    /// native sheet is impossible (the Developer ID `.dmg`, and dev). Runs the
+    /// OAuth flow through `ASWebAuthenticationSession` + the lux-apple-auth web
+    /// routes: `/start` mints the authorize URL, the sheet returns a one-time
+    /// code over the `lux://` redirect, `/exchange` trades it (with the PKCE
+    /// verifier) for the same session the native and SRP paths produce. Async
+    /// for the same reason as the native path — the sheet is user-paced and its
+    /// callback lands on the main thread, which must stay unblocked.
+    pub async fn sign_in_with_apple_web(&self, app: &AppHandle) -> Result<AuthStatus, String> {
+        use lux_wire::apple::{
+            APPLE_SEGMENT, AUTH_SEGMENT, EXCHANGE_SEGMENT, START_SEGMENT, WEB_SEGMENT,
+        };
+        if !self.apple_web_sign_in_available() {
+            return Err("web sign in with apple is not available in this build".into());
+        }
+        let base = self
+            .apple_auth_url
+            .clone()
+            .ok_or("sign in with apple is not configured")?;
+
+        // PKCE: keep the verifier; send only its challenge to `/start`. Only
+        // this app instance can then redeem the one-time code the redirect
+        // carries, even if another app grabbed the `lux://` URL.
+        let verifier = format!(
+            "{}{}",
+            uuid::Uuid::new_v4().simple(),
+            uuid::Uuid::new_v4().simple()
+        );
+        let http = reqwest::Client::new();
+        let start: lux_wire::apple::WebStartResponse = post_json(
+            &http,
+            &format!("{base}/{AUTH_SEGMENT}/{APPLE_SEGMENT}/{WEB_SEGMENT}/{START_SEGMENT}"),
+            &lux_wire::apple::WebStartRequest {
+                code_challenge: pkce_challenge(&verifier),
+            },
+        )
+        .await?;
+
+        // Open the browser sheet; it hands back the `lux://` callback URL.
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let authorize_url = start.authorize_url;
+        app.run_on_main_thread(move || {
+            lux_apple_id::authorize_web(
+                &authorize_url,
+                lux_wire::apple::WEB_REDIRECT_SCHEME,
+                Box::new(move |result| {
+                    let _ = tx.send(result);
+                }),
+            );
+        })
+        .map_err(|e| format!("could not present the sign-in sheet: {e}"))?;
+        let callback_url = rx
+            .await
+            .map_err(|_| "the sign-in sheet never completed".to_string())??;
+
+        // A one-time code (or a relayed error) rides on the redirect's query.
+        let code = callback_code(&callback_url)?;
+
+        let tokens: lux_wire::apple::SignInResponse = post_json(
+            &http,
+            &format!("{base}/{AUTH_SEGMENT}/{APPLE_SEGMENT}/{WEB_SEGMENT}/{EXCHANGE_SEGMENT}"),
+            &lux_wire::apple::WebExchangeRequest {
+                code,
+                code_verifier: verifier,
+            },
+        )
+        .await?;
+
         let email =
             email_from_id_token(&tokens.id_token).ok_or("sign-in response carried no email")?;
         save_session(&StoredSession {
@@ -750,6 +862,95 @@ async fn do_refresh(cfg: Config, refresh_token: String) -> Result<Tokens, String
         .await
         .map_err(sdk_err)?;
     tokens_from(out.authentication_result())
+}
+
+/// PKCE `S256` challenge: `base64url(SHA-256(verifier))`, no padding (RFC 7636).
+fn pkce_challenge(verifier: &str) -> String {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use sha2::{Digest, Sha256};
+    URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()))
+}
+
+/// POST `body` as JSON and decode the JSON reply, mapping a non-2xx into the
+/// service's error text (the shared shape for the two web-auth calls).
+async fn post_json<B: Serialize, R: serde::de::DeserializeOwned>(
+    http: &reqwest::Client,
+    url: &str,
+    body: &B,
+) -> Result<R, String> {
+    let response = http
+        .post(url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| format!("could not reach the sign-in service: {e}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let message = response
+            .json::<lux_wire::ErrorResponse>()
+            .await
+            .map(|body| body.error)
+            .unwrap_or_else(|_| format!("sign-in service answered {status}"));
+        return Err(message);
+    }
+    response
+        .json()
+        .await
+        .map_err(|e| format!("malformed sign-in response: {e}"))
+}
+
+/// Pull the one-time `code` out of the `lux://…?code=…&state=…` redirect, or
+/// surface a relayed `error=…`.
+fn callback_code(callback_url: &str) -> Result<String, String> {
+    let query = callback_url.split_once('?').map_or("", |(_, q)| q);
+    let mut code = None;
+    for pair in query.split('&').filter(|p| !p.is_empty()) {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        match key {
+            "code" => code = Some(percent_decode(value)),
+            "error" => return Err(percent_decode(value)),
+            _ => {}
+        }
+    }
+    code.filter(|c| !c.is_empty())
+        .ok_or_else(|| "sign-in redirect carried no code".to_string())
+}
+
+/// Minimal percent-decode for a redirect query value (`+`→space, `%XX`→byte);
+/// invalid escapes pass through literally.
+fn percent_decode(s: &str) -> String {
+    let hex = |b: u8| match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    };
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => match (hex(bytes[i + 1]), hex(bytes[i + 2])) {
+                (Some(h), Some(l)) => {
+                    out.push(h * 16 + l);
+                    i += 3;
+                }
+                _ => {
+                    out.push(b'%');
+                    i += 1;
+                }
+            },
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 fn tokens_from(

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -114,6 +114,11 @@ pub trait CmdMethods {
     /// run (and block) exactly there. Rejects with "canceled" (verbatim) when
     /// the user dismisses the sheet.
     async fn sign_in_with_apple(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
+    /// The web (browser) Sign in with Apple fallback, for builds where the
+    /// native sheet is impossible (the Developer ID `.dmg`, and dev). Async and
+    /// "canceled"-on-dismissal like the native path; the browser sheet is
+    /// `ASWebAuthenticationSession`.
+    async fn sign_in_with_apple_web(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
     fn sign_out(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
     fn delete_account(&self, app_handle: AppHandle) -> Result<AuthStatus, String>;
     // Cloud sync — current status for the indicator, and a manual pull (fired on
@@ -605,6 +610,17 @@ impl CmdMethods for CmdEndpoint {
         emit_auth_changed(&app_handle, status.clone())?;
         // Same post-sign-in tail as the SRP path: pull the account's setups,
         // then listen for change nudges from their other devices.
+        crate::cloud::schedule_sync(&app_handle);
+        crate::nudge::start(&app_handle);
+        Ok(status)
+    }
+
+    async fn sign_in_with_apple_web(&self, app_handle: AppHandle) -> Result<AuthStatus, String> {
+        let status = app_handle
+            .state::<LuxAccount>()
+            .sign_in_with_apple_web(&app_handle)
+            .await?;
+        emit_auth_changed(&app_handle, status.clone())?;
         crate::cloud::schedule_sync(&app_handle);
         crate::nudge::start(&app_handle);
         Ok(status)

--- a/apps/desktop/src-tauri/src/endpoints.rs
+++ b/apps/desktop/src-tauri/src/endpoints.rs
@@ -40,6 +40,11 @@ pub struct Endpoints {
     /// the endpoints file only carries outputs that exist in applied state —
     /// and empty means the feature stays dark.
     pub apple_auth_url: String,
+    /// Whether the web (browser) Sign in with Apple flow is provisioned — the
+    /// `.dmg`/dev fallback. True once the Services ID + its verified domain are
+    /// live; the desktop lights its web Apple button on it. Default-false so a
+    /// file that predates the field keeps the feature dark.
+    pub apple_web_enabled: bool,
     /// Dev-machine remote control (device identity + mTLS material); only ever
     /// present in `endpoints.local.json` — the generated prod file never
     /// carries it, so plain installs have no remote-control surface.

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -130,6 +130,11 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  sign_in_with_apple_web(): Promise<AuthStatus> {
+    return invoke("cmd.sign_in_with_apple_web");
+  },
+
+  /** @throws {string} */
   sign_out(): Promise<AuthStatus> {
     return invoke("cmd.sign_out");
   },
@@ -322,6 +327,12 @@ export type AuthStatus = {
 	 *  carries the entitlement AND the backend URL is configured).
 	 */
 	apple: boolean,
+	/**
+	 *  Whether the web (browser) Sign in with Apple fallback is available — the
+	 *  Developer ID `.dmg` and dev, where the native sheet is impossible. The
+	 *  UI shows one Apple button and dispatches on whichever is true.
+	 */
+	appleWeb: boolean,
 };
 
 export type Channel = {

--- a/apps/desktop/src/components/account-menu.tsx
+++ b/apps/desktop/src/components/account-menu.tsx
@@ -214,7 +214,11 @@ export default function AccountMenu() {
   const signInWithApple = async () => {
     setPending(true);
     try {
-      await cmd().sign_in_with_apple();
+      // Native sheet where entitled (iOS/MAS); the browser fallback on the
+      // Developer ID .dmg and dev, where the native sheet is impossible.
+      await (status.apple
+        ? cmd().sign_in_with_apple()
+        : cmd().sign_in_with_apple_web());
       await refreshAuth();
       setOpen(false);
     } catch (err) {
@@ -325,7 +329,7 @@ export default function AccountMenu() {
           </Button>
         </form>
 
-        {status.apple && mode !== "confirm" ? (
+        {(status.apple || status.appleWeb) && mode !== "confirm" ? (
           <>
             <div className="flex items-center gap-3 text-xs text-muted-foreground">
               <div className="h-px flex-1 bg-border" />

--- a/crates/lux-apple-id/Cargo.toml
+++ b/crates/lux-apple-id/Cargo.toml
@@ -28,6 +28,7 @@ objc2-foundation = { version = "0.3", features = [
     "NSError",
     "NSPersonNameComponents",
     "NSString",
+    "NSURL",
 ] }
 objc2-authentication-services = { version = "0.3", features = [
     "ASAuthorization",
@@ -39,7 +40,15 @@ objc2-authentication-services = { version = "0.3", features = [
     "ASAuthorizationOpenIDRequest",
     "ASAuthorizationRequest",
     "ASFoundation",
+    # The web (browser) fallback used off the App Store — block-based session.
+    "ASWebAuthenticationSession",
+    "block2",
 ] }
+
+# The web session's completion handler is a block; the native sheet is
+# delegate-based and needs none, so this is web-only.
+[target.'cfg(target_os = "macos")'.dependencies.block2]
+version = "0.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { version = "0.3", features = [

--- a/crates/lux-apple-id/src/lib.rs
+++ b/crates/lux-apple-id/src/lib.rs
@@ -38,6 +38,26 @@ pub fn authorize(_hashed_nonce: &str, on_done: OnDone) {
     ));
 }
 
+/// A completed web-auth session's outcome: the `lux://` callback URL the session
+/// captured, or an error (`CANCELED` on user dismissal).
+pub type OnDoneUrl = Box<dyn FnOnce(Result<String, String>) + Send>;
+
+/// The web (browser) Sign in with Apple fallback, for builds where the native
+/// sheet is impossible — the Developer ID `.dmg` and dev (Apple forbids the
+/// entitlement off the Mac App Store). Opens `url` in an
+/// `ASWebAuthenticationSession` and hands back the `callback_scheme://` URL it
+/// captured — whose query carries a one-time code + state, never a token. macOS
+/// only; iOS/MAS use the native sheet. Main-thread only, like [`authorize`].
+#[cfg(target_os = "macos")]
+pub use platform_web::authorize_web;
+
+#[cfg(not(target_os = "macos"))]
+pub fn authorize_web(_url: &str, _callback_scheme: &str, on_done: OnDoneUrl) {
+    on_done(Err(
+        "web sign in with apple is only available on macOS".into()
+    ));
+}
+
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod platform {
     use std::cell::RefCell;
@@ -234,6 +254,141 @@ mod platform {
                 let responder = Retained::into_super(window);
                 Retained::into_super(responder)
             }
+            None => NSObject::new(),
+        }
+    }
+}
+
+/// The web (browser) Sign in with Apple fallback (`ASWebAuthenticationSession`),
+/// macOS only — see [`crate::authorize_web`].
+#[cfg(target_os = "macos")]
+mod platform_web {
+    use std::cell::RefCell;
+
+    use block2::RcBlock;
+    use objc2::rc::Retained;
+    use objc2::runtime::ProtocolObject;
+    use objc2::{define_class, msg_send, AnyThread, MainThreadMarker, MainThreadOnly};
+    use objc2_authentication_services::{
+        ASPresentationAnchor, ASWebAuthenticationPresentationContextProviding,
+        ASWebAuthenticationSession, ASWebAuthenticationSessionErrorCode,
+    };
+    use objc2_foundation::{NSError, NSObject, NSObjectProtocol, NSString, NSURL};
+
+    use super::{OnDoneUrl, CANCELED};
+
+    // Keeps the in-flight (provider, session) pair alive until the completion
+    // handler fires: a session with no strong reference is deallocated (which
+    // cancels the flow), and its presentationContextProvider property is WEAK.
+    // Replaced (and released) on the next call; main thread only.
+    thread_local! {
+        static IN_FLIGHT: RefCell<
+            Option<(Retained<AnchorProvider>, Retained<ASWebAuthenticationSession>)>,
+        > = const { RefCell::new(None) };
+    }
+
+    define_class!(
+        #[unsafe(super(NSObject))]
+        #[thread_kind = MainThreadOnly]
+        #[name = "LuxWebAuthAnchorProvider"]
+        #[ivars = ()]
+        struct AnchorProvider;
+
+        unsafe impl NSObjectProtocol for AnchorProvider {}
+
+        unsafe impl ASWebAuthenticationPresentationContextProviding for AnchorProvider {
+            #[unsafe(method_id(presentationAnchorForWebAuthenticationSession:))]
+            fn presentation_anchor(
+                &self,
+                _session: &ASWebAuthenticationSession,
+            ) -> Retained<ASPresentationAnchor> {
+                anchor_window()
+            }
+        }
+    );
+
+    impl AnchorProvider {
+        fn new(mtm: MainThreadMarker) -> Retained<Self> {
+            let this = Self::alloc(mtm).set_ivars(());
+            // SAFETY: plain NSObject init on a freshly allocated instance.
+            unsafe { msg_send![super(this), init] }
+        }
+    }
+
+    pub fn authorize_web(url: &str, callback_scheme: &str, on_done: OnDoneUrl) {
+        let Some(mtm) = MainThreadMarker::new() else {
+            on_done(Err("authorize_web must be called on the main thread".into()));
+            return;
+        };
+        // URLWithString returns null for a malformed URL.
+        let Some(nsurl) = NSURL::URLWithString(&NSString::from_str(url)) else {
+            on_done(Err("invalid authorize url".into()));
+            return;
+        };
+
+        // The session's completion handler is a `Fn` block, but our callback is
+        // a `FnOnce` — fire it at most once through this slot.
+        let slot: RefCell<Option<OnDoneUrl>> = RefCell::new(Some(on_done));
+        let handler = RcBlock::new(move |callback_url: *mut NSURL, error: *mut NSError| {
+            let Some(on_done) = slot.borrow_mut().take() else {
+                return;
+            };
+            // SAFETY: the session passes borrowed, possibly-null pointers.
+            let result = unsafe {
+                if let Some(url) = callback_url.as_ref() {
+                    url.absoluteString()
+                        .map(|s| s.to_string())
+                        .ok_or_else(|| "callback url had no string form".to_owned())
+                } else if let Some(error) = error.as_ref() {
+                    if error.code() == ASWebAuthenticationSessionErrorCode::CanceledLogin.0 {
+                        Err(CANCELED.to_owned())
+                    } else {
+                        Err(format!(
+                            "web sign-in failed ({}): {}",
+                            error.code(),
+                            error.localizedDescription()
+                        ))
+                    }
+                } else {
+                    Err("web sign-in completed with neither url nor error".to_owned())
+                }
+            };
+            on_done(result);
+        });
+
+        let provider = AnchorProvider::new(mtm);
+        // SAFETY: all main-thread; the session copies the completion block, and
+        // both provider and session live in IN_FLIGHT until the callback fires.
+        unsafe {
+            // The scheme-based init is deprecated for `initWithURL:callback:…`,
+            // but that replacement needs macOS 14.4; this one works back to the
+            // 10.15 where ASWebAuthenticationSession first shipped.
+            #[allow(deprecated)]
+            let session =
+                ASWebAuthenticationSession::initWithURL_callbackURLScheme_completionHandler(
+                    ASWebAuthenticationSession::alloc(),
+                    &nsurl,
+                    Some(&NSString::from_str(callback_scheme)),
+                    RcBlock::as_ptr(&handler),
+                );
+            session.setPresentationContextProvider(Some(ProtocolObject::from_ref(&*provider)));
+            // Reuse an existing Apple web session where one exists (smoother UX).
+            session.setPrefersEphemeralWebBrowserSession(false);
+            session.start();
+            IN_FLIGHT.with(|slot| *slot.borrow_mut() = Some((provider, session)));
+        }
+    }
+
+    /// The window the sheet attaches to (`ASPresentationAnchor` is `NSObject`):
+    /// the key window, else the main window, else a bare object (the sheet then
+    /// fails visibly rather than never calling back).
+    fn anchor_window() -> Retained<NSObject> {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return NSObject::new();
+        };
+        let app = objc2_app_kit::NSApplication::sharedApplication(mtm);
+        match app.keyWindow().or_else(|| app.mainWindow()) {
+            Some(window) => Retained::into_super(Retained::into_super(window)),
             None => NSObject::new(),
         }
     }

--- a/scripts/gen-endpoints
+++ b/scripts/gen-endpoints
@@ -22,6 +22,7 @@ jq -Sn \
   --arg syncUrl               "$(out lux_sync_url)" \
   --arg nudgeEndpoint         "$(out iot_endpoint)" \
   --arg appleAuthUrl          "$(out apple_auth_url)" \
+  --argjson appleWebEnabled   "$(out apple_web_enabled)" \
   '{
     cognitoRegion:         $cognitoRegion,
     cognitoUserPoolId:     $cognitoUserPoolId,
@@ -29,7 +30,8 @@ jq -Sn \
     cognitoDeviceClientId: $cognitoDeviceClientId,
     syncUrl:               $syncUrl,
     nudgeEndpoint:         $nudgeEndpoint,
-    appleAuthUrl:          $appleAuthUrl
+    appleAuthUrl:          $appleAuthUrl,
+    appleWebEnabled:       $appleWebEnabled
   }' > apps/desktop/src-tauri/endpoints.prod.json
 
 echo "wrote apps/desktop/src-tauri/endpoints.prod.json:"


### PR DESCRIPTION
Adds the browser-OAuth Sign in with Apple flow to the desktop app — the fallback for surfaces where the native sheet is impossible (the Developer ID `.dmg` and dev builds, which can't carry the `applesignin` entitlement). iOS and the Mac App Store keep the native sheet; the UI shows one "Sign in with Apple" button and dispatches on whichever is available.

- **`lux-apple-id`**: `authorize_web` opens the authorize URL in an `ASWebAuthenticationSession` (macOS; block-based completion, key-window presentation anchor, the session retained until its callback fires — mirroring the native sheet's retention) and hands back the `lux://` callback URL. A compile-clean error stub elsewhere.
- **`account.rs`**: `sign_in_with_apple_web` runs PKCE + the web routes (`/start` → sheet → `/exchange`) and lands the same session the native and SRP paths produce. `apple_web_sign_in_available` gates it to entitlement-less macOS builds when the backend advertises it.
- **endpoints**: `appleWebEnabled` (from the `apple_web_enabled` Terraform output) is the availability signal; `gen-endpoints` + the committed prod file updated.
- **cmd + regenerated bindings**: the `sign_in_with_apple_web` command and the `appleWeb` `AuthStatus` field.

The native path is untouched. Gate is green (fmt, clippy `-D warnings`, workspace tests, bindings drift, front-end build/typecheck/lint/test).

**Needs a real-macOS pass before merge.** The `ASWebAuthenticationSession` path compiles and passes the lint gate but can only be exercised on a signed run. It's testable via `just dev` on this branch (a dev build is entitlement-less macOS, so it shows the web button and hits the live backend) — once the Services ID config is saved in the Apple portal.

Follow-ups (separate, not blocking): the web flow currently signs client secrets with `lux/siwa-key`; switch to the backed-up `lux/siwa-key-web` only if a live exchange returns `invalid_client`. And the now-unused `.well-known` domain-association route can be removed (Apple dropped that requirement for web auth).