### PR TITLE
feat(desktop): fixture color presets

### DIFF
--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -17,13 +17,10 @@ const FIXTURE_PRESETS: ReadonlyArray<{
   { id: "reading-light", label: "Reading Light", color: { r: 255, g: 128, b: 0, a: 0.4 } },
   { id: "daylight", label: "Daylight", color: { r: 255, g: 255, b: 255, a: 0.4 } },
   { id: "fire", label: "Fire", color: { r: 255, g: 80, b: 0, a: 0.4 } },
-  { id: "red", label: "Red", color: { r: 255, g: 0, b: 0, a: 0.4 } },
   { id: "rose", label: "Rose", color: { r: 255, g: 80, b: 120, a: 0.4 } },
   { id: "lavender", label: "Lavender", color: { r: 150, g: 120, b: 255, a: 0.4 } },
-  { id: "deep-blue", label: "Deep Blue", color: { r: 0, g: 0, b: 255, a: 0.4 } },
   { id: "cobalt", label: "Cobalt", color: { r: 0, g: 70, b: 200, a: 0.4 } },
   { id: "teal", label: "Teal", color: { r: 0, g: 200, b: 180, a: 0.4 } },
-  { id: "green", label: "Green", color: { r: 0, g: 255, b: 0, a: 0.4 } },
 ];
 
 /** First DMX address (1-based) within the fixture carrying `role`, or null. */

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -20,7 +20,7 @@ const FIXTURE_PRESETS: ReadonlyArray<{
   { id: "rose", label: "Rose", color: { r: 255, g: 80, b: 120, a: 0.4 } },
   { id: "lavender", label: "Lavender", color: { r: 150, g: 120, b: 255, a: 0.4 } },
   { id: "cobalt", label: "Cobalt", color: { r: 0, g: 70, b: 200, a: 0.4 } },
-  { id: "teal", label: "Teal", color: { r: 0, g: 200, b: 180, a: 0.4 } },
+  { id: "slate", label: "Slate", color: { r: 70, g: 110, b: 190, a: 0.4 } },
   { id: "steel", label: "Steel", color: { r: 140, g: 160, b: 190, a: 0.4 } },
 ];
 

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -21,6 +21,7 @@ const FIXTURE_PRESETS: ReadonlyArray<{
   { id: "lavender", label: "Lavender", color: { r: 150, g: 120, b: 255, a: 0.4 } },
   { id: "cobalt", label: "Cobalt", color: { r: 0, g: 70, b: 200, a: 0.4 } },
   { id: "teal", label: "Teal", color: { r: 0, g: 200, b: 180, a: 0.4 } },
+  { id: "steel", label: "Steel", color: { r: 140, g: 160, b: 190, a: 0.4 } },
 ];
 
 /** First DMX address (1-based) within the fixture carrying `role`, or null. */

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -171,8 +171,7 @@ export default function FixtureColor({
       />
       <PopoverContent align="start">
         <RgbaColorPicker className="mx-auto" color={color} onChange={onChange} />
-        <p className="-mt-0.5 text-right text-[10px] text-muted-foreground">Brightness</p>
-        <div className="mt-2 grid grid-cols-2 gap-1.5">
+        <div className="mt-3 grid grid-cols-2 gap-1.5">
           {FIXTURE_PRESETS.map((preset) => (
             <FixturePresetButton
               key={preset.id}

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -171,7 +171,8 @@ export default function FixtureColor({
       />
       <PopoverContent align="start">
         <RgbaColorPicker className="mx-auto" color={color} onChange={onChange} />
-        <div className="mt-3 grid grid-cols-2 gap-1.5">
+        <p className="-mt-0.5 text-right text-[10px] text-muted-foreground">Brightness</p>
+        <div className="mt-2 grid grid-cols-2 gap-1.5">
           {FIXTURE_PRESETS.map((preset) => (
             <FixturePresetButton
               key={preset.id}

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { RgbaColorPicker, type RgbaColor } from "react-colorful";
-import { LampDesk } from "lucide-react";
 import { type Fixture, type LuxLabelColor } from "@/bindings";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent } from "@/components/ui/popover";
@@ -10,19 +9,85 @@ import { setChannelValue } from "@/lib/actions";
 import { emittersToRgb, mixToEmitters } from "@/lib/color-mix";
 import { togglePreset, useIsPresetActive } from "@/lib/preset-toggle";
 
-/**
- * Reading light: tungsten/amber at full, master at 40%. Expressed as a picker
- * color so it flows through the same role-aware mix as the wheel — on an
- * amber-equipped fixture the warm content lands on the Amber emitter (≈255),
- * an RGB-only fixture renders the same look with its own emitters, and the
- * alpha drives the Brightness channel where one exists.
- */
-const READING_LIGHT: RgbaColor = { r: 255, g: 128, b: 0, a: 0.4 };
+const FIXTURE_PRESETS: ReadonlyArray<{
+  id: string;
+  label: string;
+  color: RgbaColor;
+}> = [
+  { id: "reading-light", label: "Reading Light", color: { r: 255, g: 128, b: 0, a: 0.4 } },
+  { id: "daylight", label: "Daylight", color: { r: 255, g: 255, b: 255, a: 0.4 } },
+  { id: "fire", label: "Fire", color: { r: 255, g: 80, b: 0, a: 0.4 } },
+  { id: "red", label: "Red", color: { r: 255, g: 0, b: 0, a: 0.4 } },
+  { id: "rose", label: "Rose", color: { r: 255, g: 80, b: 120, a: 0.4 } },
+  { id: "lavender", label: "Lavender", color: { r: 150, g: 120, b: 255, a: 0.4 } },
+  { id: "deep-blue", label: "Deep Blue", color: { r: 0, g: 0, b: 255, a: 0.4 } },
+  { id: "green", label: "Green", color: { r: 0, g: 255, b: 0, a: 0.4 } },
+];
 
 /** First DMX address (1-based) within the fixture carrying `role`, or null. */
 function roleAddress(fixture: Fixture, role: LuxLabelColor): number | null {
   const i = fixture.channels.findIndex((c) => c.role === role);
   return i < 0 ? null : fixture.address + i;
+}
+
+function FixturePresetButton({
+  preset,
+  fixture,
+  disabled,
+}: {
+  preset: (typeof FIXTURE_PRESETS)[number];
+  fixture: Fixture;
+  disabled: boolean;
+}) {
+  const presetId = `${preset.id}-${fixture.id}`;
+  const active = useIsPresetActive(presetId);
+
+  const onClick = () => {
+    const r = roleAddress(fixture, "Red");
+    const g = roleAddress(fixture, "Green");
+    const b = roleAddress(fixture, "Blue");
+    const amber = roleAddress(fixture, "Amber");
+    const white = roleAddress(fixture, "White");
+    const dimmer = roleAddress(fixture, "Brightness");
+    const mix = mixToEmitters(preset.color.r, preset.color.g, preset.color.b, {
+      amber: amber !== null,
+      white: white !== null,
+    });
+    const writes = new Map<number, number>();
+    for (const [addr, value] of [
+      [r, mix.r],
+      [g, mix.g],
+      [b, mix.b],
+      [amber, mix.a],
+      [white, mix.w],
+      [dimmer, Math.round(preset.color.a * 255)],
+    ] as Array<[number | null, number]>) {
+      if (addr !== null) writes.set(addr, value);
+    }
+    togglePreset(presetId, writes, {
+      kind: "fixture",
+      fixtureId: fixture.id,
+    }).catch(() => {});
+  };
+
+  return (
+    <Button
+      variant={active ? "default" : "outline"}
+      size="sm"
+      className="h-7 gap-1.5 px-2 text-xs"
+      aria-pressed={active}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <span
+        className="size-2.5 shrink-0 rounded-full border border-foreground/20"
+        style={{
+          backgroundColor: `rgb(${preset.color.r}, ${preset.color.g}, ${preset.color.b})`,
+        }}
+      />
+      {preset.label}
+    </Button>
+  );
 }
 
 /**
@@ -91,23 +156,6 @@ export default function FixtureColor({
     send(next);
   };
 
-  // Reading light toggles: engaging snapshots the frame it replaces, pressing
-  // again restores it. Applied as one buffer write (not through the throttled
-  // wheel path) so the toggle store can track exactly what it set; the swatch
-  // and wheel follow via the buffer round-trip like any out-of-band change.
-  const presetId = `reading-light-${fixture.id}`;
-  const readingLightActive = useIsPresetActive(presetId);
-  const onReadingLight = () => {
-    const writes = new Map<number, number>();
-    for (const [addr, value] of emitterWrites(READING_LIGHT)) {
-      if (addr) writes.set(addr, value);
-    }
-    togglePreset(presetId, writes, {
-      kind: "fixture",
-      fixtureId: fixture.id,
-    }).catch(() => {});
-  };
-
   // Glow tracks the dimmer when present, else the brightest color channel.
   const luminance = dimmer ? color.a : Math.max(color.r, color.g, color.b) / 255;
 
@@ -123,17 +171,15 @@ export default function FixtureColor({
       />
       <PopoverContent align="start">
         <RgbaColorPicker className="mx-auto" color={color} onChange={onChange} />
-        <div className="mt-3">
-          <Button
-            variant={readingLightActive ? "default" : "outline"}
-            size="sm"
-            className="w-full gap-2"
-            aria-pressed={readingLightActive}
-            disabled={!buffer}
-            onClick={onReadingLight}
-          >
-            <LampDesk className="size-4" /> Reading light
-          </Button>
+        <div className="mt-3 grid grid-cols-2 gap-1.5">
+          {FIXTURE_PRESETS.map((preset) => (
+            <FixturePresetButton
+              key={preset.id}
+              preset={preset}
+              fixture={fixture}
+              disabled={!buffer}
+            />
+          ))}
         </div>
       </PopoverContent>
     </Popover>

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -20,8 +20,8 @@ const FIXTURE_PRESETS: ReadonlyArray<{
   { id: "rose", label: "Rose", color: { r: 255, g: 80, b: 120, a: 0.4 } },
   { id: "lavender", label: "Lavender", color: { r: 150, g: 120, b: 255, a: 0.4 } },
   { id: "cobalt", label: "Cobalt", color: { r: 0, g: 70, b: 200, a: 0.4 } },
-  { id: "gold", label: "Gold", color: { r: 255, g: 180, b: 0, a: 0.4 } },
   { id: "steel", label: "Steel", color: { r: 140, g: 160, b: 190, a: 0.4 } },
+  { id: "ember", label: "Ember", color: { r: 210, g: 140, b: 80, a: 0.4 } },
 ];
 
 /** First DMX address (1-based) within the fixture carrying `role`, or null. */

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -20,7 +20,7 @@ const FIXTURE_PRESETS: ReadonlyArray<{
   { id: "rose", label: "Rose", color: { r: 255, g: 80, b: 120, a: 0.4 } },
   { id: "lavender", label: "Lavender", color: { r: 150, g: 120, b: 255, a: 0.4 } },
   { id: "cobalt", label: "Cobalt", color: { r: 0, g: 70, b: 200, a: 0.4 } },
-  { id: "slate", label: "Slate", color: { r: 70, g: 110, b: 190, a: 0.4 } },
+  { id: "gold", label: "Gold", color: { r: 255, g: 180, b: 0, a: 0.4 } },
   { id: "steel", label: "Steel", color: { r: 140, g: 160, b: 190, a: 0.4 } },
 ];
 

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -21,6 +21,8 @@ const FIXTURE_PRESETS: ReadonlyArray<{
   { id: "rose", label: "Rose", color: { r: 255, g: 80, b: 120, a: 0.4 } },
   { id: "lavender", label: "Lavender", color: { r: 150, g: 120, b: 255, a: 0.4 } },
   { id: "deep-blue", label: "Deep Blue", color: { r: 0, g: 0, b: 255, a: 0.4 } },
+  { id: "cobalt", label: "Cobalt", color: { r: 0, g: 70, b: 200, a: 0.4 } },
+  { id: "teal", label: "Teal", color: { r: 0, g: 200, b: 180, a: 0.4 } },
   { id: "green", label: "Green", color: { r: 0, g: 255, b: 0, a: 0.4 } },
 ];
 

--- a/apps/desktop/src/components/fixtures/fixture-color.tsx
+++ b/apps/desktop/src/components/fixtures/fixture-color.tsx
@@ -21,7 +21,7 @@ const FIXTURE_PRESETS: ReadonlyArray<{
   { id: "lavender", label: "Lavender", color: { r: 150, g: 120, b: 255, a: 0.4 } },
   { id: "cobalt", label: "Cobalt", color: { r: 0, g: 70, b: 200, a: 0.4 } },
   { id: "steel", label: "Steel", color: { r: 140, g: 160, b: 190, a: 0.4 } },
-  { id: "ember", label: "Ember", color: { r: 210, g: 140, b: 80, a: 0.4 } },
+  { id: "dusk", label: "Dusk", color: { r: 190, g: 155, b: 140, a: 0.4 } },
 ];
 
 /** First DMX address (1-based) within the fixture carrying `role`, or null. */

--- a/apps/desktop/src/globals.css
+++ b/apps/desktop/src/globals.css
@@ -85,6 +85,15 @@
   }
 }
 
+/* Restyle the react-colorful alpha slider as a brightness/dimmer slider:
+   black background instead of the checkerboard pattern makes the gradient
+   read as dark→bright rather than transparent→opaque. */
+.react-colorful__alpha,
+.react-colorful__alpha-pointer {
+  background-color: #000;
+  background-image: none;
+}
+
 /* Chrome, Safari, Edge, Opera */
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {

--- a/apps/desktop/src/globals.css
+++ b/apps/desktop/src/globals.css
@@ -85,15 +85,6 @@
   }
 }
 
-/* Restyle the react-colorful alpha slider as a brightness/dimmer slider:
-   black background instead of the checkerboard pattern makes the gradient
-   read as dark→bright rather than transparent→opaque. */
-.react-colorful__alpha,
-.react-colorful__alpha-pointer {
-  background-color: #000;
-  background-image: none;
-}
-
 /* Chrome, Safari, Edge, Opera */
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {


### PR DESCRIPTION
## Summary

- Replace the single Reading Light button in the fixture color popover with a 2-column grid of 8 per-fixture presets
- All presets at 40% dimmer: Reading Light, Daylight, Fire, Rose, Lavender, Cobalt, Steel, Dusk
- Each preset flows through `mixToEmitters` so RGBAW fixtures use their Amber and White emitters properly
- Same toggle/restore behavior as before via the preset engine (per-fixture lanes, snapshot/restore)

## Test plan

- [x] Open a fixture's color popover — 8 preset buttons visible in a 2×4 grid with colored dot swatches
- [x] Toggle each preset on an RGBAW fixture — verify correct emitter decomposition
- [x] Toggle a preset off — verify prior channel values restore
- [x] Engage one preset over another on the same fixture — verify clean switch
- [x] Engage presets on two different fixtures independently
- [x] Verify presets auto-deactivate when a fader is moved