### PR TITLE
docs(site): publish a terms of service page

### DIFF
--- a/apps/site/src/chrome.tsx
+++ b/apps/site/src/chrome.tsx
@@ -8,12 +8,15 @@ export function Nav() {
         </svg>
         lux
       </a>
-      <div className="flex items-center gap-7 text-[15px]">
+      <div className="flex items-center gap-5 text-[15px] sm:gap-7">
         <a className="text-mut transition-colors hover:text-ink" href="/#how">
           How it works
         </a>
         <a className="text-mut transition-colors hover:text-ink" href="/privacy/">
           Privacy
+        </a>
+        <a className="text-mut transition-colors hover:text-ink" href="/terms/">
+          Terms
         </a>
       </div>
     </nav>
@@ -37,6 +40,9 @@ export function Footer() {
           </a>
           <a className="transition-colors hover:text-ink" href="/privacy/">
             Privacy
+          </a>
+          <a className="transition-colors hover:text-ink" href="/terms/">
+            Terms
           </a>
         </div>
       </div>

--- a/apps/site/src/pages/terms.tsx
+++ b/apps/site/src/pages/terms.tsx
@@ -1,0 +1,222 @@
+import { Nav, Footer } from "../chrome";
+
+export function Terms() {
+  return (
+    <div className="mx-auto max-w-[1120px] px-6">
+      <Nav />
+
+      <article className="mx-auto max-w-[68ch] py-14 pb-24 [&_h2]:mt-10 [&_h2]:mb-2.5 [&_h2]:text-2xl [&_h2]:font-semibold [&_li]:my-1.5 [&_li]:text-[#c6ccd4] [&_p]:my-3 [&_p]:text-[#c6ccd4] [&_strong]:text-ink [&_ul]:my-3 [&_ul]:ml-6 [&_ul]:list-disc">
+        <h1 className="text-[clamp(32px,4vw,44px)] font-bold tracking-[-0.02em]">
+          Terms
+        </h1>
+        <p className="mt-1.5 !text-[15px] !text-mut">
+          Effective August 10, 2026 · applies to lux for macOS and iOS, the lux
+          account, and this site
+        </p>
+
+        <h2>The short version</h2>
+        <p>
+          The app is free and open source, and it works without an account. An
+          account exists only for the things that cross a boundary — another
+          device, another person, another company's service. Two sections below
+          are worth reading twice:{" "}
+          <strong>lighting control</strong> and{" "}
+          <strong>Planning Center</strong>. They are the ones that matter when
+          something goes wrong during a service.
+        </p>
+
+        <h2>Who you're agreeing with</h2>
+        <p>
+          lux is made and run by John Carmack —{" "}
+          <a className="text-accent underline underline-offset-3" href="mailto:johncarmack@me.com">
+            johncarmack@me.com
+          </a>
+          . "We" means that. "You" means you, and if you're agreeing on behalf
+          of a church or an organization, it means that organization and you're
+          confirming you may bind it.
+        </p>
+
+        <h2>The app is free, and it's yours</h2>
+        <p>
+          The lux desktop and mobile apps are free and open source under the
+          GNU General Public License v3.0. That license governs the software
+          itself, and{" "}
+          <strong>nothing in these terms takes away a right it grants you</strong>.
+          The full 512-channel desk, all three outputs, custom fixtures,
+          scenes, and manual control work with no account and no payment.
+        </p>
+
+        <h2>There's nothing to buy</h2>
+        <p>
+          lux has no paid plan, no subscription, and no in-app purchase. If
+          that ever changes, the terms for it will be published here before
+          anyone is asked to pay, and the offline app will stay free.
+        </p>
+
+        <h2>Accounts</h2>
+        <p>
+          You need an account only for the features that leave your machine:
+          syncing setups between your devices, sharing control with someone
+          else, connecting Planning Center. You're responsible for what happens
+          under yours. Tell us at the address above if you think someone else
+          has it.
+        </p>
+        <p>
+          Don't hand out your password to share a rig — share the setup
+          instead. That's a thing lux does properly, and it's revocable.
+        </p>
+
+        <h2>Sharing control</h2>
+        <p>
+          Sharing a setup gives another lux account real control of real lights
+          on your rig. Give it only to people you trust, and know what it costs
+          to take back:
+        </p>
+        <ul>
+          <li>
+            An invite is single-use and expires on its own. Either side can end
+            a grant at any time — revoking and leaving are the same act named
+            from opposite ends, and neither party needs the other's
+            cooperation.
+          </li>
+          <li>
+            <strong>Revoking is not instant for a guest who is already
+            connected.</strong> Their access is checked when they connect, and
+            their connection re-checks about once an hour, so someone already
+            at your desk may keep it until then. If you need them off the rig
+            right now, pull the setup off the network or close the app.
+          </li>
+        </ul>
+
+        <h2>Planning Center</h2>
+        <p>
+          If you connect Planning Center, you're confirming you're allowed to
+          do that for your organization.
+        </p>
+        <ul>
+          <li>
+            <strong>lux only reads.</strong> It never creates, edits, or
+            deletes anything in Planning Center, and it never advances your
+            service. That's a property of how the software is built, not only a
+            promise — the Privacy Policy says exactly how.
+          </li>
+          <li>
+            lux reads your service types and, for the one you pick, the next
+            plan and its items. Precisely what that means is in the{" "}
+            <a className="text-accent underline underline-offset-3" href="/privacy/">
+              Privacy Policy
+            </a>
+            .
+          </li>
+          <li>
+            Planning Center is your provider, not ours. Your relationship with
+            them, and their availability, are between you and them. If they're
+            down, change their API, or end your access, lux's plan features
+            stop — and, per the next section, your lights do not.
+          </li>
+          <li>
+            Disconnect at any time, from lux or from Planning Center. Either
+            one ends it.
+          </li>
+        </ul>
+
+        <h2>Lighting control — read this one twice</h2>
+        <p>
+          <strong>lux is a tool, and you are the operator.</strong>
+        </p>
+        <ul>
+          <li>
+            <strong>Local control is authoritative and doesn't depend on
+            us.</strong> Live DMX output goes from your machine to your
+            hardware. If our servers are down, your internet is out, or
+            Planning Center is unreachable, your lights hold and manual control
+            keeps working. That's how lux is built, and it's the reason the
+            cloud features are allowed to exist at all.
+          </li>
+          <li>
+            The plan view shows you your running order. It does not touch your
+            lights on its own — you're the one pressing Go — and nothing in it
+            sits in the path between a fader and a fixture.
+          </li>
+          <li>
+            <strong>Keep a person who can take over.</strong> For any service
+            that matters, have someone at the desk who can run it by hand, and
+            make sure they know how.
+          </li>
+          <li>
+            <strong>Do not use lux where a lighting failure could hurt
+            someone</strong>, or where a specific light must be guaranteed on
+            or off for safety. It is not certified for life-safety, emergency
+            lighting, or anything with that kind of consequence. Strobing and
+            rapid intensity changes can trigger photosensitive seizures; what
+            you put in front of an audience is your call and your
+            responsibility.
+          </li>
+        </ul>
+
+        <h2>Acceptable use</h2>
+        <p>
+          Don't use lux to break the law, don't try to get into other people's
+          accounts or setups, and don't attack the service.
+        </p>
+
+        <h2>Availability</h2>
+        <p>
+          We try to keep the cloud features up, but there's no promised uptime
+          and no SLA. We may change or retire a cloud feature with reasonable
+          notice. <strong>The offline app is the guarantee; the servers are the
+          convenience.</strong>
+        </p>
+
+        <h2>Your content</h2>
+        <p>
+          Your setups, your scenes, and your plan data are yours. We claim no
+          ownership of them and no license beyond storing and transmitting them
+          to give you the features you turned on. Deleting your account removes
+          them from our servers — the{" "}
+          <a className="text-accent underline underline-offset-3" href="/privacy/">
+            Privacy Policy
+          </a>{" "}
+          says what that reaches, and what you should end yourself first.
+        </p>
+
+        <h2>Warranties and liability</h2>
+        <p>
+          The hosted service is provided "as is", without warranties beyond
+          those the law doesn't let us disclaim. (The software itself carries
+          the GPL's own warranty disclaimer; this covers the servers.) To the
+          extent the law allows, we're not liable for indirect or consequential
+          losses — a missed cue, a service that didn't look the way you wanted,
+          lost volunteer time. Nothing here limits liability for death or
+          personal injury caused by negligence, or for anything else that can't
+          be limited.
+        </p>
+
+        <h2>Ending it</h2>
+        <p>
+          Stop using it whenever you like; delete the account from the account
+          menu. We may suspend or end an account that breaks these terms, and
+          we'll say why unless we're not allowed to. When it ends, the cloud
+          features stop and the free app carries on.
+        </p>
+
+        <h2>Changes</h2>
+        <p>
+          If these terms change, the new text lands on this page with a new
+          date at the top. If a change is material and you have an account,
+          we'll tell you before it takes effect.
+        </p>
+
+        <h2>Contact</h2>
+        <p>
+          Questions:{" "}
+          <a className="text-accent underline underline-offset-3" href="mailto:johncarmack@me.com">
+            johncarmack@me.com
+          </a>
+        </p>
+      </article>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/site/src/terms-main.tsx
+++ b/apps/site/src/terms-main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./app.css";
+import { Terms } from "./pages/terms";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <Terms />
+  </StrictMode>,
+);

--- a/apps/site/terms/index.html
+++ b/apps/site/terms/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Terms — lux</title>
+    <meta
+      name="description"
+      content="The terms for the lux apps and the lux account: free and open source, no account required, and who is responsible for what when the lights are on."
+    />
+    <link rel="canonical" href="https://lux.johncarmack.com/terms/" />
+    <meta property="og:title" content="Terms — lux" />
+    <meta
+      property="og:description"
+      content="Free and open source, no account required, and who is responsible for what when the lights are on."
+    />
+    <meta property="og:url" content="https://lux.johncarmack.com/terms/" />
+    <meta name="theme-color" content="#0b0d10" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpolygon points='16,6 26,28 6,28' fill='%23e8a33d' fill-opacity='0.35'/%3E%3Ccircle cx='16' cy='7' r='4' fill='%23e8a33d'/%3E%3C/svg%3E"
+    />
+    <link
+      rel="preload"
+      href="/fonts/Geist-Variable.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/terms-main.tsx"></script>
+  </body>
+</html>

--- a/apps/site/vite.config.ts
+++ b/apps/site/vite.config.ts
@@ -4,7 +4,7 @@ import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
 import tailwindcss from "@tailwindcss/vite";
 
-// MPA on purpose: two real HTML documents (home + privacy), so the privacy URL
+// MPA on purpose: real HTML documents (home, privacy, terms), so each legal URL
 // resolves as a document with no client routing involved.
 export default defineConfig({
   plugins: [react(), babel({ presets: [reactCompilerPreset()] }), tailwindcss()],
@@ -13,6 +13,7 @@ export default defineConfig({
       input: {
         main: resolve(import.meta.dirname, "index.html"),
         privacy: resolve(import.meta.dirname, "privacy/index.html"),
+        terms: resolve(import.meta.dirname, "terms/index.html"),
       },
     },
   },


### PR DESCRIPTION
lux has no Terms of Service. It is on two app stores, it holds accounts, it lets one person take control of another person's lights, and as of #270 it reads a church's service plan. This adds `/terms/` and links it beside Privacy in the nav and the footer.

**Site-only. No app, service, infra or wire changes** — safe to merge before the release; it deploys on merge via `site.yml` (`apps/site/**`). Independent of the privacy-page PR: different files, either order.

### Shape

Third real document in the existing MPA (`terms/index.html` + `src/terms-main.tsx` + `src/pages/terms.tsx`, one more rollup input), so `/terms/` is a document with no client routing — same as `/privacy/`. CloudFront's directory-index function already rewrites any `…/` path, so no infra change. Nav gets a third link and drops to `gap-5` below `sm:` so three items still fit a narrow phone.

### It only claims what exists today

Every section is checked against the repo:

- **Free, GPLv3, no account required** — the license, and the desk/outputs/fixtures/scenes all working from the local `setups.json`.
- **"There's nothing to buy"** — matches the home page's *"No subscription, no tiers."* **The whole paid-plan section of the draft is dropped**: Bridge pricing, Stripe, refund window, price-change notice, failed-payment behaviour. None of it is built, and publishing refund terms for a product nobody can buy would be the same kind of defect the privacy page had. When Stripe is real, it comes back as its own PR.
- **Shared control** — invites single-use and self-expiring, revoke and leave symmetric, and the honest bit: a guest already connected keeps access until their connection re-authorizes, up to about an hour (`docs/shared-control.md`, "Revocation latency"). It is a real operational fact about someone else's hands on your lights, so it says so and tells you what to do if you need them off now.
- **Planning Center** — read-only by construction, cancellable from either end, and their availability is between you and them. Detail deferred to the Privacy Policy rather than restated.
- **Lighting control** — local control authoritative; the plan view shows a running order and does not touch lights on its own (`plan.rs`: *"Nothing in this module is in the DMX path"*); keep an operator; not for life-safety; photosensitivity.
- **Availability / your content / liability / ending it / changes** — plain versions.

Dropped from the draft as unverifiable: the *"one-page manual fallback"* it promised (I found no such document in the repo), and *"plan-following fires the scenes you mapped"* — cue-map authoring isn't shipped, the app sends `cue_map: None` today, so the page describes read-and-manual-Go, which is what a user actually gets.

### Your calls before merging

1. **Who the counterparty is.** The page says "made and run by John Carmack" with your personal address, matching the site footer and the live privacy page. If it should be the S-Corp instead, that name has to match the App Store listing — and the IRS rename is in flight. This is the one line I would not merge without deciding.
2. **Governing law, venue, arbitration** — deliberately absent rather than guessed. For small churches an aggressive dispute clause may cost more trust than it saves risk; that's a call for you with counsel, not a default I should pick.
3. **Liability section** — plain-language and conservative, with the GPL disclaimer carved out from the hosted-service disclaimer, and no dollar cap (a cap of "what you paid us" reads oddly at zero). Counsel should still redraft it; it's the part that actually binds.
4. **Apple's standard EULA** already applies to the App Store builds. Whether to add a rider that names the App Store terms is worth asking counsel.
5. **Support address.** `johncarmack@me.com` on a page churches read is the same open question as on the privacy page.
6. **Voice pass.** Plain register throughout — matching the privacy page's structure, not performing its voice. Rewrite freely.