### PR TITLE
Ignore .env files at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
+.env.*
 .env*.local
 
 # vercel


### PR DESCRIPTION
The root .gitignore only matched `.env*.local`, so a plain `.env` (which now holds real OAuth credentials locally) was unprotected. Covers `.env` and `.env.*`. Same change rides in #264; identical content merges cleanly in either order.