### PR TITLE
docs(site): correct the privacy page's storage list and cover Planning Center

### DIFF
--- a/apps/site/src/pages/privacy.tsx
+++ b/apps/site/src/pages/privacy.tsx
@@ -5,12 +5,12 @@ export function Privacy() {
     <div className="mx-auto max-w-[1120px] px-6">
       <Nav />
 
-      <article className="mx-auto max-w-[68ch] py-14 pb-24 [&_h2]:mt-10 [&_h2]:mb-2.5 [&_h2]:text-2xl [&_h2]:font-semibold [&_li]:my-1.5 [&_li]:text-[#c6ccd4] [&_p]:my-3 [&_p]:text-[#c6ccd4] [&_strong]:text-ink [&_ul]:my-3 [&_ul]:ml-6 [&_ul]:list-disc">
+      <article className="mx-auto max-w-[68ch] py-14 pb-24 [&_h2]:mt-10 [&_h2]:mb-2.5 [&_h2]:text-2xl [&_h2]:font-semibold [&_h3]:mt-6 [&_h3]:mb-1.5 [&_h3]:text-[17px] [&_h3]:font-semibold [&_li]:my-1.5 [&_li]:text-[#c6ccd4] [&_p]:my-3 [&_p]:text-[#c6ccd4] [&_strong]:text-ink [&_ul]:my-3 [&_ul]:ml-6 [&_ul]:list-disc">
         <h1 className="text-[clamp(32px,4vw,44px)] font-bold tracking-[-0.02em]">
           Privacy
         </h1>
         <p className="mt-1.5 !text-[15px] !text-mut">
-          Effective July 3, 2026 · applies to lux for macOS and iOS
+          Effective August 10, 2026 · applies to lux for macOS and iOS
         </p>
 
         <h2>The short version</h2>
@@ -23,9 +23,10 @@ export function Privacy() {
 
         <h2>On your device</h2>
         <p>
-          Your setups (their names, universe numbers, and fixture definitions)
-          are stored in a local file on your computer. That file never leaves
-          your device unless you sign in.
+          Your setups (their names, universe numbers, fixture definitions, and
+          the scenes you save on them) are stored in a local file on your
+          computer, next to a small file of app preferences. Those files never
+          leave your device unless you sign in.
         </p>
         <p>
           lux has <strong>no analytics, no crash reporting, no tracking, and no
@@ -34,24 +35,129 @@ export function Privacy() {
         </p>
 
         <h2>If you create an account</h2>
-        <p>lux stores exactly two things:</p>
+        <p>lux stores these things:</p>
         <ul>
           <li>
             <strong>Your email address</strong> — your sign-in identity, held
-            in AWS Cognito.
+            in AWS Cognito. With Sign in with Apple that's whichever address
+            Apple hands over, including the private relay address if you chose
+            to hide yours.
           </li>
           <li>
             <strong>Your setups</strong> — the same names, universe numbers,
-            and fixture definitions from your device, held in AWS DynamoDB
-            (US West).
+            fixture definitions, and saved scenes from your device, held in AWS
+            DynamoDB (US West).
+          </li>
+          <li>
+            <strong>Your app preferences</strong> — one small settings record
+            that syncs alongside the setups. Today it holds which way the
+            faders run.
+          </li>
+          <li>
+            <strong>Sharing, if you share a setup</strong> — who you gave
+            control of which setup, the label you gave them in your own list,
+            and the matching record on their side so the setup shows up for
+            them. An invite nobody has claimed yet is stored as a hash of the
+            code rather than the code itself, and expires on its own.
+          </li>
+          <li>
+            <strong>A Sign in with Apple link, if you use one</strong> —
+            Apple's stable identifier for you, tied to your lux account, plus
+            the token lux needs to tell Apple to end the link when you delete
+            the account.
+          </li>
+          <li>
+            <strong>Paired devices, if you run lux-node</strong> — the device's
+            id, the name it reported, and the setup and universe it was paired
+            to. The short-lived record that carries out the pairing itself is
+            keyed by a hash of the code you type, notes the public IP the
+            approval came from, and deletes itself when it expires.
+          </li>
+          <li>
+            <strong>A Planning Center connection, if you make one</strong> —
+            the next section is entirely about that.
           </li>
         </ul>
-        <p>That's the entire list.</p>
         <p>
-          Your password never leaves your device: sign-in uses SRP, a
+          That's the list. It is longer than it was in July, because the
+          software grew; when lux stores something new, this page says so.
+        </p>
+        <p>
+          Your password never leaves your device: password sign-in uses SRP, a
           zero-knowledge proof, so lux's servers verify you know the password
-          without ever seeing it. Session tokens are kept in your operating
-          system's keychain.
+          without ever seeing it. Sign in with Apple has no password for anyone
+          to see. Session tokens are kept in your operating system's keychain.
+        </p>
+
+        <h2>If you connect Planning Center</h2>
+        <p>
+          Connecting is something you do, from the app, one lux account at a
+          time — and it finishes on Planning Center's own approval screen. lux
+          can only ever see what the person who approves it can see.
+        </p>
+
+        <h3>What lux reads</h3>
+        <p>
+          Your organization's name and id, your service types, and — for the
+          service type you pick — the next plan and its items: each item's
+          title, its type (song, header, media, or one your church made up),
+          its planned length, its place in the running order, and for songs
+          Planning Center's id for the song. That's the list.
+        </p>
+
+        <h3>What lux never does</h3>
+        <p>
+          <strong>lux never writes to Planning Center.</strong> It cannot
+          create, edit, or delete a plan, and it cannot advance your service.
+          The permission Planning Center calls "services" has no read-only
+          version, so that isn't something the grant enforces — it's built into
+          lux, whose Planning Center client issues read requests and has no
+          method that sends anything else.
+        </p>
+        <p>
+          lux asks for "services" and nothing else: not your people, giving,
+          check-ins, groups, registrations, or calendar. It doesn't read
+          attachments, arrangements, keys, item notes, or anything about who is
+          scheduled.
+        </p>
+
+        <h3>What lux keeps</h3>
+        <p>
+          When you approve, Planning Center hands lux a token. It is stored on
+          lux's servers — with your organization's name and id and the date you
+          connected — and it is never sent to the app on your desk or your
+          phone. That is the reason this part runs on a server at all. The plan
+          itself is read when you ask for it and passed straight through to the
+          app: <strong>lux does not store your plans, your items, or your song
+          list</strong>. While you're connecting, a single-use record holds the
+          request for fifteen minutes and then expires by itself.
+        </p>
+
+        <h3>Reconnecting</h3>
+        <p>
+          Planning Center's authorization runs 90 days from the last time it
+          was renewed. lux renews it quietly while you keep using it, and says
+          something a week before the ceiling, so you reconnect on a weekday
+          instead of finding out on a Sunday. Reconnecting is the same approval
+          screen again.
+        </p>
+
+        <h3>Turning it off</h3>
+        <p>
+          <strong>Disconnect</strong>, in the Plan view, deletes the stored
+          token — a delete, not a flag. You can also revoke lux in Planning
+          Center's own settings, which stops it immediately; lux's next read
+          then fails and asks you to connect again. Deleting your lux account
+          does not by itself end a Planning Center connection, so disconnect or
+          revoke first.
+        </p>
+
+        <h3>Whose data it is</h3>
+        <p>
+          Your plans are your church's. Planning Center is your provider, not
+          lux's. lux reads them to turn a plan into lighting cues and for
+          nothing else — not analyzed, not aggregated, not used to train
+          anything.
         </p>
 
         <h2>Network calls lux makes</h2>
@@ -71,11 +177,30 @@ export function Privacy() {
             messages say "something changed" and nothing else.
           </li>
           <li>
+            <strong>Shared control</strong>, when you share a setup or someone
+            shares one with you, rides that same AWS IoT connection. What
+            crosses it is the desk itself: the layout of the setup being
+            shared, and fader values in both directions.
+          </li>
+          <li>
+            <strong>Planning Center</strong>, when you connect it, goes through
+            lux's own bridge on AWS. The app never holds a Planning Center
+            credential and never contacts Planning Center directly.
+          </li>
+          <li>
             <strong>Discord remote control</strong> exists only if you build
             and configure it yourself from the source; nothing is set up by
             default.
           </li>
         </ul>
+
+        <h2>Server logs</h2>
+        <p>
+          The services behind sign-in, sync, and the Planning Center bridge
+          write short operational logs — enough to see that something failed
+          and roughly where. They don't carry your password, your tokens, or
+          the contents of your plans, and AWS deletes them after 14 days.
+        </p>
 
         <h2>What lux never does</h2>
         <p>
@@ -86,8 +211,20 @@ export function Privacy() {
         <h2>Deleting your account</h2>
         <p>
           Account menu → Delete account. That permanently deletes your synced
-          setups from lux's servers and removes your sign-in, right then. The
-          local files on your devices stay yours; delete the app and its
+          setups and scenes, your settings record, and your sharing grants from
+          lux's servers, tells Apple to end the Sign in with Apple link if you
+          made one, and removes your sign-in, right then. Removing the sign-in
+          is also what ends a paired lux-node's access, since its credentials
+          are your account's.
+        </p>
+        <p>
+          One thing it does not reach: a Planning Center connection. That token
+          belongs to another company's system, so end it deliberately —
+          Disconnect in the Plan view, or revoke lux in Planning Center —
+          before you delete the account.
+        </p>
+        <p>
+          The local files on your devices stay yours; delete the app and its
           configuration folder if you want those gone too.
         </p>
 


### PR DESCRIPTION
The live page at lux.johncarmack.com/privacy says lux stores **"exactly two things"** — email and setups — and closes with *"That's the entire list."* That stopped being true in July. Since then the software added scenes, the synced settings record, sharing grants, Sign in with Apple links and paired-device records, and #270 adds a Planning Center token. A specific, checkable promise that the software outgrew is the worst kind of privacy-page defect, so this replaces it with the real inventory.

**Site-only. No app, service, infra or wire changes** — merging this before the release is safe, and it deploys on merge via `site.yml` (`apps/site/**`).

### What the page now claims, and where each claim comes from

| Claim | Verified against |
|---|---|
| Email in Cognito; with Apple, whichever address Apple hands over (relay included) | `infra/accounts.tf` (`username_attributes = ["email"]`), `services/apple-auth/src/cognito.rs` (`create_user` uses the asserted email as username) |
| Setups: name, universe, fixtures, scenes | `apps/desktop/src-tauri/src/setup.rs::Setup`, `services/sync-api/src/store.rs` (`USER#<sub>` / `SETUP#<id>`) |
| One settings record; today it holds fader orientation | `apps/desktop/src-tauri/src/settings.rs::UserSettings`, `sk = SETTINGS` |
| Sharing: grant rows both sides, owner's label, invite stored as a hash and self-expiring | `services/sync-api/src/shares.rs` (`INVITE#<sha256>`, `GRANT#`, `SHARED#`) |
| Apple link: Apple's stable id + the revoke token | `services/apple-auth/src/store.rs` (`APPLE#` / `APPLELINK#`) |
| Paired devices: id, reported name, setup + universe; pairing record keyed by a code hash, notes the approving public IP, self-expires | `services/apple-auth/src/store.rs` (`DEVICE#`, `PAIR#`, `PAIRIP#`), table `ttl` in `infra/accounts.tf` |
| PCO: org name + id, tokens, connected-at stored; plans passed through, never stored | `services/plan-bridge/src/store.rs::Connection`, `routes.rs` (`plan` reads and replies) |
| PCO connect state is single-use and dies in 15 minutes | `routes.rs` `STATE_TTL_SECS = 900`, `store::take_state` (delete-and-return + explicit expiry check) |
| 90-day reconnect, warned a week out | `store.rs` `REFRESH_LIFETIME_S` / `RECONNECT_WARNING_S` / `needs_reconnect` |
| lux never writes to PCO, and that is a property of the client, not the grant | `crates/lux-pco/src/lib.rs` + `client.rs` — every method builds a GET; the only POST is the token endpoint |
| `services` scope and nothing else | `crates/lux-pco/src/oauth.rs::SCOPE` |
| Disconnect deletes the token | `store::delete_connection` (hard delete, not a tombstone) |
| Server logs kept 14 days, no tokens or plan contents | `retention_in_days = 14` in `accounts.tf`, `apple-auth.tf`, `nudge.tf`, `plan-bridge.tf`; no `tracing` call in the bridge logs a token or an item |
| Shared control rides the same IoT connection, carrying the compiled desk and fader values | `apps/desktop/src-tauri/src/guest.rs`, `docs/shared-control.md` |
| SRP is now one of two sign-in paths | `infra/accounts.tf` app client (`ALLOW_USER_SRP_AUTH`) + the Apple CUSTOM_AUTH flow |

### The one uncomfortable line, and why it is there

The deletion section now says plainly that deleting your account **does not** end a Planning Center connection. That is what the code does: `delete_account` revokes the Apple grant, wipes the `USER#<sub>` partition and cleans up shares — nothing touches `PCO#<sub>`, so a live 90-day refresh token for a church's data survives the account that authorized it. The honest sentence is the stopgap; **the fix is a few lines** (have `cmd::delete_account` call `plan_disconnect` first, or wipe the partition server-side). That is app/service code, deliberately not in this PR so this one stays free to merge before the release. Worth its own issue.

### Your calls before merging

- **Effective date** says August 10, 2026. Bump it if this merges later.
- **Voice pass.** This is deliberately plain, matching the page's existing structure and register rather than performing it. The page is yours; rewrite freely.
- **"That's the whole business model: there isn't one"** is kept verbatim from the live page and is still true today.
- Contact stays `johncarmack@me.com`, unchanged — a `privacy@` alias and a named legal entity are still open questions, and neither belongs in a PR that only fixes accuracy.
- Counsel items untouched here: transfer mechanism for non-US churches, GDPR lawful basis, whether to offer a DPA, CCPA "Do Not Sell or Share" wording, retention and response-time commitments.

Companion PR adds the Terms of Service page; the two are independent and can merge in either order.