### PR TITLE
fix(account): deleting an account disconnects Planning Center and its devices

### DIFF
--- a/apps/desktop/src-tauri/src/account.rs
+++ b/apps/desktop/src-tauri/src/account.rs
@@ -486,6 +486,75 @@ impl LuxAccount {
         }
     }
 
+    /// Freshen the session's tokens before a deletion's detach steps run.
+    ///
+    /// Those steps present the current id token and have no refresh path of
+    /// their own, and an id token lasts an hour — so an app that has been open
+    /// since breakfast would 401 its way through every one of them and delete
+    /// the account anyway, which is precisely the outcome (a live credential
+    /// behind a deleted account) the detach steps exist to prevent. One refresh
+    /// up front costs a round trip and removes the whole class.
+    ///
+    /// Ignores failure: if the refresh token is dead too, the steps will fail
+    /// the way they already handle, and the deletion still has to go through.
+    pub fn refresh_before_deletion(&self) {
+        // Owned arguments, so the future outlives this borrow of `self` — the
+        // same shape `delete_account`'s own retry uses.
+        let Ok(cfg) = self.config() else { return };
+        let Some(refresh) = self.session.lock_or_recover().refresh_token.clone() else {
+            return;
+        };
+        match block_on(do_refresh(cfg, refresh)) {
+            Ok(tokens) => self.apply(tokens, None, None),
+            Err(e) => {
+                log::warn!("could not refresh before deleting ({e}); cleanups may be skipped")
+            }
+        }
+    }
+
+    /// Drop every paired device from the account's registry, as part of
+    /// deleting the account.
+    ///
+    /// The boxes stop working the moment the Cognito user goes — their sessions
+    /// are this account's — but the registry rows are keyed by the `sub` and
+    /// outlive it, leaving a list of someone's hardware behind an account that
+    /// no longer exists. This removes them.
+    ///
+    /// Same shape as [`revoke_apple_link`](Self::revoke_apple_link): no return
+    /// value, because nothing here may stop a deletion. An account with no
+    /// devices, a build with no auth service, and an unreachable service are
+    /// all logged and stepped over.
+    pub fn forget_paired_devices(&self) {
+        let Some(base) = self.apple_auth_url.clone() else {
+            return;
+        };
+        let Some(token) = self.current_id_token() else {
+            return;
+        };
+        let result = block_on(async move {
+            let response = reqwest::Client::new()
+                .post(format!(
+                    "{base}/{}/{}/{}",
+                    lux_wire::apple::AUTH_SEGMENT,
+                    lux_wire::device::DEVICE_SEGMENT,
+                    lux_wire::device::FORGET_ALL_SEGMENT
+                ))
+                .bearer_auth(token)
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            if response.status().is_success() {
+                Ok(())
+            } else {
+                Err(format!("device forget-all answered {}", response.status()))
+            }
+        });
+        match result {
+            Ok(()) => log::info!("paired devices forgotten as part of account deletion"),
+            Err(e) => log::warn!("device cleanup skipped ({e}); continuing with deletion"),
+        }
+    }
+
     /// The account's paired headless devices (lux-node boxes) from the auth
     /// service's registry — the delete-account confirm's tally. No auth
     /// service configured means no pairing anywhere: an empty list.

--- a/apps/desktop/src-tauri/src/cmd.rs
+++ b/apps/desktop/src-tauri/src/cmd.rs
@@ -740,10 +740,30 @@ impl CmdMethods for CmdEndpoint {
     }
 
     fn delete_account(&self, app_handle: AppHandle) -> Result<AuthStatus, String> {
-        // Revoke the Apple-side grant first (required when an Apple link
-        // exists; a quiet no-op otherwise) — best-effort, never blocks the
-        // deletion itself.
+        // Everything this account reaches outside lux, detached first — while
+        // the tokens still authenticate, because after the Cognito user goes
+        // there is nothing left to authorize any of these calls with.
+        //
+        // Every step in this block is best-effort by type — none of them
+        // returns an error — because a deletion that refuses to finish is worse
+        // than a cleanup that has to be retried, and each of them is idempotent
+        // if it is. What they must never do is leave a live credential behind a
+        // deleted account.
+        //
+        // One refresh first: they all present the current id token, which is an
+        // hour old at most, and a 401 here is a cleanup silently skipped.
+        app_handle.state::<LuxAccount>().refresh_before_deletion();
+        // Revoke the Apple-side grant (required when an Apple link exists; a
+        // quiet no-op otherwise).
         app_handle.state::<LuxAccount>().revoke_apple_link();
+        // Hand the church's Planning Center authorization back — the bridge
+        // revokes it upstream before dropping the token it held. Without this,
+        // deleting an account left a 90-day refresh token for another company's
+        // data alive and unreachable.
+        crate::plan::disconnect_for_deletion(&app_handle);
+        // And the paired-device registry, whose rows are keyed by the `sub` and
+        // would otherwise outlive the account they describe.
+        app_handle.state::<LuxAccount>().forget_paired_devices();
         // Wipe the cloud data while the tokens still authenticate, then remove
         // the Cognito user; a failure at either step leaves the account intact
         // and the whole flow retryable.

--- a/apps/desktop/src-tauri/src/plan.rs
+++ b/apps/desktop/src-tauri/src/plan.rs
@@ -225,6 +225,30 @@ impl PlanMethods for PlanEndpoint {
     }
 }
 
+/// Disconnect Planning Center as part of deleting the account.
+///
+/// The same `/pco/disconnect` the Plan view's button calls — "this church is
+/// done with lux" is one operation, whichever end asked for it — which means
+/// the bridge revokes the church's authorization at Planning Center before
+/// dropping the token it held. Deleting an account cannot leave a live 90-day
+/// credential for another company's data behind it.
+///
+/// Best-effort *by type*: there is no error to return, and that is deliberate.
+/// The three ordinary failures — this build has no bridge, the account never
+/// connected, Planning Center or the bridge is unreachable right now — are all
+/// answered the same way, because none of them is a reason to refuse to delete
+/// someone's account. Each one is logged; the deletion carries on.
+pub fn disconnect_for_deletion(app: &AppHandle) {
+    let Some((base, token)) = credentials(app) else {
+        // No bridge in this build, or nothing signed in: nothing to disconnect.
+        return;
+    };
+    match request::<StatusResponse>(app, Method::Post, &base, DISCONNECT_SEGMENT, token, None) {
+        Ok(_) => log::info!("planning center disconnected as part of account deletion"),
+        Err(e) => log::warn!("planning center disconnect skipped ({e}); continuing with deletion"),
+    }
+}
+
 /// Hand a URL to the OS's default browser.
 ///
 /// Only ever called with a URL this app just built from

--- a/apps/desktop/src/components/account-menu.tsx
+++ b/apps/desktop/src/components/account-menu.tsx
@@ -5,6 +5,7 @@ import { LogOut, Trash2, User as UserIcon } from "lucide-react";
 import { createTauRPCProxy } from "@/bindings";
 import useAuth, { AUTH_QUERY_KEY } from "@/hooks/useAuth";
 import useSetups from "@/hooks/useSetups";
+import { PLAN_STATUS_QUERY_KEY } from "@/hooks/usePlan";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -27,6 +28,7 @@ import {
 } from "@/components/ui/dialog";
 
 const cmd = () => createTauRPCProxy().cmd;
+const plan = () => createTauRPCProxy().plan;
 
 type Mode = "signIn" | "signUp" | "confirm";
 
@@ -72,6 +74,14 @@ export default function AccountMenu() {
   const { data: shares } = useQuery({
     queryKey: ["shares"],
     queryFn: () => cmd().list_shares(),
+    enabled: !!status?.signedIn && confirmDelete,
+  });
+  // Deletion now ends the church's Planning Center authorization too, so the
+  // confirm has to say so: it is the one item in the blast radius that reaches
+  // another company's system, and the one nobody would guess.
+  const { data: planConnection } = useQuery({
+    queryKey: PLAN_STATUS_QUERY_KEY,
+    queryFn: () => plan().plan_status(),
     enabled: !!status?.signedIn && confirmDelete,
   });
 
@@ -174,6 +184,13 @@ export default function AccountMenu() {
                   ? ` You also lose access to setups shared with you by ${peopleList(
                       shares.receivedFrom,
                     )}.`
+                  : ""}
+                {/* The part that reaches outside lux: the church's Planning
+                    Center authorization is handed back, not merely forgotten. */}
+                {planConnection?.connected
+                  ? ` It also disconnects ${
+                      planConnection.orgName ?? "your Planning Center organization"
+                    } from lux and ends the authorization at Planning Center.`
                   : ""}{" "}
                 Setups on this device stay on this device. This can't be undone.
               </DialogDescription>

--- a/crates/lux-pco/src/http.rs
+++ b/crates/lux-pco/src/http.rs
@@ -24,8 +24,9 @@ use crate::error::Error;
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// The two verbs this crate knows. There is no `PUT`, `PATCH` or `DELETE`
-/// here, and [`Method::Post`] exists only for the OAuth token endpoint — see
-/// the crate docs on why that boundary is structural rather than a promise.
+/// here, and [`Method::Post`] exists only for the OAuth token and revocation
+/// endpoints — see the crate docs on why that boundary is structural rather
+/// than a promise.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Method {
     Get,

--- a/crates/lux-pco/src/lib.rs
+++ b/crates/lux-pco/src/lib.rs
@@ -3,7 +3,8 @@
 //! This crate does four things and refuses to do a fifth:
 //!
 //! - [`oauth`] — the authorization-code flow: build the consent URL, exchange
-//!   the code, refresh the token. The one client secret lives here.
+//!   the code, refresh the token, and hand it back when a church is done. The
+//!   one client secret lives here.
 //! - [`jsonapi`] — the JSON:API envelope Planning Center answers in
 //!   (`data`/`included`/`links`), typed once so no reader hand-rolls it.
 //! - [`services`] — the vertices the bridge reads: service types, plans, plan
@@ -17,9 +18,11 @@
 //! token the bridge already holds — so "lux never advances someone else's
 //! service" cannot be enforced by the grant. It is enforced here instead:
 //! [`PcoClient`] builds `GET` requests and nothing else, no method on it names
-//! a write action, and the only `POST` in the crate is the token endpoint in
-//! [`oauth`], which talks to the OAuth server rather than the API. A write
-//! would have to be *written*, in a diff, on purpose.
+//! a write action, and the only `POST`s in the crate are the token and
+//! revocation endpoints in [`oauth`], which talk to the OAuth server rather
+//! than the API — one asks for a credential, the other gives it back, and
+//! neither touches a church's data. A write would have to be *written*, in a
+//! diff, on purpose.
 //!
 //! Rate limits are Planning Center's, not ours: 100 requests per 20 seconds
 //! per connected church, reported on every response and re-read from the

--- a/crates/lux-pco/src/oauth.rs
+++ b/crates/lux-pco/src/oauth.rs
@@ -14,6 +14,9 @@
 //!    a refresh token (good for up to 90 days after issuance).
 //! 4. [`OAuthApp::refresh`] renews both, well before
 //!    [`Tokens::needs_refresh`] says the access token is about to expire.
+//! 5. [`OAuthApp::revoke`] gives the grant back when the church disconnects or
+//!    deletes its lux account — the only way lux can end its own access
+//!    without the administrator visiting Planning Center's settings.
 //!
 //! **The redirect URI must match the registration byte for byte**, port and
 //! all, so the two live here as constants and travel as a *field* on
@@ -34,6 +37,9 @@ use crate::http::{Http, HttpRequest};
 
 pub const AUTHORIZE_URL: &str = "https://api.planningcenteronline.com/oauth/authorize";
 pub const TOKEN_URL: &str = "https://api.planningcenteronline.com/oauth/token";
+/// Where a grant is handed back. Revoking a refresh token also invalidates the
+/// access token it minted, so one call ends lux's access entirely.
+pub const REVOKE_URL: &str = "https://api.planningcenteronline.com/oauth/revoke";
 
 /// The only scope the bridge asks for. Planning Center has no finer grain than
 /// this — see the crate docs on why read-only is enforced in code instead.
@@ -176,6 +182,46 @@ impl OAuthApp {
             ("client_secret", &self.client_secret),
         ]);
         self.post_token(http, body).await
+    }
+
+    /// Hand a refresh token back, ending the grant it belongs to.
+    ///
+    /// The one thing lux can do about its own access without asking a church to
+    /// go and click something: a disconnect, and an account deletion, both end
+    /// here. Revoking the refresh token invalidates its access token too, so
+    /// this single call is the whole of it.
+    ///
+    /// Planning Center answers 200 for a token that was already revoked or was
+    /// never valid, so success means "this token cannot be spent", not "this
+    /// token was live a moment ago" — which is exactly the property a caller
+    /// deleting an account wants, and the reason this is safe to retry.
+    ///
+    /// The response body is an empty JSON object and nothing here reads it: the
+    /// status is the entire answer.
+    pub async fn revoke<H: Http + ?Sized>(
+        &self,
+        http: &H,
+        refresh_token: &str,
+    ) -> Result<(), Error> {
+        let body = form(&[
+            ("token", refresh_token),
+            ("token_type_hint", "refresh_token"),
+            ("client_id", &self.client_id),
+            ("client_secret", &self.client_secret),
+        ]);
+        let response = http.send(HttpRequest::form(REVOKE_URL, body)).await?;
+        if response.status == 401 {
+            // The application's own credentials were refused — a deployment
+            // problem, not a token that is now gone.
+            return Err(Error::Unauthorized);
+        }
+        if !(200..300).contains(&response.status) {
+            return Err(Error::Status {
+                status: response.status,
+                detail: truncate(&response.body, 300),
+            });
+        }
+        Ok(())
     }
 
     async fn post_token<H: Http + ?Sized>(&self, http: &H, body: String) -> Result<Tokens, Error> {

--- a/crates/lux-pco/tests/flow.rs
+++ b/crates/lux-pco/tests/flow.rs
@@ -46,6 +46,10 @@ const ERROR_401: &str = include_str!("fixtures/error_401.json");
 struct Recorded {
     routes: Mutex<BTreeMap<String, VecDeque<HttpResponse>>>,
     calls: Mutex<Vec<(Method, String)>>,
+    /// The form bodies the OAuth hops sent, in order. Kept apart from `calls`
+    /// because only those hops have one, and the read path's assertion is
+    /// precisely that it never does.
+    bodies: Mutex<Vec<String>>,
 }
 
 impl Recorded {
@@ -67,12 +71,19 @@ impl Recorded {
     fn calls(&self) -> Vec<(Method, String)> {
         self.calls.lock().map(|c| c.clone()).unwrap_or_default()
     }
+
+    fn bodies(&self) -> Vec<String> {
+        self.bodies.lock().map(|b| b.clone()).unwrap_or_default()
+    }
 }
 
 impl Http for Recorded {
     fn send(&self, request: HttpRequest) -> BoxFuture<'_, Result<HttpResponse, Error>> {
         if let Ok(mut calls) = self.calls.lock() {
             calls.push((request.method, request.url.clone()));
+        }
+        if let (Ok(mut bodies), Some(body)) = (self.bodies.lock(), request.body.as_ref()) {
+            bodies.push(body.clone());
         }
         let answer = match self.routes.lock() {
             Ok(mut routes) => match routes.get_mut(&request.url) {
@@ -474,4 +485,73 @@ async fn a_rejected_code_is_reported_not_swallowed() {
         matches!(&error, Error::Status { status: 400, detail } if detail.contains("invalid_grant")),
         "expected the OAuth error to survive, got {error:?}"
     );
+}
+
+// --- handing the grant back -------------------------------------------------
+
+fn revoking_app() -> OAuthApp {
+    OAuthApp::new(
+        "client-id",
+        "client-secret",
+        lux_pco::oauth::REDIRECT_URI_PROD,
+    )
+}
+
+#[tokio::test]
+async fn a_disconnect_hands_the_refresh_token_back_to_planning_center() {
+    // Planning Center answers a successful revocation with 200 and an empty
+    // JSON body.
+    let http = Recorded::new().ok(lux_pco::oauth::REVOKE_URL, "{}");
+
+    revoking_app()
+        .revoke(&http, "the-churchs-refresh-token")
+        .await
+        .expect("a 200 is a revocation");
+
+    // One POST, to the revocation endpoint, naming the refresh token as a
+    // refresh token — the hint is what makes this end the whole grant rather
+    // than one two-hour access token, which would leave the 90-day credential
+    // alive and the defect unfixed.
+    let calls = http.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, Method::Post);
+    assert_eq!(calls[0].1, lux_pco::oauth::REVOKE_URL);
+
+    let body = http.bodies().pop().expect("the revocation carried a body");
+    assert!(body.contains("token=the-churchs-refresh-token"), "{body}");
+    assert!(body.contains("token_type_hint=refresh_token"), "{body}");
+    assert!(body.contains("client_id=client-id"), "{body}");
+    assert!(body.contains("client_secret=client-secret"), "{body}");
+}
+
+#[tokio::test]
+async fn revoking_a_token_that_is_already_gone_is_a_success() {
+    // Their endpoint answers 200 for a token that was already revoked or never
+    // existed. That is the property that makes an account deletion safe to
+    // retry: "revoked" here means "cannot be spent", not "was live a moment
+    // ago".
+    let http = Recorded::new().ok(lux_pco::oauth::REVOKE_URL, "{}");
+    assert!(revoking_app().revoke(&http, "spent-token").await.is_ok());
+}
+
+#[tokio::test]
+async fn a_refused_revocation_is_reported_rather_than_swallowed() {
+    // The caller deleting an account carries on regardless — but it can only
+    // log what it is told, so a failure has to arrive as one.
+    let http = Recorded::new().on(
+        lux_pco::oauth::REVOKE_URL,
+        HttpResponse::new(500, r#"{"error":"server_error"}"#),
+    );
+    let error = revoking_app()
+        .revoke(&http, "the-churchs-refresh-token")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(&error, Error::Status { status: 500, .. }),
+        "expected the refusal to survive, got {error:?}"
+    );
+
+    // And an unreachable Planning Center is a transport error, not a silent ok.
+    let offline = Recorded::new();
+    assert!(revoking_app().revoke(&offline, "rt").await.is_err());
 }

--- a/crates/lux-pco/tests/live.rs
+++ b/crates/lux-pco/tests/live.rs
@@ -24,9 +24,11 @@
 //! `redirect_uri`, so no unauthenticated request can confirm that the callback
 //! URIs are registered — that is only checked after a human signs in. What is
 //! provable without a human is the half below: the token endpoint is reachable
-//! over TLS, it answers in the shape this crate parses, and a dead refresh
-//! token produces exactly the error the bridge turns into "reconnect" rather
-//! than into a 500 in the middle of a service.
+//! over TLS, it answers in the shape this crate parses, a dead refresh token
+//! produces exactly the error the bridge turns into "reconnect" rather than
+//! into a 500 in the middle of a service, and the revocation endpoint — the
+//! one account deletion depends on — is there and answers the way its
+//! documentation says.
 
 use lux_pco::{Error, OAuthApp, ReqwestHttp};
 
@@ -94,6 +96,36 @@ async fn a_bogus_authorization_code_is_refused_cleanly() {
     assert!(
         matches!(err, Error::Unauthorized | Error::Status { .. }),
         "expected a typed refusal; got {err:?}"
+    );
+}
+
+/// The revocation endpoint exists, accepts this application's credentials, and
+/// treats a token it has never seen as already gone.
+///
+/// Account deletion leans on both halves of that: the endpoint has to be there
+/// (it is the only way lux can end its own access without a church visiting
+/// Planning Center's settings), and a 200 for an unknown token is what makes a
+/// retried deletion — or a second disconnect — a no-op rather than a failure.
+/// Documented as "a successful revocation returns 200, including for a token
+/// that was already revoked or is invalid"; pinned here so a change in that
+/// behaviour surfaces during a runbook pass instead of leaving a live 90-day
+/// credential behind a deleted account.
+#[tokio::test]
+#[ignore = "hits the live Planning Center OAuth server"]
+async fn revoking_a_token_planning_center_never_issued_still_answers_ok() {
+    let Some(app) = app() else { return };
+    let http = ReqwestHttp::new().expect("transport");
+
+    let result = app
+        .revoke(&http, "definitely-not-a-real-refresh-token")
+        .await;
+    match &result {
+        Ok(()) => eprintln!("live revoke: 200, as documented"),
+        Err(e) => eprintln!("live revoke error: {e}"),
+    }
+    assert!(
+        result.is_ok(),
+        "the documented answer is 200 even for an unknown token; got {result:?}"
     );
 }
 

--- a/crates/lux-wire/src/lib.rs
+++ b/crates/lux-wire/src/lib.rs
@@ -304,13 +304,15 @@ pub mod device {
     //! - `POST /auth/device/token`     — device: poll for the grant
     //! - `GET  /auth/device/pending`   — bearer-authed: same-egress pending list
     //! - `POST /auth/device/approve`   — bearer-authed: approve one device
-    //! - `GET  /auth/device/list`      — bearer-authed: the owner's paired devices
-    //! - `POST /auth/device/revoke`    — bearer-authed: remove a paired device
+    //! - `GET  /auth/device/list`       — bearer-authed: the owner's paired devices
+    //! - `POST /auth/device/revoke`     — bearer-authed: remove a paired device
+    //! - `POST /auth/device/forget-all` — bearer-authed: remove every one of
+    //!   them, for an account that is being deleted
 
     use serde::{Deserialize, Serialize};
 
     /// Path segments under [`super::apple::AUTH_SEGMENT`]:
-    /// `/auth/device/{authorize|token|pending|approve|list|revoke}`.
+    /// `/auth/device/{authorize|token|pending|approve|list|revoke|forget-all}`.
     pub const DEVICE_SEGMENT: &str = "device";
     pub const AUTHORIZE_SEGMENT: &str = "authorize";
     pub const TOKEN_SEGMENT: &str = "token";
@@ -318,6 +320,9 @@ pub mod device {
     pub const APPROVE_SEGMENT: &str = "approve";
     pub const LIST_SEGMENT: &str = "list";
     pub const REVOKE_SEGMENT: &str = "revoke";
+    /// Deliberately not `forget`: a route that removes *every* device should
+    /// not be one letter away from reading like it removes one.
+    pub const FORGET_ALL_SEGMENT: &str = "forget-all";
 
     /// Body for `POST /auth/device/authorize`. Everything here is display
     /// metadata for the approve screen — identity is established by approval,
@@ -468,6 +473,20 @@ pub mod device {
     #[serde(rename_all = "camelCase")]
     pub struct RevokeResponse {
         pub revoked: bool,
+    }
+
+    /// Response to `POST /auth/device/forget-all` — every device dropped from
+    /// the caller's registry, for an account that is being deleted.
+    ///
+    /// A hard delete, unlike [`RevokeRequest`]'s tombstone: an account that is
+    /// going away should not leave a row behind saying which boxes it once
+    /// paired. `forgotten` is how many were dropped, `0` when the account never
+    /// paired one — a no-op, never an error, because deletion is the operation
+    /// that always has to finish.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ForgetAllResponse {
+        pub forgotten: u32,
     }
 }
 
@@ -1594,6 +1613,21 @@ mod tests {
         assert_eq!(device::APPROVE_SEGMENT, "approve");
         assert_eq!(device::LIST_SEGMENT, "list");
         assert_eq!(device::REVOKE_SEGMENT, "revoke");
+        assert_eq!(device::FORGET_ALL_SEGMENT, "forget-all");
+        // The two removal routes must not be confusable: one takes a device id
+        // in its body, the other takes nothing and removes them all.
+        assert_ne!(device::FORGET_ALL_SEGMENT, device::REVOKE_SEGMENT);
+    }
+
+    #[test]
+    fn device_forget_all_shape() {
+        let answer: device::ForgetAllResponse =
+            serde_json::from_str(r#"{"forgotten":3}"#).expect("forget-all answer parses");
+        assert_eq!(answer.forgotten, 3);
+        // An account that never paired a device: zero, not an error.
+        let none = serde_json::to_string(&device::ForgetAllResponse { forgotten: 0 })
+            .expect("forget-all answer serializes");
+        assert_eq!(none, r#"{"forgotten":0}"#);
     }
 
     #[test]

--- a/docs/claim-code-pairing.md
+++ b/docs/claim-code-pairing.md
@@ -269,7 +269,18 @@ sub + client id if we accept one-device-per-account granularity in v1).
 CONNECTs happen hourly, not per frame, so cost is negligible; a revoked box
 degrades to no-remote (sACN keeps last local state → blackout at the venue's
 discretion) within ≤1 h or next reconnect. Tighten in v2 with Cognito
-refresh-token rotation on the device client. **Granularity decision for
+refresh-token rotation on the device client.
+
+**Account deletion** is the other end of this: `POST /auth/device/forget-all`
+(bearer-authed, no body — the caller's `sub` names the partition) hard-deletes
+every `DEVICE#<sub>` row, and the app calls it while deleting an account. The
+boxes lose their access anyway the moment the Cognito user goes, since their
+sessions are that account's; the rows are keyed by `sub` and would otherwise
+outlive it, leaving a list of someone's hardware behind an account that no
+longer exists. Hard delete rather than the tombstone `/revoke` writes: a row
+kept for audit against a deleted account is a record of someone who asked to be
+forgotten. `PAIR#`/`PAIRIP#` litter is not reachable by `sub` and self-expires
+on its `ttl`. **Granularity decision for
 review** (claim-based per-device vs per-account) — claim-based is the clean
 answer and the pre-token trigger is small.
 

--- a/services/apple-auth/src/device.rs
+++ b/services/apple-auth/src/device.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use lambda_runtime::Error;
 use lux_wire::device::{
     ApproveRequest, ApproveResponse, AuthorizeRequest, AuthorizeResponse, DeviceRecord,
-    ListResponse, PendingDevice, PendingResponse, RevokeRequest, RevokeResponse, TokenRequest,
-    TokenResponse,
+    ForgetAllResponse, ListResponse, PendingDevice, PendingResponse, RevokeRequest, RevokeResponse,
+    TokenRequest, TokenResponse,
 };
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -239,6 +239,44 @@ pub async fn revoke(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
         Ok(revoked) => reply(200, &RevokeResponse { revoked }),
         Err(e) => {
             tracing::error!("device revoke failed: {e}");
+            reply(500, &error("internal"))
+        }
+    }
+}
+
+/// `POST /auth/device/forget-all` — bearer-authed: drop every device in the
+/// caller's registry.
+///
+/// Account deletion's cleanup step. The boxes lose their access the moment the
+/// Cognito user goes (their sessions are that account's), but the registry rows
+/// are keyed by the `sub` and survive it — a list of someone's hardware, still
+/// sitting in a table, belonging to an account that no longer exists. This is
+/// what removes them.
+///
+/// A hard delete rather than `/revoke`'s tombstone, and an empty registry
+/// answers `0` rather than a refusal: the caller is a deletion, and a deletion
+/// has to be able to finish. It carries no body — there is nothing to name.
+pub async fn forget_all(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
+    let Some(caller_sub) = caller(ctx, event) else {
+        return reply(401, &error("invalid or missing token"));
+    };
+    match store::delete_devices(ctx, &caller_sub).await {
+        Ok(forgotten) => {
+            if forgotten > 0 {
+                tracing::info!("forgot {forgotten} paired device(s) for a deleted account");
+            }
+            reply(
+                200,
+                &ForgetAllResponse {
+                    // A registry that somehow held four billion rows would
+                    // report the ceiling rather than wrap; the delete itself
+                    // already happened either way.
+                    forgotten: u32::try_from(forgotten).unwrap_or(u32::MAX),
+                },
+            )
+        }
+        Err(e) => {
+            tracing::error!("device forget-all failed: {e}");
             reply(500, &error("internal"))
         }
     }

--- a/services/apple-auth/src/http.rs
+++ b/services/apple-auth/src/http.rs
@@ -1,7 +1,10 @@
 //! The Function URL surface: parse the Lambda URL (payload v2) event, route,
-//! and reply in `lux-wire` shapes. Identity on `/link` and `/revoke` comes only
-//! from the verified Cognito bearer token; identity on `/auth/apple` comes only
-//! from the verified Apple identity token — a request body never names a user.
+//! and reply in `lux-wire` shapes. Identity on `/link`, `/revoke` and the
+//! bearer-authed `/auth/device/*` routes comes only from the verified Cognito
+//! bearer token; identity on `/auth/apple` comes only from the verified Apple
+//! identity token — a request body never names a user. That is what makes
+//! `/auth/device/forget-all`, which takes no body at all, unable to name
+//! anyone's devices but the caller's.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -64,8 +67,8 @@ pub async fn handle(ctx: &Arc<Ctx>, payload: Value) -> Result<Value, Error> {
     let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
 
     use lux_wire::device::{
-        APPROVE_SEGMENT, AUTHORIZE_SEGMENT, DEVICE_SEGMENT, LIST_SEGMENT, PENDING_SEGMENT,
-        REVOKE_SEGMENT as DEVICE_REVOKE_SEGMENT, TOKEN_SEGMENT,
+        APPROVE_SEGMENT, AUTHORIZE_SEGMENT, DEVICE_SEGMENT, FORGET_ALL_SEGMENT, LIST_SEGMENT,
+        PENDING_SEGMENT, REVOKE_SEGMENT as DEVICE_REVOKE_SEGMENT, TOKEN_SEGMENT,
     };
 
     match (method, segments.as_slice()) {
@@ -129,6 +132,11 @@ pub async fn handle(ctx: &Arc<Ctx>, payload: Value) -> Result<Value, Error> {
             if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == DEVICE_REVOKE_SEGMENT =>
         {
             crate::device::revoke(ctx, &event).await
+        }
+        ("POST", [a, b, c])
+            if *a == AUTH_SEGMENT && *b == DEVICE_SEGMENT && *c == FORGET_ALL_SEGMENT =>
+        {
+            crate::device::forget_all(ctx, &event).await
         }
         _ => reply(404, &error("not found")),
     }

--- a/services/apple-auth/src/store.rs
+++ b/services/apple-auth/src/store.rs
@@ -591,6 +591,64 @@ pub async fn list_devices(
     Ok(out.items.unwrap_or_default())
 }
 
+/// Delete every one of the owner's device-registry rows (`DEVICE#<sub>`),
+/// answering how many there were.
+///
+/// A hard delete, unlike [`revoke_device`]'s tombstone. That one keeps the row
+/// so a device can be seen to have been removed; this one runs when the account
+/// itself is going away, and a record kept "for audit" against a deleted
+/// account is just a note about someone who asked to be forgotten.
+///
+/// Paged, and it re-reads after each page rather than trusting one query to
+/// have seen everything — a partial wipe here would be the same class of defect
+/// as the one this exists to fix. Deletes go one at a time (`BatchWriteItem` is
+/// not in this role's policy, and a registry is a handful of rows).
+///
+/// The `PAIR#`/`PAIRIP#` items a pairing leaves behind are keyed by the device
+/// code's hash and the caller's public IP, not by `sub`, so they cannot be
+/// found from here — they carry a `ttl` and expire on their own within the
+/// hour, holding no credential in the meantime.
+pub async fn delete_devices(ctx: &Ctx, sub: &str) -> Result<usize, String> {
+    let mut deleted = 0usize;
+    let mut start: Option<HashMap<String, AttributeValue>> = None;
+    loop {
+        let page = ctx
+            .ddb
+            .query()
+            .table_name(&ctx.table)
+            .key_condition_expression("pk = :pk")
+            .expression_attribute_values(":pk", AttributeValue::S(device_pk(sub)))
+            .set_exclusive_start_key(start)
+            .send()
+            .await
+            .map_err(|e| format!("device query failed: {e}"))?;
+
+        for item in page.items.unwrap_or_default() {
+            let Some(device_id) = item.get("sk").and_then(|v| v.as_s().ok()).cloned() else {
+                // DynamoDB cannot return a row without its sort key. Read for
+                // it anyway rather than assume: this runs inside a deletion,
+                // where the one unacceptable outcome is an abort.
+                tracing::warn!("device row with no sort key; skipping");
+                continue;
+            };
+            ctx.ddb
+                .delete_item()
+                .table_name(&ctx.table)
+                .key("pk", AttributeValue::S(device_pk(sub)))
+                .key("sk", AttributeValue::S(device_id))
+                .send()
+                .await
+                .map_err(|e| format!("device delete failed: {e}"))?;
+            deleted += 1;
+        }
+
+        start = page.last_evaluated_key;
+        if start.is_none() {
+            return Ok(deleted);
+        }
+    }
+}
+
 /// Approve a pending grant: bind it to the approver and the chosen setup,
 /// retire its pending-list row, and record the device in the owner's registry
 /// — one transaction. Fails (condition) if the grant isn't pending anymore.

--- a/services/plan-bridge/README.md
+++ b/services/plan-bridge/README.md
@@ -17,17 +17,19 @@ Served on a Function URL, fronted by the `auth.lux.johncarmack.com` CloudFront d
 | `GET /pco/status` | Cognito bearer | Is this account connected, and to which church |
 | `GET /pco/service-types` | Cognito bearer | What a setup could follow (retired ones filtered out) |
 | `POST /pco/plan` | Cognito bearer | The next plan, resolved against the cue map in the body |
-| `POST /pco/disconnect` | Cognito bearer | Delete the tokens |
+| `POST /pco/disconnect` | Cognito bearer | Revoke the authorization at Planning Center, then delete the tokens |
 
 `/pco/plan` is a `POST` for what is plainly a read because the request carries the `CueMap`: the map lives on the setup and travels by sync, so the bridge holds no copy, and sending it up means one engine (`lux-cue`, server-side) decides what a plan means. A laptop and a phone looking at the same plan cannot then disagree.
 
 ## Guarantees
 
-**Read-only against Planning Center, structurally.** `lux-pco`'s client builds `GET` requests and nothing else; the only `POST` in that crate is the OAuth token endpoint. The `services` scope has no read-only variant, so this cannot be enforced by the grant — it is enforced by there being no method that writes. lux never advances someone else's service.
+**Read-only against Planning Center, structurally.** `lux-pco`'s client builds `GET` requests and nothing else; the only `POST`s in that crate are the OAuth token and revocation endpoints, which talk to the OAuth server rather than the API — one asks for a credential, the other gives it back. The `services` scope has no read-only variant, so this cannot be enforced by the grant — it is enforced by there being no method that writes. lux never advances someone else's service.
 
 **Identity is the verified bearer's `sub`, never a request field.** A church can only read the connection it authorized.
 
 **Planning Center's failures are translated, not forwarded.** Their 401 becomes "reconnect", their 429 becomes "busy, try again", and their response body never reaches a lux surface — it is their wording about their system, and an operator reading it in a lux dialog would not know which of two products was complaining.
+
+**Disconnecting hands the credential back, and account deletion is a disconnect.** `/pco/disconnect` revokes the refresh token at Planning Center *before* deleting the stored row — deleting alone would only stop lux from being able to spend the token, while the grant stayed live in the church's Planning Center settings for up to ninety days. The app calls this same route while deleting an account, so a deleted account never leaves a live credential for another company's data behind it. The revocation is best-effort by type (`tokens::Revoked` has no error arm): an account that never connected, an unreadable OAuth secret, and an unreachable Planning Center are each logged, and the row is deleted regardless — because a deletion that refuses to finish is worse than a cleanup that has to be retried, and revoking a token twice is a no-op at their end.
 
 **Nothing here is in the DMX path.** Losing Planning Center costs the plan list, never the lights.
 
@@ -44,7 +46,7 @@ Two item kinds in the `lux-sync` table, in their own partitions, pinned by the r
 
 ## Verifying it
 
-The unit tests cover routing, the token-refresh decision, HTML escaping, and the failure translation, all without a network. Against the live Planning Center OAuth server:
+The unit tests cover routing, the token-refresh decision, the three revocation outcomes (connected, never connected, upstream refused), HTML escaping, and the failure translation, all without a network. Against the live Planning Center OAuth server:
 
 ```sh
 eval "$(aws secretsmanager get-secret-value --profile newearth-admin \

--- a/services/plan-bridge/src/routes.rs
+++ b/services/plan-bridge/src/routes.rs
@@ -317,15 +317,50 @@ pub async fn plan(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
     )
 }
 
-/// `POST /pco/disconnect` — forget the church's tokens.
+/// `POST /pco/disconnect` — give the church's authorization back and forget
+/// its tokens.
+///
+/// Two steps, in this order: revoke at Planning Center, then delete the row.
+/// Deleting alone would only stop *lux* from being able to spend the token —
+/// the grant would still be live in the church's Planning Center settings for
+/// up to ninety days, listed as an integration nobody can see the end of. So
+/// the credential is handed back first, and the delete is what makes it gone
+/// from here.
 ///
 /// Deletes rather than marks: the point of disconnecting is that lux stops
 /// holding a credential for someone else's data, and a soft delete would not
 /// be that.
+///
+/// **This is also account deletion's Planning Center step** — the app calls
+/// this route while deleting an account, because "the church is done with us"
+/// is the same operation whichever end asked for it. Which is why every failure
+/// below is survivable: the revoke is best-effort by type
+/// ([`tokens::Revoked`]), an account that never connected takes the quiet path,
+/// and only the delete can answer anything but 200.
 pub async fn disconnect(ctx: &Arc<Ctx>, event: &UrlEvent) -> Result<Value, Error> {
     let Some(sub) = caller(ctx, event) else {
         return reply(401, &error("unauthorized"));
     };
+
+    // A read that fails is not a reason to keep the row: it costs the upstream
+    // revoke (nothing to revoke *with*), and the delete below still runs.
+    let conn = match store::get_connection(ctx, &sub).await {
+        Ok(conn) => conn,
+        Err(e) => {
+            tracing::error!("connection read failed before revoke: {e}");
+            None
+        }
+    };
+    match ctx.oauth().await {
+        Ok(app) => {
+            tokens::revoke(app, &ctx.http, conn.as_ref()).await;
+        }
+        // The secret is unreadable, so there is no way to ask Planning Center
+        // for anything. Still delete: holding a token lux cannot even revoke is
+        // strictly worse than dropping it.
+        Err(e) => tracing::error!("oauth app unavailable; dropping the token unrevoked: {e}"),
+    }
+
     match store::delete_connection(ctx, &sub).await {
         Ok(()) => reply(200, &StatusResponse::default()),
         Err(e) => {

--- a/services/plan-bridge/src/tokens.rs
+++ b/services/plan-bridge/src/tokens.rs
@@ -1,4 +1,5 @@
-//! Keeping the access token fresh, on the read path.
+//! Keeping the access token fresh on the read path — and handing it back at
+//! the end.
 //!
 //! Planning Center's access tokens last two hours and their refresh tokens
 //! ninety days, and a refresh mints a *new* refresh token — so the stored pair
@@ -9,6 +10,8 @@
 //! schedule: a church that has not opened lux in a month should not be costing
 //! a timer, and the read path is the only place where a stale token has any
 //! consequence.
+
+use lux_pco::{Http, OAuthApp};
 
 use crate::store::{self, Connection};
 use crate::Ctx;
@@ -151,8 +154,64 @@ async fn token_from_a_concurrent_refresh(
     Some(current.access_token)
 }
 
+// --- giving it back -----------------------------------------------------------
+
+/// What became of a revocation attempt.
+///
+/// There is no error arm, and [`revoke`] returns this rather than a `Result` on
+/// purpose: its callers are a disconnect and an account deletion, and both are
+/// operations that must finish. A deletion that refused to complete because
+/// Planning Center was unreachable would leave lux holding the very credential
+/// the church just asked it to let go of — the opposite of what was asked for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Revoked {
+    /// Nothing was connected. The ordinary case for an account that never used
+    /// the bridge, and for a second disconnect.
+    NothingToRevoke,
+    /// Planning Center accepted it — or had already revoked it, which answers
+    /// the same way and means the same thing.
+    Done,
+    /// The attempt did not land. The stored row is deleted regardless, so lux
+    /// stops holding the token; the grant itself may outlive it at Planning
+    /// Center until the church revokes lux in their own settings or the 90 days
+    /// run out. Logged loudly here because nothing downstream can see it.
+    Failed,
+}
+
+/// Hand the church's refresh token back to Planning Center.
+///
+/// Called before the stored row is deleted, never after: once the row is gone
+/// the token is gone with it, and a credential nobody can revoke is exactly the
+/// thing this exists to prevent. Doing it in this order also makes a failed
+/// delete harmless — the token is already dead by then.
+pub async fn revoke<H: Http + ?Sized>(
+    app: &OAuthApp,
+    http: &H,
+    conn: Option<&Connection>,
+) -> Revoked {
+    let Some(conn) = conn else {
+        return Revoked::NothingToRevoke;
+    };
+    match app.revoke(http, &conn.refresh_token).await {
+        Ok(()) => {
+            tracing::info!("planning center authorization revoked");
+            Revoked::Done
+        }
+        Err(e) => {
+            // Never the token itself: the error type redacts it, and this line
+            // must stay safe to read in CloudWatch.
+            tracing::error!("pco revoke failed, deleting the stored token anyway: {e}");
+            Revoked::Failed
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
+    use lux_pco::http::{BoxFuture, HttpRequest, HttpResponse};
+
     use super::*;
 
     fn conn(access_expires_at_s: i64) -> Connection {
@@ -165,6 +224,107 @@ mod tests {
             connected_at_ms: 0,
             refresh_issued_at_s: 0,
         }
+    }
+
+    /// A transport that answers with one canned outcome and remembers whether
+    /// it was asked anything at all. "Was Planning Center called?" is half of
+    /// what the tests below are about: a disconnect on an account that never
+    /// connected must not send a request carrying an empty token.
+    struct Fake {
+        answer: Result<HttpResponse, lux_pco::Error>,
+        calls: Mutex<Vec<HttpRequest>>,
+    }
+
+    impl Fake {
+        fn answering(status: u16) -> Self {
+            Self {
+                answer: Ok(HttpResponse::new(status, "{}")),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn offline() -> Self {
+            Self {
+                answer: Err(lux_pco::Error::Transport("no route to host".into())),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<HttpRequest> {
+            self.calls.lock().map(|c| c.clone()).unwrap_or_default()
+        }
+    }
+
+    impl Http for Fake {
+        fn send(
+            &self,
+            request: HttpRequest,
+        ) -> BoxFuture<'_, Result<HttpResponse, lux_pco::Error>> {
+            if let Ok(mut calls) = self.calls.lock() {
+                calls.push(request);
+            }
+            let answer = match &self.answer {
+                Ok(response) => Ok(response.clone()),
+                Err(e) => Err(lux_pco::Error::Transport(e.to_string())),
+            };
+            Box::pin(async move { answer })
+        }
+    }
+
+    fn app() -> OAuthApp {
+        OAuthApp::new("cid", "csecret", lux_pco::oauth::REDIRECT_URI_PROD)
+    }
+
+    #[tokio::test]
+    async fn a_connected_church_has_its_token_handed_back() {
+        let http = Fake::answering(200);
+        let connection = conn(10_000);
+
+        assert_eq!(
+            revoke(&app(), &http, Some(&connection)).await,
+            Revoked::Done
+        );
+
+        // The refresh token, at the revocation endpoint. Revoking that half is
+        // what ends the 90-day credential — the whole point of the exercise.
+        let calls = http.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].url, lux_pco::oauth::REVOKE_URL);
+        let body = calls[0].body.clone().expect("a form body");
+        assert!(body.contains("token=rt"), "{body}");
+        assert!(body.contains("token_type_hint=refresh_token"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn an_account_that_never_connected_is_a_quiet_no_op() {
+        // Deleting an account is the common case here: most accounts have no
+        // Planning Center connection at all, and the deletion must not spend a
+        // round trip — or send a request with an empty token in it — to learn
+        // that.
+        let http = Fake::answering(200);
+
+        assert_eq!(revoke(&app(), &http, None).await, Revoked::NothingToRevoke);
+        assert!(http.calls().is_empty(), "nothing should have been asked");
+    }
+
+    #[tokio::test]
+    async fn a_failed_revocation_is_reported_but_never_fatal() {
+        // Planning Center refusing, and Planning Center unreachable. Neither
+        // may become an error: the caller is deleting an account, and the row
+        // is deleted either way. `revoke` has no error arm to return, which is
+        // the guarantee — this test pins the outcome it reports instead.
+        let refused = Fake::answering(500);
+        assert_eq!(
+            revoke(&app(), &refused, Some(&conn(10_000))).await,
+            Revoked::Failed
+        );
+        assert_eq!(refused.calls().len(), 1, "it did try");
+
+        let offline = Fake::offline();
+        assert_eq!(
+            revoke(&app(), &offline, Some(&conn(10_000))).await,
+            Revoked::Failed
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The defect

Deleting a lux account revoked the Apple grant and wiped `USER#<sub>` and the sharing grants — and stopped there. Two things outlived the account:

- **The Planning Center connection.** `PCO#<sub>` was never touched, so a refresh token good for 90 days, for another company's data about a church, stayed live behind an account that no longer existed. Nothing in lux could reach it any more, and the only way to end it was for the church to go and revoke lux in Planning Center's own settings — which nobody would think to do, because they had just deleted the account.
- **The paired-device registry.** `DEVICE#<sub>` rows survived. The boxes lose their access the moment the Cognito user goes (their sessions are that account's), but a list of someone's hardware stayed in the table, keyed by a `sub` with nothing behind it.

Found while writing the privacy page, which currently has to tell people to disconnect *before* deleting.

## What deletion does now

One block of detach steps, before the wipe, while the tokens still authenticate:

1. **Refresh the session once.** The detach calls present the current id token and have no refresh path of their own; an app open since breakfast would 401 through all three and delete the account anyway.
2. **Revoke the Apple grant** (unchanged).
3. **Disconnect Planning Center** — `POST /pco/disconnect`, the same route the Plan view's button calls, because "this church is done with lux" is one operation whichever end asked for it.
4. **Forget the paired devices** — `POST /auth/device/forget-all`, new.
5. Wipe the cloud data (fails loud, unchanged), then delete the Cognito user (unchanged).

### The bridge now hands the credential back

`/pco/disconnect` revokes at Planning Center **before** deleting the stored row. Order matters both ways: deleting first would leave a token nobody could revoke, and revoking first makes a failed delete harmless, because what is left is already dead. `OAuthApp::revoke` is new in `lux-pco` — `POST /oauth/revoke` with `token_type_hint=refresh_token`, which invalidates the access token with it. It sits on `OAuthApp`, not `PcoClient`, so the crate's structural read-only guarantee is untouched: still no method that writes to a church's data.

### Deletion cannot fail on any of this

- `tokens::revoke` returns `Revoked { NothingToRevoke, Done, Failed }` and **has no error arm** — the guarantee is in the type, not in a promise.
- The app-side callers return no value at all.
- Never connected: no round trip, no request carrying an empty token.
- OAuth secret unreadable, or Planning Center unreachable: logged, row deleted anyway.
- Revoking twice is a no-op at their end (documented 200 for an already-revoked or invalid token), so a retried deletion finishes the job.

`/auth/device/forget-all` is a hard delete rather than `/revoke`'s tombstone — a row kept for audit against a deleted account is a record of someone who asked to be forgotten. It takes no body: the caller's verified `sub` names the partition, so it cannot name anyone else's devices. `PAIR#`/`PAIRIP#` litter isn't reachable by `sub`, carries a `ttl`, holds no credential, and expires within the hour.

No infra change: both roles already carry `DeleteItem` (and `Query`) under the `LeadingKeys` pins that scope them to their own partitions.

## Tests

`cargo test --workspace --locked` — 292 passing, 0 failing.

The three cases, at the bridge (`services/plan-bridge/src/tokens.rs`, against a fake transport that records whether it was called):

- `a_connected_church_has_its_token_handed_back` — one POST to the revocation endpoint carrying the *refresh* token and the hint that ends the whole grant.
- `an_account_that_never_connected_is_a_quiet_no_op` — `NothingToRevoke`, and nothing was asked.
- `a_failed_revocation_is_reported_but_never_fatal` — 500 and unreachable both give `Failed`, and the refusal case asserts it did try.

At the OAuth layer (`crates/lux-pco/tests/flow.rs`): the form body's four parameters, an already-revoked token being a success, and a refusal surviving as a typed error rather than being swallowed. In `lux-wire`: the new segment is `forget-all` and is not confusable with `revoke`.

`crates/lux-pco/tests/live.rs` gains an `#[ignore]`d probe that pins the revocation endpoint's existence and its 200-for-an-unknown-token behaviour against the real server — run from the runbook, never in the gate.

## Also

The in-app delete confirm names the church when one is connected. The **privacy page still says deletion does not reach a Planning Center connection**, which is now wrong — that copy is a separate PR, for review rather than merge.