### PR TITLE
feat(scenes): save a look and recall it with a fade

### DIFF
--- a/apps/desktop/src-tauri/src/buffer.rs
+++ b/apps/desktop/src-tauri/src/buffer.rs
@@ -89,6 +89,33 @@ impl LuxBuffer {
         self.commit(snapshot, app)
     }
 
+    /// Overlay a sparse set of 1-based slot levels in one write, then emit +
+    /// render once. This is the crossfade ticker's path (`scene::recall`): a
+    /// fade touches a handful of scattered slots forty times a second, and
+    /// looping `set_channel` would emit, persist and render once per *slot*
+    /// instead of once per frame.
+    ///
+    /// Out-of-range slots are skipped rather than rejected, matching
+    /// [`lux_engine::fade::Crossfade`]: a scene saved against a wider patch
+    /// must still recall the slots that are real.
+    pub fn apply_levels<R: Runtime>(
+        &mut self,
+        levels: &[(u16, u8)],
+        app: tauri::AppHandle<R>,
+    ) -> Result<LuxBuffer, String> {
+        let snapshot = {
+            let mut guard = self.buffer.lock_or_recover();
+            for &(channel_number, value) in levels {
+                let index = usize::from(channel_number);
+                if (1..=UNIVERSE_SIZE).contains(&index) {
+                    guard[index - 1] = value;
+                }
+            }
+            guard.clone()
+        };
+        self.commit(snapshot, app)
+    }
+
     /// Shared tail of `set`/`set_channel`: reflect the new buffer in the UI
     /// optimistically — *before* the render, which may hit the network (sACN) or
     /// have no device attached — then push it to the active DMX output. Leading

--- a/apps/desktop/src-tauri/src/cloud.rs
+++ b/apps/desktop/src-tauri/src/cloud.rs
@@ -116,6 +116,11 @@ fn cloud_to_setup(c: &SetupRecord) -> Option<Setup> {
         name: c.name.clone(),
         universe: c.universe,
         fixtures: serde_json::from_value(c.fixtures.clone()).ok()?,
+        // A setup written before scenes existed (or by a server that predates
+        // them) carries `null` here. That is "no scenes", not a broken record:
+        // unlike `fixtures`, an unreadable list must not cost us the whole
+        // setup — losing a patch to a bad scene blob would be the worse bug.
+        scenes: serde_json::from_value(c.scenes.clone()).unwrap_or_default(),
         updated_at: Some(c.updated_at),
         dirty: false,
     })
@@ -197,6 +202,7 @@ async fn upsert(
         universe: setup.universe,
         fixtures: serde_json::to_value(&setup.fixtures)
             .map_err(|e| SyncError::Other(e.to_string()))?,
+        scenes: serde_json::to_value(&setup.scenes).map_err(|e| SyncError::Other(e.to_string()))?,
         base_updated_at: setup.updated_at,
     };
     let resp = client
@@ -810,6 +816,7 @@ mod tests {
             name: name.into(),
             universe: 1,
             fixtures: vec![],
+            scenes: vec![],
             updated_at,
             dirty,
         }
@@ -821,6 +828,7 @@ mod tests {
             name: name.into(),
             universe: 1,
             fixtures: serde_json::json!([]),
+            scenes: serde_json::json!([]),
             rev: 1,
             updated_at,
             deleted,
@@ -834,6 +842,31 @@ mod tests {
         assert_eq!(merged[0].name, "Home");
         assert_eq!(merged[0].updated_at, Some(100));
         assert!(!merged[0].dirty);
+    }
+
+    #[test]
+    fn scenes_cross_the_wire_with_their_setup() {
+        // The reason scenes ride `SetupRecord` at all: adopting a remote-newer
+        // setup must bring its saved looks, not silently drop them.
+        let mut remote = cloud_setup(1, "Home", 200, false);
+        remote.scenes = serde_json::json!([{
+            "id": "00000000-0000-0000-0000-000000000009",
+            "name": "Worship",
+            "levels": [{ "ch": 1, "val": 200 }],
+            "fadeMs": 3000
+        }]);
+        let merged = reconcile(vec![local_setup(1, "Home", Some(100), false)], &[remote]);
+        assert_eq!(merged[0].scenes.len(), 1);
+        assert_eq!(merged[0].scenes[0].name, "Worship");
+        assert_eq!(merged[0].scenes[0].fade_ms, 3000);
+
+        // A record from a server that predates scenes reads as "none" and still
+        // yields a usable setup — the patch is never lost to a missing blob.
+        let mut old = cloud_setup(2, "Church", 200, false);
+        old.scenes = serde_json::Value::Null;
+        let merged = reconcile(vec![], &[old]);
+        assert_eq!(merged[0].name, "Church");
+        assert!(merged[0].scenes.is_empty());
     }
 
     #[test]
@@ -918,6 +951,7 @@ mod tests {
                 name: "Sync Round-Trip".into(),
                 universe: 7,
                 fixtures: vec![],
+                scenes: vec![],
                 updated_at: None,
                 dirty: true,
             };

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -8,6 +8,7 @@ use crate::{
     devices::{self, DmxDeviceInfo, DmxOutput},
     fixture::{self, ChannelDef, Fixture, FixturePreset},
     nudge::RemotePeer,
+    scene::{self, Scene},
     settings::{SliderOrientation, UserSettings},
     setup::{self, LuxSetups, SetupSummary},
     sync::*,
@@ -54,6 +55,38 @@ pub trait CmdMethods {
         channels: Vec<ChannelDef>,
     ) -> Result<Vec<Fixture>, String>;
     fn remove_fixture(&self, app_handle: AppHandle, id: String) -> Result<Vec<Fixture>, String>;
+    // Scenes — the active setup's saved looks. Every mutator returns the whole
+    // list, the repo's cache-through pattern: the `scenesSet` event is a
+    // desktop fast path, and iOS never receives events.
+    fn list_scenes(&self, app_handle: AppHandle) -> Result<Vec<Scene>, String>;
+    /// Save the live buffer as a new scene, over whatever the patch covers.
+    fn capture_scene(&self, app_handle: AppHandle, name: String) -> Result<Vec<Scene>, String>;
+    /// Re-capture an existing scene's levels from the live buffer.
+    fn update_scene(&self, app_handle: AppHandle, id: String) -> Result<Vec<Scene>, String>;
+    /// Start the crossfade toward a scene. Returns as soon as the fade is
+    /// running — the buffer it could return would be stale by the next tick,
+    /// and the UI already watches the buffer.
+    fn recall_scene(&self, app_handle: AppHandle, id: String) -> Result<(), String>;
+    fn rename_scene(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        name: String,
+    ) -> Result<Vec<Scene>, String>;
+    fn set_scene_fade(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        fade_ms: u32,
+    ) -> Result<Vec<Scene>, String>;
+    /// Move a scene `delta` places in the list, saturating at either end.
+    fn move_scene(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        delta: i32,
+    ) -> Result<Vec<Scene>, String>;
+    fn delete_scene(&self, app_handle: AppHandle, id: String) -> Result<Vec<Scene>, String>;
     // Setups — a user's named (fixtures + universe) configurations.
     fn list_setups(&self, app_handle: AppHandle) -> Result<Vec<SetupSummary>, String>;
     fn create_setup(
@@ -338,6 +371,10 @@ pub enum CmdEvent {
         setup_id: String,
         fixtures: Vec<Fixture>,
     },
+    ScenesSet {
+        setup_id: String,
+        scenes: Vec<Scene>,
+    },
     SetupsChanged {
         setups: Vec<SetupSummary>,
         active_setup_id: String,
@@ -452,6 +489,75 @@ impl CmdMethods for CmdEndpoint {
         let setups = app_handle.state::<LuxSetups>();
         setups.remove_fixture(id)?;
         commit_patch(&app_handle, setups.inner())
+    }
+
+    fn list_scenes(&self, app_handle: AppHandle) -> Result<Vec<Scene>, String> {
+        Ok(app_handle.state::<LuxSetups>().active_scenes())
+    }
+
+    fn capture_scene(&self, app_handle: AppHandle, name: String) -> Result<Vec<Scene>, String> {
+        let setups = app_handle.state::<LuxSetups>();
+        setups.add_scene(name, capture_live_levels(&app_handle, setups.inner()))?;
+        commit_scenes(&app_handle, setups.inner())
+    }
+
+    fn update_scene(&self, app_handle: AppHandle, id: String) -> Result<Vec<Scene>, String> {
+        let id = parse_scene_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        setups.set_scene_levels(id, capture_live_levels(&app_handle, setups.inner()))?;
+        commit_scenes(&app_handle, setups.inner())
+    }
+
+    fn recall_scene(&self, app_handle: AppHandle, id: String) -> Result<(), String> {
+        let id = parse_scene_id(&id)?;
+        let scene = app_handle
+            .state::<LuxSetups>()
+            .active_scene(id)
+            .ok_or_else(|| format!("scene {id} not found"))?;
+        scene::recall(&app_handle, &scene)
+    }
+
+    fn rename_scene(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        name: String,
+    ) -> Result<Vec<Scene>, String> {
+        let id = parse_scene_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        setups.rename_scene(id, name)?;
+        commit_scenes(&app_handle, setups.inner())
+    }
+
+    fn set_scene_fade(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        fade_ms: u32,
+    ) -> Result<Vec<Scene>, String> {
+        let id = parse_scene_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        setups.set_scene_fade(id, fade_ms)?;
+        commit_scenes(&app_handle, setups.inner())
+    }
+
+    fn move_scene(
+        &self,
+        app_handle: AppHandle,
+        id: String,
+        delta: i32,
+    ) -> Result<Vec<Scene>, String> {
+        let id = parse_scene_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        setups.move_scene(id, delta)?;
+        commit_scenes(&app_handle, setups.inner())
+    }
+
+    fn delete_scene(&self, app_handle: AppHandle, id: String) -> Result<Vec<Scene>, String> {
+        let id = parse_scene_id(&id)?;
+        let setups = app_handle.state::<LuxSetups>();
+        setups.remove_scene(id)?;
+        commit_scenes(&app_handle, setups.inner())
     }
 
     fn list_setups(&self, app_handle: AppHandle) -> Result<Vec<SetupSummary>, String> {
@@ -946,6 +1052,34 @@ fn parse_setup_id(id: &str) -> Result<uuid::Uuid, String> {
     uuid::Uuid::parse_str(id).map_err(|e| format!("bad setup id: {e}"))
 }
 
+fn parse_scene_id(id: &str) -> Result<uuid::Uuid, String> {
+    uuid::Uuid::parse_str(id).map_err(|e| format!("bad scene id: {e}"))
+}
+
+/// Snapshot the live buffer over the active setup's patch — what "save this
+/// look" means. Reading the buffer (never `sync_buffer`, which is a command
+/// path) keeps capture a pure read with no render or echo side effects.
+fn capture_live_levels(app: &AppHandle, setups: &LuxSetups) -> Vec<crate::scene::SceneLevel> {
+    let buffer = app.state::<LuxBuffer>().buffer.lock_or_recover().clone();
+    scene::capture_levels(&buffer, &setups.active_fixtures())
+}
+
+/// Persist the store and broadcast the active setup's scenes to the UI. Like
+/// [`commit_patch`], the `setup_id` lets the UI ignore a list from a setup it
+/// has already switched away from.
+fn commit_scenes(app: &AppHandle, setups: &LuxSetups) -> Result<Vec<Scene>, String> {
+    setup::save(app, setups);
+    let scenes = setups.active_scenes();
+    CmdEvent::ScenesSet {
+        setup_id: setups.active_id().to_string(),
+        scenes: scenes.clone(),
+    }
+    .emit(app)
+    .map_err(|e| format!("Failed to emit scenes_set event: {e}"))?;
+    crate::cloud::schedule_push(app);
+    Ok(scenes)
+}
+
 /// Persist the store and broadcast the active setup's patch to the UI, returning
 /// the new fixture list. The `setup_id` lets the UI ignore a `PatchSet` from a
 /// setup it has already switched away from.
@@ -1011,8 +1145,13 @@ pub fn broadcast_synced_state(app: &AppHandle) {
     }
     .emit(app);
     let _ = CmdEvent::PatchSet {
-        setup_id: active_id,
+        setup_id: active_id.clone(),
         fixtures: setups.active_fixtures(),
+    }
+    .emit(app);
+    let _ = CmdEvent::ScenesSet {
+        setup_id: active_id,
+        scenes: setups.active_scenes(),
     }
     .emit(app);
     let _ = CmdEvent::SettingsChanged {
@@ -1052,6 +1191,13 @@ fn activate(app: &AppHandle, setups: &LuxSetups) -> Result<(), String> {
     }
     .emit(app)
     .map_err(|e| format!("Failed to emit patch_set event: {e}"))?;
+    // Scenes belong to the setup, so switching swaps the whole list.
+    CmdEvent::ScenesSet {
+        setup_id: setups.active_id().to_string(),
+        scenes: setups.active_scenes(),
+    }
+    .emit(app)
+    .map_err(|e| format!("Failed to emit scenes_set event: {e}"))?;
     // Remote surfaces learn the new binding through the presence card.
     crate::nudge::presence_changed(app);
     Ok(())

--- a/apps/desktop/src-tauri/src/fixture.rs
+++ b/apps/desktop/src-tauri/src/fixture.rs
@@ -40,7 +40,7 @@ pub struct Fixture {
 
 impl Fixture {
     /// Last DMX slot this fixture occupies (1-based, inclusive).
-    fn end(&self) -> u16 {
+    pub(crate) fn end(&self) -> u16 {
         // A validated fixture spans ≤512 consecutive slots, so its channel count
         // fits u16; saturate rather than wrap if that invariant is ever violated.
         let count = u16::try_from(self.channels.len()).unwrap_or(u16::MAX);

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod lock;
 mod logger;
 mod nudge;
 mod remote;
+mod scene;
 mod settings;
 mod setup;
 mod sync;
@@ -79,7 +80,8 @@ pub async fn run() {
         .manage(DmxOutput::default())
         .manage(cloud::LuxSync::default())
         .manage(nudge::LuxNudge::default())
-        .manage(guest::LuxGuest::default());
+        .manage(guest::LuxGuest::default())
+        .manage(scene::LuxFade::default());
     // Window positioning relative to monitors and the tray, backing the
     // frontend's @tauri-apps/plugin-positioner API. Desktop-only: mobile has
     // no movable windows and no tray.

--- a/apps/desktop/src-tauri/src/nudge.rs
+++ b/apps/desktop/src-tauri/src/nudge.rs
@@ -958,6 +958,7 @@ mod tests {
             name: name.to_owned(),
             universe: 1,
             fixtures: Vec::new(),
+            scenes: Vec::new(),
             updated_at: None,
             dirty: false,
         };

--- a/apps/desktop/src-tauri/src/scene.rs
+++ b/apps/desktop/src-tauri/src/scene.rs
@@ -1,0 +1,445 @@
+//! Scenes: named, savable snapshots of a setup's lighting, recalled with a fade.
+//!
+//! A [`Scene`] is the volunteer's noun — "pre-service", "worship", "sermon",
+//! "blackout". It holds the levels of every DMX slot the setup's patch covers,
+//! captured from the live buffer at the moment the user pressed *Save look*,
+//! plus how long a recall should take to get there.
+//!
+//! **Sparse on purpose.** A scene names only the slots its setup patches, so
+//! recalling one leaves every other slot exactly where it was — the same
+//! overlay discipline as [`crate::buffer::LuxBuffer::set`]. A setup with no
+//! fixtures captures the whole universe instead, because "no patch" means "the
+//! plain universe" everywhere else in this app too (see [`crate::setup::Setup::compile`]).
+//!
+//! **Scenes are destinations; presets are momentary.** The preset engine in the
+//! front end (`lib/preset-engine.ts`) exists to remember a frame and put it
+//! back; a scene has no undo lane, because the way back from a scene is another
+//! scene. Recall moves the buffer through the ordinary write path, so an engaged
+//! preset drops its own marker through the reconcile it already runs — nothing
+//! here duplicates or reaches into that machinery.
+//!
+//! This module owns the scene *domain* (types, capture, the operations over a
+//! `Vec<Scene>`) and the recall driver. Persistence is the setup store's job,
+//! exactly as it is for fixtures.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use tauri::{AppHandle, Manager, Runtime};
+
+use lux_engine::fade::Crossfade;
+
+use crate::buffer::{Buffer, LuxBuffer, UNIVERSE_SIZE};
+use crate::fixture::Fixture;
+use crate::lock::LockPolicy;
+
+/// How many scenes one setup may hold. A volunteer's Sunday needs five, not a
+/// show file; the cap keeps a synced setup item small and bounds the UI.
+pub const MAX_SCENES_PER_SETUP: usize = 64;
+
+/// Longest recall a scene may ask for (one minute). Anything above is a typo.
+pub const MAX_FADE_MS: u32 = 60_000;
+
+/// Default crossfade for a freshly captured scene — slow enough to read as a
+/// transition in a room, fast enough not to feel broken.
+pub const DEFAULT_FADE_MS: u32 = 2_000;
+
+/// One slot's level inside a scene. `ch` is the 1-based DMX slot, matching
+/// `lux_wire::ctl::Frame::Channel` — the same names the wire already uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SceneLevel {
+    pub ch: u16,
+    pub val: u8,
+}
+
+/// A saved look: sparse levels plus the time a recall takes to reach them.
+///
+/// Order is the scene's position — scenes live in a `Vec` on the setup, so the
+/// vector index *is* the position. There is deliberately no `position` field to
+/// keep in step with it.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Scene {
+    #[specta(type = String)]
+    pub id: uuid::Uuid,
+    pub name: String,
+    /// Sparse levels, sorted by slot.
+    pub levels: Vec<SceneLevel>,
+    /// Crossfade duration on recall, in milliseconds. `0` snaps.
+    pub fade_ms: u32,
+}
+
+// --- capture ----------------------------------------------------------------
+
+/// Snapshot the slots `fixtures` covers, read from `buffer`.
+///
+/// An unpatched setup captures the whole universe: with no patch there is no
+/// smaller honest answer, and the Universe view is a legitimate place to build
+/// a look from.
+pub fn capture_levels(buffer: &[u8], fixtures: &[Fixture]) -> Vec<SceneLevel> {
+    let level = |ch: u16| -> Option<SceneLevel> {
+        let index = usize::from(ch).checked_sub(1)?;
+        buffer.get(index).map(|&val| SceneLevel { ch, val })
+    };
+
+    if fixtures.is_empty() {
+        let last = u16::try_from(UNIVERSE_SIZE).unwrap_or(u16::MAX);
+        return (1..=last).filter_map(level).collect();
+    }
+
+    let mut slots: Vec<u16> = fixtures.iter().flat_map(|f| f.address..=f.end()).collect();
+    slots.sort_unstable();
+    slots.dedup();
+    slots.into_iter().filter_map(level).collect()
+}
+
+// --- operations (over a plain `Vec<Scene>`) ---------------------------------
+//
+// Storage-agnostic like `crate::fixture`: the scenes live inside whichever
+// setup is active, and the caller persists the owning store.
+
+fn clean_name(name: String) -> Result<String, String> {
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return Err("scene name can't be empty".into());
+    }
+    Ok(name)
+}
+
+fn find(scenes: &mut [Scene], id: uuid::Uuid) -> Result<&mut Scene, String> {
+    scenes
+        .iter_mut()
+        .find(|s| s.id == id)
+        .ok_or_else(|| format!("scene {id} not found"))
+}
+
+/// Append a captured look. A scene with no levels is refused: it would recall
+/// nothing, which is indistinguishable from a broken button.
+pub fn add(
+    scenes: &mut Vec<Scene>,
+    name: String,
+    levels: Vec<SceneLevel>,
+) -> Result<Scene, String> {
+    if scenes.len() >= MAX_SCENES_PER_SETUP {
+        return Err(format!(
+            "this setup already holds {MAX_SCENES_PER_SETUP} scenes"
+        ));
+    }
+    if levels.is_empty() {
+        return Err("nothing to save — patch a fixture first".into());
+    }
+    let scene = Scene {
+        id: uuid::Uuid::new_v4(),
+        name: clean_name(name)?,
+        levels,
+        fade_ms: DEFAULT_FADE_MS,
+    };
+    scenes.push(scene.clone());
+    Ok(scene)
+}
+
+/// Re-capture an existing scene's levels — the "I moved a fader, keep it" edit.
+pub fn set_levels(
+    scenes: &mut [Scene],
+    id: uuid::Uuid,
+    levels: Vec<SceneLevel>,
+) -> Result<(), String> {
+    if levels.is_empty() {
+        return Err("nothing to save — patch a fixture first".into());
+    }
+    find(scenes, id)?.levels = levels;
+    Ok(())
+}
+
+pub fn rename(scenes: &mut [Scene], id: uuid::Uuid, name: String) -> Result<(), String> {
+    let name = clean_name(name)?;
+    find(scenes, id)?.name = name;
+    Ok(())
+}
+
+/// Set a scene's recall time, clamped to something a room can sit through.
+pub fn set_fade(scenes: &mut [Scene], id: uuid::Uuid, fade_ms: u32) -> Result<(), String> {
+    find(scenes, id)?.fade_ms = fade_ms.min(MAX_FADE_MS);
+    Ok(())
+}
+
+/// Move a scene `delta` places in the list, saturating at either end (moving
+/// the first scene left is a no-op, not an error — it is a button a user may
+/// press twice).
+pub fn move_by(scenes: &mut [Scene], id: uuid::Uuid, delta: i32) -> Result<(), String> {
+    let from = scenes
+        .iter()
+        .position(|s| s.id == id)
+        .ok_or_else(|| format!("scene {id} not found"))?;
+    let last = scenes.len().saturating_sub(1);
+    let step = usize::try_from(delta.unsigned_abs()).unwrap_or(usize::MAX);
+    let to = if delta < 0 {
+        from.saturating_sub(step)
+    } else {
+        from.saturating_add(step).min(last)
+    };
+    // Rotating the span between the two positions moves the scene and shuffles
+    // everything it passed by one place — no clone, no hole to fill.
+    if to > from {
+        scenes[from..=to].rotate_left(1);
+    } else if to < from {
+        scenes[to..=from].rotate_right(1);
+    }
+    Ok(())
+}
+
+pub fn remove(scenes: &mut Vec<Scene>, id: uuid::Uuid) -> Result<(), String> {
+    let before = scenes.len();
+    scenes.retain(|s| s.id != id);
+    if scenes.len() == before {
+        return Err(format!("scene {id} not found"));
+    }
+    Ok(())
+}
+
+// --- recall (the crossfade driver) ------------------------------------------
+
+/// How often the fade writes. 40 Hz sits under DMX512's ~44 Hz frame ceiling
+/// and matches what a fader drag already produces, so nothing downstream —
+/// render, debounced persist, coalesced state echo — sees a new load shape.
+const TICK: Duration = Duration::from_millis(25);
+
+/// Which recall owns the rig. Every [`recall`] bumps the generation; an
+/// in-flight ticker that no longer holds the current one stops at its next
+/// tick. That is the whole cancellation story: **the last recall wins**, with
+/// no channels, no join handles, and no torn frames from two fades writing the
+/// same slot.
+#[derive(Debug, Default)]
+pub struct LuxFade {
+    generation: AtomicU64,
+}
+
+/// Start recalling `scene`: crossfade every slot it owns from wherever the rig
+/// is *now* to the saved levels, over the scene's fade time.
+///
+/// Returns as soon as the fade is running (immediately, for a snap). The fade
+/// writes through [`LuxBuffer::apply_levels`], so persistence, the remote state
+/// echo, shared desks and DMX output all behave exactly as they do for a fader
+/// — there is no second output path to keep correct.
+pub fn recall<R: Runtime>(app: &AppHandle<R>, scene: &Scene) -> Result<(), String> {
+    let targets: Vec<(u16, u8)> = scene.levels.iter().map(|l| (l.ch, l.val)).collect();
+    let from: Buffer = app.state::<LuxBuffer>().buffer.lock_or_recover().clone();
+    let fade = Crossfade::new(&from, &targets, scene.fade_ms);
+    let generation = app
+        .state::<LuxFade>()
+        .generation
+        .fetch_add(1, Ordering::SeqCst)
+        .saturating_add(1);
+
+    // A snap has nothing to schedule: apply it on the calling thread so a
+    // zero-fade scene is as immediate as pressing Blackout.
+    if fade.is_done(0) {
+        let mut buffer = app.state::<LuxBuffer>().inner().clone();
+        buffer.apply_levels(&fade.at(0), app.clone())?;
+        return Ok(());
+    }
+
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let started = Instant::now();
+        loop {
+            tokio::time::sleep(TICK).await;
+            if app.state::<LuxFade>().generation.load(Ordering::SeqCst) != generation {
+                return; // a newer recall (or a blackout) owns the rig now
+            }
+            let elapsed = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+            let mut buffer = app.state::<LuxBuffer>().inner().clone();
+            if let Err(e) = buffer.apply_levels(&fade.at(elapsed), app.clone()) {
+                // A missing output is not a reason to abandon the fade: the
+                // buffer is still the truth, and the user may plug in mid-fade.
+                log::trace!("scene fade write failed: {e}");
+            }
+            if fade.is_done(elapsed) {
+                return;
+            }
+        }
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::colors::LuxLabelColor;
+    use crate::fixture::ChannelDef;
+
+    fn fixture(name: &str, address: u16, count: usize) -> Fixture {
+        Fixture {
+            id: uuid::Uuid::new_v4(),
+            name: name.to_owned(),
+            address,
+            channels: (0..count)
+                .map(|_| ChannelDef {
+                    role: LuxLabelColor::Generic,
+                    label: "ch".into(),
+                })
+                .collect(),
+        }
+    }
+
+    fn buffer() -> Vec<u8> {
+        (0..UNIVERSE_SIZE)
+            .map(|i| u8::try_from(i % 256).unwrap_or(0))
+            .collect()
+    }
+
+    fn levels(pairs: &[(u16, u8)]) -> Vec<SceneLevel> {
+        pairs
+            .iter()
+            .map(|&(ch, val)| SceneLevel { ch, val })
+            .collect()
+    }
+
+    #[test]
+    fn capture_covers_the_patch_in_slot_order() {
+        // Patched out of order, and overlapping nothing: capture is a universe
+        // read, so it comes back sorted regardless of patch order.
+        let fixtures = vec![fixture("Back", 10, 3), fixture("Front", 1, 2)];
+        let captured = capture_levels(&buffer(), &fixtures);
+        assert_eq!(
+            captured.iter().map(|l| l.ch).collect::<Vec<_>>(),
+            vec![1, 2, 10, 11, 12]
+        );
+        assert_eq!(captured[0].val, 0); // slot 1 → buffer[0]
+        assert_eq!(captured[2].val, 9); // slot 10 → buffer[9]
+    }
+
+    #[test]
+    fn capture_on_an_unpatched_setup_takes_the_whole_universe() {
+        let captured = capture_levels(&buffer(), &[]);
+        assert_eq!(captured.len(), UNIVERSE_SIZE);
+        assert_eq!(captured[0].ch, 1);
+        assert_eq!(captured[UNIVERSE_SIZE - 1].ch, 512);
+    }
+
+    #[test]
+    fn capture_ignores_slots_past_the_universe() {
+        // A fixture at the very top of the universe: nothing beyond 512 appears.
+        let captured = capture_levels(&buffer(), &[fixture("Edge", 511, 2)]);
+        assert_eq!(
+            captured.iter().map(|l| l.ch).collect::<Vec<_>>(),
+            vec![511, 512]
+        );
+    }
+
+    #[test]
+    fn add_names_validates_and_caps() {
+        let mut scenes = Vec::new();
+        assert!(add(&mut scenes, "  ".into(), levels(&[(1, 5)])).is_err());
+        assert!(add(&mut scenes, "Empty".into(), vec![]).is_err());
+
+        let scene = add(&mut scenes, "  Worship  ".into(), levels(&[(1, 5)])).unwrap();
+        assert_eq!(scene.name, "Worship"); // trimmed
+        assert_eq!(scene.fade_ms, DEFAULT_FADE_MS);
+        assert_eq!(scenes.len(), 1);
+
+        while scenes.len() < MAX_SCENES_PER_SETUP {
+            add(&mut scenes, "filler".into(), levels(&[(1, 5)])).unwrap();
+        }
+        assert!(add(&mut scenes, "one too many".into(), levels(&[(1, 5)])).is_err());
+    }
+
+    #[test]
+    fn rename_set_levels_and_fade() {
+        let mut scenes = Vec::new();
+        let id = add(&mut scenes, "Worship".into(), levels(&[(1, 5)]))
+            .unwrap()
+            .id;
+
+        rename(&mut scenes, id, " Sermon ".into()).unwrap();
+        assert_eq!(scenes[0].name, "Sermon");
+        assert!(rename(&mut scenes, id, "".into()).is_err());
+        assert!(rename(&mut scenes, uuid::Uuid::new_v4(), "ghost".into()).is_err());
+
+        set_levels(&mut scenes, id, levels(&[(1, 200), (2, 10)])).unwrap();
+        assert_eq!(scenes[0].levels.len(), 2);
+        assert!(set_levels(&mut scenes, id, vec![]).is_err());
+
+        set_fade(&mut scenes, id, 500).unwrap();
+        assert_eq!(scenes[0].fade_ms, 500);
+        // An absurd fade clamps rather than erroring — it came from a picker.
+        set_fade(&mut scenes, id, u32::MAX).unwrap();
+        assert_eq!(scenes[0].fade_ms, MAX_FADE_MS);
+    }
+
+    #[test]
+    fn move_by_reorders_and_saturates() {
+        let mut scenes = Vec::new();
+        for name in ["a", "b", "c"] {
+            add(&mut scenes, name.into(), levels(&[(1, 5)])).unwrap();
+        }
+        let names = |s: &[Scene]| s.iter().map(|s| s.name.clone()).collect::<Vec<_>>();
+        let a = scenes[0].id;
+        let c = scenes[2].id;
+
+        move_by(&mut scenes, a, 1).unwrap();
+        assert_eq!(names(&scenes), vec!["b", "a", "c"]);
+        move_by(&mut scenes, c, -2).unwrap();
+        assert_eq!(names(&scenes), vec!["c", "b", "a"]);
+
+        // Pressing "move left" on the first scene is a no-op, not an error.
+        move_by(&mut scenes, c, -1).unwrap();
+        assert_eq!(names(&scenes), vec!["c", "b", "a"]);
+        move_by(&mut scenes, a, 9).unwrap();
+        assert_eq!(names(&scenes), vec!["c", "b", "a"]);
+        assert!(move_by(&mut scenes, uuid::Uuid::new_v4(), 1).is_err());
+    }
+
+    #[test]
+    fn remove_deletes_and_reports_missing() {
+        let mut scenes = Vec::new();
+        let id = add(&mut scenes, "Worship".into(), levels(&[(1, 5)]))
+            .unwrap()
+            .id;
+        remove(&mut scenes, id).unwrap();
+        assert!(scenes.is_empty());
+        assert!(remove(&mut scenes, id).is_err());
+    }
+
+    /// Capture → crossfade → apply, the seam the two halves of this brick meet
+    /// at, exercised without Tauri: the sparse levels a capture produces must
+    /// be exactly what a recall lands on, and nothing else may move.
+    #[test]
+    fn a_captured_look_recalls_to_itself_and_leaves_the_rest_alone() {
+        let fixtures = vec![fixture("Front", 1, 3)];
+        let mut saved = vec![0u8; UNIVERSE_SIZE];
+        saved[0] = 255;
+        saved[1] = 128;
+        saved[2] = 10;
+        saved[400] = 77; // an unpatched slot a raw fader owns
+        let captured = capture_levels(&saved, &fixtures);
+
+        // Someone has since moved everything, including the raw fader.
+        let mut live = vec![9u8; UNIVERSE_SIZE];
+        let targets: Vec<(u16, u8)> = captured.iter().map(|l| (l.ch, l.val)).collect();
+        let fade = Crossfade::new(&live, &targets, 1000);
+
+        // Mid-fade nothing has arrived yet, and the fade owns three slots only.
+        assert_eq!(fade.at(500).len(), 3);
+
+        for (ch, val) in fade.at(1000) {
+            live[usize::from(ch) - 1] = val;
+        }
+        assert_eq!(&live[..3], &saved[..3]); // the look is back, exactly
+        assert_eq!(live[400], 9); // the raw fader was never in the scene
+    }
+
+    #[test]
+    fn scenes_round_trip_through_json() {
+        let mut scenes = Vec::new();
+        add(&mut scenes, "Worship".into(), levels(&[(1, 5), (2, 255)])).unwrap();
+        let json = serde_json::to_string(&scenes).unwrap();
+        assert!(json.contains(r#""levels":[{"ch":1,"val":5},{"ch":2,"val":255}]"#));
+        let back: Vec<Scene> = serde_json::from_str(&json).unwrap();
+        assert_eq!(back[0].levels, scenes[0].levels);
+        assert_eq!(back[0].fade_ms, DEFAULT_FADE_MS);
+    }
+}

--- a/apps/desktop/src-tauri/src/setup.rs
+++ b/apps/desktop/src-tauri/src/setup.rs
@@ -21,6 +21,7 @@ use specta::Type;
 use tauri::{Manager, Runtime};
 
 use crate::fixture::{self, ChannelDef, Fixture};
+use crate::scene::{self, Scene, SceneLevel};
 use crate::settings::{self, SliderOrientation, UserSettings};
 use lux_wire::SettingsRecord;
 
@@ -41,6 +42,11 @@ pub struct Setup {
     /// sACN/E1.31 universe this setup transmits on (1..=63999).
     pub universe: u16,
     pub fixtures: Vec<Fixture>,
+    /// Saved looks for this patch, in display order (the vector index *is* the
+    /// scene's position — see [`crate::scene`]). Defaults keep every
+    /// `setups.json` written before scenes existed readable.
+    #[serde(default)]
+    pub scenes: Vec<Scene>,
     /// Server timestamp (epoch millis) from the last successful push or pull —
     /// the optimistic-concurrency base for the next push. `None` until first
     /// synced (so the cloud layer treats it as a create). Cloud-sync metadata;
@@ -179,6 +185,7 @@ fn new_setup(name: impl Into<String>, universe: u16, fixtures: Vec<Fixture>) -> 
         name: name.into(),
         universe: normalize_universe(universe),
         fixtures,
+        scenes: Vec::new(),
         updated_at: None,
         dirty: false,
     }
@@ -332,6 +339,76 @@ impl LuxSetups {
         let mut store = self.store.lock_or_recover();
         let active = store.active_mut();
         fixture::remove(&mut active.fixtures, id)?;
+        active.dirty = true;
+        Ok(())
+    }
+
+    // -- scene ops on the active setup --
+    //
+    // Each one mutates the active setup's `scenes` and marks it dirty, exactly
+    // like the fixture ops above; the caller persists and pushes. Capture reads
+    // the live buffer, so the caller passes the levels in rather than this
+    // module reaching for app state.
+
+    pub fn active_scenes(&self) -> Vec<Scene> {
+        self.store.lock_or_recover().active().scenes.clone()
+    }
+
+    /// One scene from the active setup, by id — what `recall` fades toward.
+    pub fn active_scene(&self, id: uuid::Uuid) -> Option<Scene> {
+        self.store
+            .lock_or_recover()
+            .active()
+            .scenes
+            .iter()
+            .find(|s| s.id == id)
+            .cloned()
+    }
+
+    pub fn add_scene(&self, name: String, levels: Vec<SceneLevel>) -> Result<(), String> {
+        let mut store = self.store.lock_or_recover();
+        let active = store.active_mut();
+        scene::add(&mut active.scenes, name, levels)?;
+        active.dirty = true;
+        Ok(())
+    }
+
+    pub fn set_scene_levels(&self, id: uuid::Uuid, levels: Vec<SceneLevel>) -> Result<(), String> {
+        let mut store = self.store.lock_or_recover();
+        let active = store.active_mut();
+        scene::set_levels(&mut active.scenes, id, levels)?;
+        active.dirty = true;
+        Ok(())
+    }
+
+    pub fn rename_scene(&self, id: uuid::Uuid, name: String) -> Result<(), String> {
+        let mut store = self.store.lock_or_recover();
+        let active = store.active_mut();
+        scene::rename(&mut active.scenes, id, name)?;
+        active.dirty = true;
+        Ok(())
+    }
+
+    pub fn set_scene_fade(&self, id: uuid::Uuid, fade_ms: u32) -> Result<(), String> {
+        let mut store = self.store.lock_or_recover();
+        let active = store.active_mut();
+        scene::set_fade(&mut active.scenes, id, fade_ms)?;
+        active.dirty = true;
+        Ok(())
+    }
+
+    pub fn move_scene(&self, id: uuid::Uuid, delta: i32) -> Result<(), String> {
+        let mut store = self.store.lock_or_recover();
+        let active = store.active_mut();
+        scene::move_by(&mut active.scenes, id, delta)?;
+        active.dirty = true;
+        Ok(())
+    }
+
+    pub fn remove_scene(&self, id: uuid::Uuid) -> Result<(), String> {
+        let mut store = self.store.lock_or_recover();
+        let active = store.active_mut();
+        scene::remove(&mut active.scenes, id)?;
         active.dirty = true;
         Ok(())
     }
@@ -944,6 +1021,59 @@ mod tests {
         let json = serde_json::to_string(&setups.snapshot()).unwrap();
         let back = parse_store(&json).unwrap();
         assert_eq!(back.collapsed_fixture_ids, vec![fixture_id]);
+    }
+
+    // -- scenes --
+
+    #[test]
+    fn scene_ops_target_the_active_setup_and_mark_it_dirty() {
+        let setups: LuxSetups = SetupStore::default().into();
+        let levels = vec![SceneLevel { ch: 1, val: 200 }];
+
+        setups.add_scene("Worship".into(), levels.clone()).unwrap();
+        setups.add_scene("Sermon".into(), levels.clone()).unwrap();
+        assert_eq!(setups.active_scenes().len(), 2);
+        assert!(setups.dirty_for_push().iter().any(|s| s.dirty));
+
+        let worship = setups.active_scenes()[0].id;
+        setups.rename_scene(worship, "Pre-service".into()).unwrap();
+        setups.set_scene_fade(worship, 500).unwrap();
+        setups.move_scene(worship, 1).unwrap();
+        let scenes = setups.active_scenes();
+        assert_eq!(scenes[1].name, "Pre-service");
+        assert_eq!(scenes[1].fade_ms, 500);
+        assert_eq!(setups.active_scene(worship).unwrap().name, "Pre-service");
+
+        // A freshly created setup starts with no scenes of its own.
+        let work = setups.create("Work".into(), 1).unwrap();
+        setups.set_active(work).unwrap();
+        assert!(setups.active_scenes().is_empty());
+        assert!(setups.remove_scene(worship).is_err()); // not this setup's scene
+    }
+
+    #[test]
+    fn scenes_survive_the_store_and_a_pre_scenes_store_still_parses() {
+        let setups: LuxSetups = SetupStore::default().into();
+        setups
+            .add_scene("Worship".into(), vec![SceneLevel { ch: 3, val: 42 }])
+            .unwrap();
+
+        let json = serde_json::to_string(&setups.snapshot()).unwrap();
+        let back = parse_store(&json).unwrap();
+        assert_eq!(back.setups[0].scenes.len(), 1);
+        assert_eq!(back.setups[0].scenes[0].levels[0].val, 42);
+
+        // A store written before scenes existed (no `scenes` key at all) is
+        // read as a setup with no scenes, not as a parse failure — the same
+        // shipped-stores guarantee `settings` carries.
+        let stripped = {
+            let mut v: serde_json::Value = serde_json::from_str(&json).unwrap();
+            for setup in v["setups"].as_array_mut().unwrap() {
+                setup.as_object_mut().unwrap().remove("scenes");
+            }
+            v.to_string()
+        };
+        assert!(parse_store(&stripped).unwrap().setups[0].scenes.is_empty());
     }
 
     // -- user settings --

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -55,6 +55,46 @@ export const cmd = {
   },
 
   /** @throws {string} */
+  list_scenes(): Promise<Scene[]> {
+    return invoke("cmd.list_scenes");
+  },
+
+  /** @throws {string} */
+  capture_scene(name: string): Promise<Scene[]> {
+    return invoke("cmd.capture_scene", { name });
+  },
+
+  /** @throws {string} */
+  update_scene(id: string): Promise<Scene[]> {
+    return invoke("cmd.update_scene", { id });
+  },
+
+  /** @throws {string} */
+  recall_scene(id: string): Promise<null> {
+    return invoke("cmd.recall_scene", { id });
+  },
+
+  /** @throws {string} */
+  rename_scene(id: string, name: string): Promise<Scene[]> {
+    return invoke("cmd.rename_scene", { id, name });
+  },
+
+  /** @throws {string} */
+  set_scene_fade(id: string, fadeMs: number): Promise<Scene[]> {
+    return invoke("cmd.set_scene_fade", { id, fade_ms: fadeMs });
+  },
+
+  /** @throws {string} */
+  move_scene(id: string, delta: number): Promise<Scene[]> {
+    return invoke("cmd.move_scene", { id, delta });
+  },
+
+  /** @throws {string} */
+  delete_scene(id: string): Promise<Scene[]> {
+    return invoke("cmd.delete_scene", { id });
+  },
+
+  /** @throws {string} */
   list_setups(): Promise<SetupSummary[]> {
     return invoke("cmd.list_setups");
   },
@@ -280,7 +320,7 @@ export const sync = {
   },
 };
 
-export type CmdEvent = { type: "channelDataSet"; channels: LuxChannel[] } | { type: "patchSet"; setup_id: string; fixtures: Fixture[] } | { type: "setupsChanged"; setups: SetupSummary[]; active_setup_id: string } | { type: "settingsChanged"; settings: UserSettings } | { type: "authChanged"; status: AuthStatus } | { type: "syncStatusChanged"; state: SyncState } | { type: "dmxDevicesChanged"; devices: DmxDeviceInfo[] };
+export type CmdEvent = { type: "channelDataSet"; channels: LuxChannel[] } | { type: "patchSet"; setup_id: string; fixtures: Fixture[] } | { type: "scenesSet"; setup_id: string; scenes: Scene[] } | { type: "setupsChanged"; setups: SetupSummary[]; active_setup_id: string } | { type: "settingsChanged"; settings: UserSettings } | { type: "authChanged"; status: AuthStatus } | { type: "syncStatusChanged"; state: SyncState } | { type: "dmxDevicesChanged"; devices: DmxDeviceInfo[] };
 
 export type SyncEvent = { type: "bufferSet"; buffer: number[] };
 
@@ -290,6 +330,7 @@ export const events = {
       const unlisten = await Promise.all([
         listen<{ channels: LuxChannel[] }>("cmd:channelDataSet", (event) => callback({ type: "channelDataSet", ...event.payload })),
         listen<{ setup_id: string; fixtures: Fixture[] }>("cmd:patchSet", (event) => callback({ type: "patchSet", ...event.payload })),
+        listen<{ setup_id: string; scenes: Scene[] }>("cmd:scenesSet", (event) => callback({ type: "scenesSet", ...event.payload })),
         listen<{ setups: SetupSummary[]; active_setup_id: string }>("cmd:setupsChanged", (event) => callback({ type: "setupsChanged", ...event.payload })),
         listen<{ settings: UserSettings }>("cmd:settingsChanged", (event) => callback({ type: "settingsChanged", ...event.payload })),
         listen<{ status: AuthStatus }>("cmd:authChanged", (event) => callback({ type: "authChanged", ...event.payload })),
@@ -480,6 +521,31 @@ export type RemotePeer = {
 	session: string,
 	setupId: string,
 	name: string,
+};
+
+/**
+ *  A saved look: sparse levels plus the time a recall takes to reach them.
+ * 
+ *  Order is the scene's position — scenes live in a `Vec` on the setup, so the
+ *  vector index *is* the position. There is deliberately no `position` field to
+ *  keep in step with it.
+ */
+export type Scene = {
+	id: string,
+	name: string,
+	/**  Sparse levels, sorted by slot. */
+	levels: SceneLevel[],
+	/**  Crossfade duration on recall, in milliseconds. `0` snaps. */
+	fadeMs: number,
+};
+
+/**
+ *  One slot's level inside a scene. `ch` is the 1-based DMX slot, matching
+ *  `lux_wire::ctl::Frame::Channel` — the same names the wire already uses.
+ */
+export type SceneLevel = {
+	ch: number,
+	val: number,
 };
 
 /**

--- a/apps/desktop/src/components/scenes/scenes-panel.tsx
+++ b/apps/desktop/src/components/scenes/scenes-panel.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Camera,
+  Pencil,
+  Trash2,
+} from "lucide-react";
+import { type Scene } from "@/bindings";
+import useBuffer from "@/hooks/useBuffer";
+import useScenes from "@/hooks/useScenes";
+import { activeSceneId } from "@/lib/scene-state";
+import {
+  captureScene,
+  deleteScene,
+  moveScene,
+  recallScene,
+  renameScene,
+  setSceneFade,
+  updateScene,
+} from "@/lib/scene-actions";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+/** The fade times a volunteer actually picks between, in milliseconds. */
+const FADES = [
+  { ms: 0, label: "Snap" },
+  { ms: 1000, label: "1s" },
+  { ms: 2000, label: "2s" },
+  { ms: 3000, label: "3s" },
+  { ms: 5000, label: "5s" },
+  { ms: 10000, label: "10s" },
+];
+
+/** "2s" for the badge under a scene's name. */
+function fadeLabel(fadeMs: number): string {
+  return FADES.find((f) => f.ms === fadeMs)?.label ?? `${fadeMs / 1000}s`;
+}
+
+/**
+ * One scene: a big tappable recall button with its editor tucked behind a
+ * pencil. Recall is one tap and nothing else on this card can be hit by
+ * accident — the editor is a separate, smaller target, and delete lives two
+ * taps deep inside it.
+ */
+function SceneButton({
+  scene,
+  showing,
+  disabled,
+}: {
+  scene: Scene;
+  showing: boolean;
+  disabled: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(scene.name);
+  // Seeded from the prop, never from a background refresh mid-edit — the same
+  // rule the setup switcher's draft follows.
+  useEffect(() => setDraft(scene.name), [scene.name]);
+
+  // Deleting a scene has no undo, so the trash arms on the first tap and only
+  // deletes on the second; it disarms on a timer or when the popover closes
+  // (the setup trash's behaviour, deliberately mirrored).
+  const [armed, setArmed] = useState(false);
+  const disarm = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (disarm.current) clearTimeout(disarm.current);
+    },
+    [],
+  );
+
+  const fail = (e: unknown) => toast.error(String(e));
+
+  const commitName = () => {
+    const next = draft.trim();
+    if (!next || next === scene.name) {
+      setDraft(scene.name);
+      return;
+    }
+    renameScene(scene.id, next).catch(fail);
+  };
+
+  const onTrash = () => {
+    if (armed) {
+      setArmed(false);
+      setOpen(false);
+      deleteScene(scene.id).catch(fail);
+      return;
+    }
+    setArmed(true);
+    if (disarm.current) clearTimeout(disarm.current);
+    disarm.current = setTimeout(() => setArmed(false), 3000);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        disabled={disabled}
+        aria-pressed={showing}
+        onClick={() => recallScene(scene.id).catch(fail)}
+        className={cn(
+          // Volunteer-grade target: comfortably past 44px on a phone, and the
+          // whole tile is the button.
+          "flex h-20 w-36 flex-col items-start justify-end gap-0.5 rounded-xl border p-3 text-left transition-colors",
+          "disabled:pointer-events-none disabled:opacity-50",
+          showing
+            ? "border-primary bg-primary/15 text-foreground"
+            : "border-input bg-background hover:bg-accent",
+        )}
+      >
+        <span className="line-clamp-2 w-full text-sm font-medium leading-tight">
+          {scene.name}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {fadeLabel(scene.fadeMs)}
+        </span>
+      </button>
+
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) setArmed(false);
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={`Edit ${scene.name}`}
+            className="absolute right-1 top-1 size-7 text-muted-foreground hover:text-foreground"
+          >
+            <Pencil className="size-3.5" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="flex w-64 flex-col gap-3 p-3">
+          <Input
+            autoFocus
+            value={draft}
+            aria-label="Scene name"
+            className="h-8"
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commitName}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitName();
+              if (e.key === "Escape") setDraft(scene.name);
+            }}
+          />
+
+          <div className="flex flex-col gap-1.5">
+            <p className="text-xs font-medium text-muted-foreground">
+              Fade time
+            </p>
+            <div className="flex flex-wrap gap-1">
+              {FADES.map((fade) => (
+                <Button
+                  key={fade.ms}
+                  variant={scene.fadeMs === fade.ms ? "secondary" : "outline"}
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => setSceneFade(scene.id, fade.ms).catch(fail)}
+                >
+                  {fade.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <Button
+            variant="outline"
+            size="sm"
+            className="justify-start gap-2"
+            onClick={() => updateScene(scene.id).catch(fail)}
+          >
+            <Camera className="size-3.5" />
+            Save current levels here
+          </Button>
+
+          <div className="flex items-center justify-between">
+            <div className="flex gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                aria-label={`Move ${scene.name} earlier`}
+                onClick={() => moveScene(scene.id, -1).catch(fail)}
+              >
+                <ChevronLeft className="size-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                aria-label={`Move ${scene.name} later`}
+                onClick={() => moveScene(scene.id, 1).catch(fail)}
+              >
+                <ChevronRight className="size-4" />
+              </Button>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className={cn(
+                "gap-1.5",
+                armed
+                  ? "bg-destructive/15 text-destructive hover:text-destructive"
+                  : "text-muted-foreground hover:text-destructive",
+              )}
+              onClick={onTrash}
+            >
+              <Trash2 className="size-3.5" />
+              {armed ? "Tap again" : "Delete"}
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+/**
+ * The scenes panel: the saved looks for the active setup, plus the one button
+ * that makes a new one.
+ *
+ * Recall is a single tap on a big target — the whole point of the brick. The
+ * pressed scene is derived from the live buffer (`lib/scene-state`), not
+ * remembered, so a scene shows as up whether it was recalled here, from another
+ * device, or reproduced by hand on the faders.
+ */
+export default function ScenesPanel() {
+  const scenes = useScenes();
+  const buffer = useBuffer();
+  const showing = activeSceneId(buffer, scenes);
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      // A default name the user can immediately edit beats a modal in the way
+      // of "save this, we're about to start".
+      await captureScene(`Scene ${(scenes?.length ?? 0) + 1}`);
+    } catch (e) {
+      toast.error(String(e));
+    }
+    setSaving(false);
+  };
+
+  return (
+    <div className="flex w-full max-w-2xl shrink-0 flex-col gap-2 px-4 pt-2">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">Scenes</p>
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          disabled={saving || buffer === null}
+          onClick={() => void save()}
+        >
+          <Camera className="size-3.5" />
+          Save look
+        </Button>
+      </div>
+
+      {scenes !== null &&
+        (scenes.length === 0 ? (
+          <div className="rounded-xl border border-dashed py-6 text-center text-sm text-muted-foreground">
+            No scenes yet. Set a look, then Save look.
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {scenes.map((scene) => (
+              <SceneButton
+                key={scene.id}
+                scene={scene}
+                showing={scene.id === showing}
+                disabled={buffer === null}
+              />
+            ))}
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/hooks/useLuxRefresh.ts
+++ b/apps/desktop/src/hooks/useLuxRefresh.ts
@@ -3,15 +3,16 @@ import { FIXTURES_QUERY_KEY } from "./useFixtures";
 import { SETUPS_QUERY_KEY } from "./useSetups";
 import { CHANNELS_QUERY_KEY } from "./useChannelsMetaData";
 import { BUFFER_QUERY_KEY } from "./useBuffer";
+import { SCENES_QUERY_KEY } from "./useScenes";
 
 /**
  * Refetch the reactive views a fixture/setup mutation can affect. The backend's
- * `patchSet` / `setupsChanged` / `channelDataSet` / `bufferSet` events aren't
- * reliably delivered to the webview on iOS, so a mutation refreshes
- * authoritatively instead of relying on them. All four keys refresh together
- * because they're coupled — switching a setup swaps the active patch, its
- * channel labels, and the live buffer; patching a fixture changes the fixture
- * count and the channel metadata.
+ * `patchSet` / `scenesSet` / `setupsChanged` / `channelDataSet` / `bufferSet`
+ * events aren't reliably delivered to the webview on iOS, so a mutation
+ * refreshes authoritatively instead of relying on them. All five keys refresh
+ * together because they're coupled — switching a setup swaps the active patch,
+ * its saved scenes, its channel labels, and the live buffer; patching a fixture
+ * changes the fixture count and the channel metadata.
  */
 export default function useLuxRefresh() {
   const queryClient = useQueryClient();
@@ -19,6 +20,7 @@ export default function useLuxRefresh() {
     Promise.all(
       [
         FIXTURES_QUERY_KEY,
+        SCENES_QUERY_KEY,
         SETUPS_QUERY_KEY,
         CHANNELS_QUERY_KEY,
         BUFFER_QUERY_KEY,

--- a/apps/desktop/src/hooks/useScenes.ts
+++ b/apps/desktop/src/hooks/useScenes.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createTauRPCProxy, type Scene } from "@/bindings";
+
+/** Query key for the active setup's saved looks. */
+export const SCENES_QUERY_KEY = ["scenes"] as const;
+
+/**
+ * The active setup's scenes, in display order. `null` while the first read is
+ * in flight.
+ *
+ * Same shape as `useFixtures`, for the same reason: the backend emits a
+ * `scenesSet` event on every capture/rename/reorder/delete and after a cloud
+ * pull, but that event never reaches the webview on iOS — so the mutators push
+ * the list they return straight into this cache (see `lib/scene-actions`), and
+ * the event is honoured only as a desktop fast path for out-of-band changes.
+ */
+export default function useScenes(): Scene[] | null {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    queryKey: SCENES_QUERY_KEY,
+    queryFn: () => createTauRPCProxy().cmd.list_scenes(),
+  });
+
+  useEffect(() => {
+    const unlisten = createTauRPCProxy().cmd.event.on((event) => {
+      if (event.type === "scenesSet") {
+        queryClient.setQueryData(SCENES_QUERY_KEY, event.scenes);
+      }
+    });
+    return () => {
+      // .catch: if registration itself rejected (webview teardown), cleanup
+      // must not surface an unhandled rejection.
+      unlisten.then((f) => f()).catch(() => {});
+    };
+  }, [queryClient]);
+
+  return data ?? null;
+}

--- a/apps/desktop/src/lib/scene-actions.ts
+++ b/apps/desktop/src/lib/scene-actions.ts
@@ -1,0 +1,57 @@
+import { createTauRPCProxy, type Scene } from "@/bindings";
+import { queryClient } from "@/lib/query-client";
+import { SCENES_QUERY_KEY } from "@/hooks/useScenes";
+
+/**
+ * The Tauri adapter for scenes: every mutator lands the list the backend
+ * returns straight in the query cache, the same cache-through pattern as
+ * `lib/actions` and for the same reason — the `scenesSet` event never reaches
+ * the webview on iOS, so the return value is the only reliable update.
+ *
+ * Recall is the odd one out and deliberately so: it returns nothing, because a
+ * crossfade's first frame is stale before it arrives. The rig's truth is the
+ * buffer, which `useBuffer` already watches.
+ */
+const cmd = () => createTauRPCProxy().cmd;
+
+/** Land a mutator's returned list in the cache, cancelling any stale refetch. */
+async function commit(scenes: Scene[]): Promise<Scene[]> {
+  await queryClient.cancelQueries({ queryKey: SCENES_QUERY_KEY });
+  queryClient.setQueryData(SCENES_QUERY_KEY, scenes);
+  return scenes;
+}
+
+/** Save the live look as a new scene. */
+export async function captureScene(name: string): Promise<Scene[]> {
+  return commit(await cmd().capture_scene(name));
+}
+
+/** Re-capture an existing scene's levels from the live rig. */
+export async function updateScene(id: string): Promise<Scene[]> {
+  return commit(await cmd().update_scene(id));
+}
+
+/** Start the crossfade toward a scene. Resolves once the fade is running. */
+export async function recallScene(id: string): Promise<void> {
+  await cmd().recall_scene(id);
+}
+
+export async function renameScene(id: string, name: string): Promise<Scene[]> {
+  return commit(await cmd().rename_scene(id, name));
+}
+
+export async function setSceneFade(
+  id: string,
+  fadeMs: number,
+): Promise<Scene[]> {
+  return commit(await cmd().set_scene_fade(id, fadeMs));
+}
+
+/** Move a scene one place in either direction; the ends saturate. */
+export async function moveScene(id: string, delta: number): Promise<Scene[]> {
+  return commit(await cmd().move_scene(id, delta));
+}
+
+export async function deleteScene(id: string): Promise<Scene[]> {
+  return commit(await cmd().delete_scene(id));
+}

--- a/apps/desktop/src/lib/scene-state.test.ts
+++ b/apps/desktop/src/lib/scene-state.test.ts
@@ -1,0 +1,73 @@
+import { test, expect, describe } from "bun:test";
+import type { Scene } from "@/bindings";
+import { activeSceneId, isSceneShowing } from "@/lib/scene-state";
+
+/** A scene over a small stand-in universe, addressed 1-based like DMX. */
+const scene = (id: string, levels: Record<number, number>): Scene => ({
+  id,
+  name: id,
+  levels: Object.entries(levels).map(([ch, val]) => ({
+    ch: Number(ch),
+    val,
+  })),
+  fadeMs: 2000,
+});
+
+// Fixture A owns slots 1..3, fixture B owns 4..6 — the patch validator
+// guarantees they are disjoint, exactly as the preset engine's tests assume.
+const WORSHIP = scene("worship", { 1: 255, 2: 128, 3: 0 });
+const SERMON = scene("sermon", { 1: 40, 2: 40, 3: 40 });
+
+describe("isSceneShowing", () => {
+  test("matches only the slots the scene named", () => {
+    // Slots 4..6 belong to another fixture and moved since capture; the scene
+    // is still showing, because a sparse scene never claimed them.
+    expect(isSceneShowing([255, 128, 0, 99, 99, 99], WORSHIP)).toBe(true);
+  });
+
+  test("one divergent slot is enough to drop it", () => {
+    expect(isSceneShowing([255, 127, 0, 0, 0, 0], WORSHIP)).toBe(false);
+  });
+
+  test("mid-fade is not showing", () => {
+    // Halfway through a recall the buffer holds interpolated values — the
+    // button lights up when the fade lands, not when it starts.
+    expect(isSceneShowing([128, 64, 0, 0, 0, 0], WORSHIP)).toBe(false);
+  });
+
+  test("a scene naming a slot past the universe never matches", () => {
+    expect(isSceneShowing([255], scene("wide", { 1: 255, 900: 10 }))).toBe(
+      false,
+    );
+  });
+
+  test("an empty scene matches nothing", () => {
+    expect(isSceneShowing([0, 0, 0], scene("empty", {}))).toBe(false);
+  });
+});
+
+describe("activeSceneId", () => {
+  test("finds the scene the buffer is showing", () => {
+    const scenes = [WORSHIP, SERMON];
+    expect(activeSceneId([255, 128, 0, 0, 0, 0], scenes)).toBe("worship");
+    expect(activeSceneId([40, 40, 40, 0, 0, 0], scenes)).toBe("sermon");
+  });
+
+  test("is null when the rig shows no saved look", () => {
+    expect(activeSceneId([1, 2, 3, 4, 5, 6], [WORSHIP, SERMON])).toBeNull();
+    expect(activeSceneId([255, 128, 0], [])).toBeNull();
+  });
+
+  test("is null while either read is still in flight", () => {
+    // Nothing is pressed before the first buffer read lands.
+    expect(activeSceneId(null, [WORSHIP])).toBeNull();
+    expect(activeSceneId([255, 128, 0], null)).toBeNull();
+  });
+
+  test("a tie resolves to the first scene in display order", () => {
+    // Two scenes saved with the same levels are the same look; highlighting
+    // the earlier one is stable across reorders of everything else.
+    const twin = { ...WORSHIP, id: "twin" };
+    expect(activeSceneId([255, 128, 0], [WORSHIP, twin])).toBe("worship");
+  });
+});

--- a/apps/desktop/src/lib/scene-state.ts
+++ b/apps/desktop/src/lib/scene-state.ts
@@ -1,0 +1,39 @@
+//! Which saved look is on the rig right now — as pure data, no React, no Tauri.
+//!
+//! A scene is a sparse set of levels (see `crates/../scene.rs`), so "this scene
+//! is up" means exactly: every slot the scene names still reads the value it
+//! saved. Slots the scene never mentioned are none of its business — that is
+//! the same sparse-overlay contract the backend recall honours, restated for
+//! the button's pressed state.
+//!
+//! Deliberately *not* the preset engine's job. Presets are momentary and carry
+//! an undo lane, so they need a remembered active set that survives an
+//! unrelated write (`lib/preset-engine.ts`). A scene is a destination: whether
+//! it is showing is answerable from the buffer alone, with nothing remembered,
+//! which is why this is a function rather than a store.
+
+import type { Scene } from "@/bindings";
+
+/** Whether the live `buffer` shows every level this scene saved. */
+export function isSceneShowing(buffer: number[], scene: Scene): boolean {
+  // An empty scene matches nothing: the backend refuses to save one, and
+  // "matches everything" would be a permanently-lit button.
+  if (scene.levels.length === 0) return false;
+  return scene.levels.every(({ ch, val }) => buffer[ch - 1] === val);
+}
+
+/**
+ * The scene the rig is currently showing, or `null`.
+ *
+ * First match wins on the rare tie — two scenes saved with identical levels are
+ * the same look, so highlighting the earlier one is both stable and honest.
+ * `null` while the buffer is still loading, so a button never flashes pressed
+ * before the first read lands.
+ */
+export function activeSceneId(
+  buffer: number[] | null,
+  scenes: Scene[] | null,
+): string | null {
+  if (!buffer || !scenes) return null;
+  return scenes.find((scene) => isSceneShowing(buffer, scene))?.id ?? null;
+}

--- a/apps/desktop/src/routes/index.tsx
+++ b/apps/desktop/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import ButtonRow from "@/components/button-row";
 import FixturesView from "@/components/fixtures/fixtures-view";
+import ScenesPanel from "@/components/scenes/scenes-panel";
 
 export const Route = createFileRoute("/")({
   component: Home,
@@ -13,6 +14,7 @@ function Home() {
     <div className="h-full w-full overflow-y-auto">
       <div className="flex min-h-full w-full flex-col items-center">
         <ButtonRow />
+        <ScenesPanel />
         <FixturesView />
       </div>
     </div>

--- a/apps/desktop/src/routes/universe.tsx
+++ b/apps/desktop/src/routes/universe.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import ButtonRow from "@/components/button-row";
 import ControlGrid from "@/components/control-grid/grid";
+import ScenesPanel from "@/components/scenes/scenes-panel";
 
 export const Route = createFileRoute("/universe")({
   component: Universe,
@@ -9,9 +10,11 @@ export const Route = createFileRoute("/universe")({
 function Universe() {
   return (
     // This view fits the viewport — the desk scrolls internally, the page
-    // never does. The presets row takes its height; the desk absorbs the rest.
+    // never does. The presets row and the scenes panel take their height; the
+    // desk absorbs the rest.
     <div className="mx-auto flex h-full w-full max-w-3xl flex-col px-4">
       <ButtonRow />
+      <ScenesPanel />
       <div className="mb-3 min-h-0 w-full flex-1">
         <ControlGrid />
       </div>

--- a/apps/node/src/install.rs
+++ b/apps/node/src/install.rs
@@ -342,6 +342,7 @@ mod tests {
             name: name.into(),
             universe,
             fixtures: serde_json::json!([]),
+            scenes: serde_json::json!([]),
             rev: 0,
             updated_at: 0,
             deleted: false,

--- a/crates/lux-engine/src/fade.rs
+++ b/crates/lux-engine/src/fade.rs
@@ -1,0 +1,183 @@
+//! Crossfades: the "recall a look over N seconds" primitive.
+//!
+//! A [`Crossfade`] is the pure half of a scene recall — it holds where every
+//! slot started, where it is going, and how long it has to get there, and
+//! answers one question: *what should these slots read at `elapsed_ms`?* It
+//! neither renders nor sleeps, so the same math drives the desktop's ticker
+//! today and a headless `lux-node` recall later.
+//!
+//! Two properties the callers rely on:
+//!
+//! - **Sparse.** A fade owns only the slots it was given, and `at` returns only
+//!   those. Every other slot in the universe is untouched, which is what lets a
+//!   scene captured over a six-fixture patch coexist with raw faders — the same
+//!   overlay discipline as [`crate::universe`].
+//! - **It lands exactly.** The last tick returns the target values verbatim, so
+//!   a fade can never leave a channel one bit short of the look that was saved.
+//!
+//! The arithmetic is integer throughout (rounding half away from zero). That is
+//! not incidental: the workspace lints forbid float comparison and the sloppy
+//! numeric casts a float path invites, and exact integers make the tests below
+//! assertions rather than approximations.
+
+/// A linear crossfade from a captured universe snapshot to a sparse target.
+#[derive(Debug, Clone)]
+pub struct Crossfade {
+    steps: Vec<Step>,
+    duration_ms: u32,
+}
+
+/// One slot's journey: 1-based DMX slot, where it started, where it ends.
+#[derive(Debug, Clone, Copy)]
+struct Step {
+    ch: u16,
+    from: u8,
+    to: u8,
+}
+
+impl Crossfade {
+    /// Build a fade from the live universe `from` (slot 1 first) to the sparse
+    /// `to` levels over `duration_ms`.
+    ///
+    /// A target slot outside the snapshot is dropped rather than rejected: a
+    /// scene saved against an older, wider patch must degrade to "fades what it
+    /// still can", never to a failed recall.
+    pub fn new(from: &[u8], to: &[(u16, u8)], duration_ms: u32) -> Self {
+        let steps = to
+            .iter()
+            .filter_map(|&(ch, target)| {
+                let index = usize::from(ch).checked_sub(1)?;
+                Some(Step {
+                    ch,
+                    from: *from.get(index)?,
+                    to: target,
+                })
+            })
+            .collect();
+        Crossfade { steps, duration_ms }
+    }
+
+    /// How long this fade runs, in milliseconds.
+    pub fn duration_ms(&self) -> u32 {
+        self.duration_ms
+    }
+
+    /// Whether the fade has reached its target by `elapsed_ms`.
+    pub fn is_done(&self, elapsed_ms: u64) -> bool {
+        elapsed_ms >= u64::from(self.duration_ms)
+    }
+
+    /// The sparse overlay to apply at `elapsed_ms` — one entry per slot the
+    /// fade owns, in the order it was given them. At or past the duration this
+    /// is exactly the target.
+    pub fn at(&self, elapsed_ms: u64) -> Vec<(u16, u8)> {
+        let done = self.is_done(elapsed_ms);
+        self.steps
+            .iter()
+            .map(|step| {
+                let value = if done {
+                    step.to
+                } else {
+                    interpolate(step.from, step.to, elapsed_ms, self.duration_ms)
+                };
+                (step.ch, value)
+            })
+            .collect()
+    }
+}
+
+/// `from + (to - from) * elapsed / duration`, rounded half away from zero and
+/// clamped to a byte. Only called with `elapsed < duration` (so `duration > 0`).
+fn interpolate(from: u8, to: u8, elapsed: u64, duration: u32) -> u8 {
+    let delta = i64::from(to) - i64::from(from);
+    // `elapsed < duration <= u32::MAX`, so both conversions are lossless; the
+    // fallbacks only exist because the lint floor forbids `unwrap`.
+    let elapsed = i64::try_from(elapsed).unwrap_or(i64::from(duration));
+    let duration = i64::from(duration);
+    let travelled = div_round(delta.saturating_mul(elapsed), duration);
+    let value = (i64::from(from) + travelled).clamp(0, 255);
+    u8::try_from(value).unwrap_or(to)
+}
+
+/// Integer division rounding half away from zero, so a fade's midpoint is the
+/// midpoint in both directions rather than biased toward the floor.
+fn div_round(numerator: i64, denominator: i64) -> i64 {
+    if denominator == 0 {
+        return 0;
+    }
+    let half = denominator / 2;
+    if numerator >= 0 {
+        (numerator + half) / denominator
+    } else {
+        (numerator - half) / denominator
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A universe snapshot with the given leading slots.
+    fn universe(leading: &[u8]) -> Vec<u8> {
+        let mut slots = vec![0u8; crate::universe::UNIVERSE_SIZE];
+        slots[..leading.len()].copy_from_slice(leading);
+        slots
+    }
+
+    #[test]
+    fn fades_linearly_between_the_endpoints() {
+        let fade = Crossfade::new(&universe(&[0, 255]), &[(1, 200), (2, 0)], 1000);
+
+        assert_eq!(fade.at(0), vec![(1, 0), (2, 255)]);
+        // Halfway: slot 1 has travelled 100 of 200, slot 2 128 of 255 (its
+        // half-unit rounds away from where it started).
+        assert_eq!(fade.at(500), vec![(1, 100), (2, 127)]);
+        assert_eq!(fade.at(1000), vec![(1, 200), (2, 0)]);
+        // Past the end it holds the target rather than overshooting.
+        assert_eq!(fade.at(99_999), vec![(1, 200), (2, 0)]);
+    }
+
+    #[test]
+    fn lands_exactly_on_the_target() {
+        // A duration that doesn't divide the delta evenly is where a naive
+        // implementation leaves a channel one bit short forever.
+        let fade = Crossfade::new(&universe(&[0]), &[(1, 255)], 700);
+        assert!(!fade.is_done(699));
+        assert!(fade.is_done(700));
+        assert_eq!(fade.at(700), vec![(1, 255)]);
+    }
+
+    #[test]
+    fn a_zero_length_fade_snaps() {
+        let fade = Crossfade::new(&universe(&[10]), &[(1, 200)], 0);
+        assert!(fade.is_done(0));
+        assert_eq!(fade.at(0), vec![(1, 200)]);
+    }
+
+    #[test]
+    fn owns_only_its_own_slots() {
+        // Slot 5 is not in the target, so nothing in the overlay mentions it —
+        // the caller's buffer keeps whatever a fader left there.
+        let fade = Crossfade::new(&universe(&[1, 2, 3, 4, 5]), &[(2, 100)], 1000);
+        assert_eq!(fade.at(1000), vec![(2, 100)]);
+    }
+
+    #[test]
+    fn drops_slots_the_snapshot_does_not_cover() {
+        // Slot 0 doesn't exist (DMX is 1-based) and 513 is past the universe: a
+        // scene carrying either still recalls the slots that are real.
+        let fade = Crossfade::new(&universe(&[7]), &[(0, 9), (1, 9), (513, 9)], 0);
+        assert_eq!(fade.at(0), vec![(1, 9)]);
+    }
+
+    #[test]
+    fn rounding_is_symmetric_up_and_down() {
+        // A half-unit of travel rounds away from where the slot started, so a
+        // rise and the matching fall cover the same distance at the same tick
+        // (2 of 3, in opposite directions) instead of one of them stalling.
+        let up = Crossfade::new(&universe(&[0]), &[(1, 3)], 2);
+        let down = Crossfade::new(&universe(&[3]), &[(1, 0)], 2);
+        assert_eq!(up.at(1), vec![(1, 2)]); // 0 + 1.5 → 2
+        assert_eq!(down.at(1), vec![(1, 1)]); // 3 - 1.5 → 1
+    }
+}

--- a/crates/lux-engine/src/lib.rs
+++ b/crates/lux-engine/src/lib.rs
@@ -2,8 +2,9 @@
 //!
 //! Everything here is plain functions and plain types: the [`DmxSink`] trait
 //! and its sACN/E1.31 sender ([`sacn`]), the universe overlay semantics
-//! ([`universe`]), the remote-control routing and gating decisions ([`ctl`]),
-//! and the TLS/JWT glue every user-channel connection needs ([`tls`],
+//! ([`universe`]), the crossfade math behind a scene recall ([`fade`]), the
+//! remote-control routing and gating decisions ([`ctl`]), and the TLS/JWT glue
+//! every user-channel connection needs ([`tls`],
 //! [`auth`]). The desktop app wraps these in Tauri state and event plumbing;
 //! `lux-node` wraps them in a systemd-friendly binary. Nothing in this crate
 //! may depend on Tauri — that boundary is what lets lux run headless on a
@@ -11,6 +12,7 @@
 
 pub mod auth;
 pub mod ctl;
+pub mod fade;
 pub mod net;
 pub mod sacn;
 pub mod tls;

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -34,9 +34,9 @@ pub const SETTINGS_SEGMENT: &str = "settings";
 
 /// One setup as it crosses the wire (an element of [`ListSetupsResponse`]).
 ///
-/// `fixtures` is deliberately opaque here: the server round-trips it as JSON
-/// and only the desktop gives it a concrete type, so fixture-schema evolution
-/// never requires a server deploy.
+/// `fixtures` and `scenes` are deliberately opaque here: the server
+/// round-trips them as JSON and only the desktop gives them a concrete type, so
+/// schema evolution on either never requires a server deploy.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetupRecord {
@@ -44,6 +44,11 @@ pub struct SetupRecord {
     pub name: String,
     pub universe: u16,
     pub fixtures: Value,
+    /// The setup's saved looks (the desktop's `Vec<Scene>`). Defaulted so a
+    /// reply from a server that predates scenes still parses — clients read
+    /// that as "no scenes", exactly as they read an absent `settings`.
+    #[serde(default)]
+    pub scenes: Value,
     /// Server-side write counter. Informational on the client today; the
     /// last-writer-wins authority is `updated_at`.
     pub rev: i64,
@@ -74,6 +79,10 @@ pub struct UpsertSetupBody {
     pub universe: u16,
     /// The desktop's `Vec<Fixture>`, opaque on the wire (see [`SetupRecord`]).
     pub fixtures: Value,
+    /// The desktop's `Vec<Scene>`, opaque on the wire (see [`SetupRecord`]).
+    /// Defaulted so a body from a client that predates scenes still parses.
+    #[serde(default)]
+    pub scenes: Value,
     /// The client's last-known server `updated_at` for this setup — the
     /// optimistic-concurrency token. `None` means "create; fail if it exists".
     #[serde(default)]
@@ -977,24 +986,28 @@ mod tests {
             name: "Home".into(),
             universe: 1,
             fixtures: json!([{ "kind": "rgbaw" }]),
+            scenes: json!([{ "name": "Worship" }]),
             rev: 3,
             updated_at: 1719000000000,
             deleted: false,
         };
         assert_eq!(
             serde_json::to_string(&record).unwrap(),
-            r#"{"id":"7f0175a6-3b64-4a2a-9e1c-000000000001","name":"Home","universe":1,"fixtures":[{"kind":"rgbaw"}],"rev":3,"updatedAt":1719000000000,"deleted":false}"#
+            r#"{"id":"7f0175a6-3b64-4a2a-9e1c-000000000001","name":"Home","universe":1,"fixtures":[{"kind":"rgbaw"}],"scenes":[{"name":"Worship"}],"rev":3,"updatedAt":1719000000000,"deleted":false}"#
         );
     }
 
     #[test]
-    fn setup_record_tolerates_missing_deleted() {
+    fn setup_record_tolerates_missing_deleted_and_scenes() {
+        // A record from a server that predates either field still parses; the
+        // client reads a null `scenes` as "this setup has none".
         let record: SetupRecord = serde_json::from_value(json!({
             "id": "a", "name": "n", "universe": 1, "fixtures": [], "rev": 0,
             "updatedAt": 1
         }))
         .unwrap();
         assert!(!record.deleted);
+        assert!(record.scenes.is_null());
     }
 
     #[test]
@@ -1029,23 +1042,25 @@ mod tests {
             name: "Home".into(),
             universe: 7,
             fixtures: json!([]),
+            scenes: json!([]),
             base_updated_at: None,
         };
         assert_eq!(
             serde_json::to_string(&create).unwrap(),
-            r#"{"name":"Home","universe":7,"fixtures":[],"baseUpdatedAt":null}"#
+            r#"{"name":"Home","universe":7,"fixtures":[],"scenes":[],"baseUpdatedAt":null}"#
         );
 
         let update: UpsertSetupBody = serde_json::from_str(
-            r#"{"name":"Home","universe":7,"fixtures":[],"baseUpdatedAt":42}"#,
+            r#"{"name":"Home","universe":7,"fixtures":[],"scenes":[],"baseUpdatedAt":42}"#,
         )
         .unwrap();
         assert_eq!(update.base_updated_at, Some(42));
 
-        // A body without the field at all (very old client) still parses.
+        // A body from a client that predates either field still parses.
         let bare: UpsertSetupBody =
             serde_json::from_str(r#"{"name":"Home","universe":7,"fixtures":[]}"#).unwrap();
         assert_eq!(bare.base_updated_at, None);
+        assert!(bare.scenes.is_null());
     }
 
     #[test]

--- a/services/sync-api/src/store.rs
+++ b/services/sync-api/src/store.rs
@@ -107,6 +107,12 @@ pub async fn list(ddb: &Client, table: &str, sub: &str) -> Result<ListSetupsResp
             fixtures: s(item, "fixtures")
                 .and_then(|raw| serde_json::from_str(&raw).ok())
                 .unwrap_or(Value::Array(vec![])),
+            // Absent on every setup written before scenes existed; an empty
+            // list is the honest reading, and the owning client repairs the
+            // attribute on its next push.
+            scenes: s(item, "scenes")
+                .and_then(|raw| serde_json::from_str(&raw).ok())
+                .unwrap_or(Value::Array(vec![])),
             rev: n(item, "rev").unwrap_or(0),
             updated_at: n(item, "updatedAt").unwrap_or(0),
             deleted: item
@@ -136,17 +142,20 @@ pub async fn upsert(
         .key("sk", AttributeValue::S(sk(setup_id)))
         .update_expression(
             "SET #name = :name, #universe = :universe, #fixtures = :fixtures, \
-             #deleted = :false, #updatedAt = :now, #rev = if_not_exists(#rev, :zero) + :one",
+             #scenes = :scenes, #deleted = :false, #updatedAt = :now, \
+             #rev = if_not_exists(#rev, :zero) + :one",
         )
         .expression_attribute_names("#name", "name")
         .expression_attribute_names("#universe", "universe")
         .expression_attribute_names("#fixtures", "fixtures")
+        .expression_attribute_names("#scenes", "scenes")
         .expression_attribute_names("#deleted", "deleted")
         .expression_attribute_names("#updatedAt", "updatedAt")
         .expression_attribute_names("#rev", "rev")
         .expression_attribute_values(":name", AttributeValue::S(body.name.clone()))
         .expression_attribute_values(":universe", AttributeValue::N(body.universe.to_string()))
         .expression_attribute_values(":fixtures", AttributeValue::S(body.fixtures.to_string()))
+        .expression_attribute_values(":scenes", AttributeValue::S(body.scenes.to_string()))
         .expression_attribute_values(":false", AttributeValue::Bool(false))
         .expression_attribute_values(":now", AttributeValue::N(now.to_string()))
         .expression_attribute_values(":zero", AttributeValue::N("0".into()))


### PR DESCRIPTION
Closes the #1 gap: lux has never been able to save a look. Scenes are the volunteer's noun — *pre-service, worship, sermon, blackout* — and the structural prerequisite for the Planning Center bridge, which fires scenes rather than channels.

Spec: `.claude/specs/scenes.md` (written first, local-only like the rest of that directory).

> A **scene** is a named, savable snapshot of the levels the active setup's patch covers, recalled with one tap over its own fade time.

## Engine

**`crates/lux-engine/src/fade.rs`** — the crossfade primitive, Tauri-free so `lux-node` inherits correct recalls the day it grows a scene consumer.

- Sparse: a fade owns only the slots it was given, so a scene captured over a six-fixture patch never disturbs a raw fader.
- Integer arithmetic throughout, rounding half away from zero — no floats to fight the `float_cmp` / numeric-cast lint floor, and the goldens are exact rather than approximate.
- Lands exactly on the target; the last tick returns the saved values verbatim.

**`apps/desktop/src-tauri/src/scene.rs`** — the domain (capture, add/rename/reorder/delete, fade clamping) plus the recall driver: snapshot the live buffer, tick at 40 Hz, write through a new `LuxBuffer::apply_levels`. A generation counter on `LuxFade` means **the last recall always wins** — an in-flight fade that no longer owns the generation stops at its next tick. No cancellation plumbing, no torn frames. A zero-length fade applies inline.

Capture takes the slots the patch covers; an unpatched setup captures the whole universe, the same rule `Setup::compile` already states for a surface with no patch.

## Sync

Scenes are setup children, so they ride `SetupRecord` / `UpsertSetupBody` as an additive opaque field alongside `fixtures` — both `#[serde(default)]`, goldens updated, old-shaped payloads still parse. Without this a pull that adopts a remote-newer setup would silently discard its scenes, which is a data-loss bug rather than a missing feature. `sync-api` round-trips one more attribute; DynamoDB is schemaless, so no migration and no Terraform.

## UI

A scenes panel on both control surfaces: big tappable recall targets (one tap, no confirm), **Save look**, and a per-scene editor behind a pencil with inline rename, a fade picker, *save current levels here*, move left/right, and an armed two-tap delete matching the setup trash.

Which scene is showing is **derived from the live buffer**, not remembered — so a scene reads as up whether it was recalled here, from another device, or reproduced by hand on the faders.

## What this deliberately does not touch

Scenes are destinations; the #250/#257 preset engine is for momentary looks with an undo lane. Nothing here duplicates or reaches into it — because recall moves the buffer through the ordinary write path, an engaged preset drops its own marker through the `reconcile` it already runs.

## Tests

- `lux-engine`: endpoints, midpoint rounding both directions, exact landing, zero-duration snap, sparse containment, out-of-range slots.
- desktop: capture over a patch / on an unpatched setup, name + fade + cap validation, reorder saturation, a pre-scenes `setups.json` still parsing, scenes surviving a cloud reconcile, and a capture → crossfade → apply round trip that asserts the look comes back exactly and the unpatched slots never move.
- `lux-wire`: goldens for both changed shapes plus missing-field tolerance.
- `bun test`: the pure `activeSceneId` matcher (sparse match, divergence, mid-fade, ties, loading).

Full local gate green: `cargo test --workspace --locked`, `cargo clippy --workspace --locked -- -D warnings`, `cargo fmt --check`, `bun run build && typecheck && lint && test`, `knip --dependencies`, `cargo machete`. The app was launched and boots clean.

## Still ahead in the scenes phase

The cue list with Go/Back, scenes on the guest desk, migrating Blackout / Full Bright to shipped-by-default scenes, a phone-first Go surface, and drag-reorder. No iOS native change was needed — the panel is the same React surface at phone width and the crossfade lives in the shared core.