### PR TITLE
fix(desktop): poll buffer when remote peers are connected

### DIFF
--- a/apps/desktop/src/hooks/useBuffer.ts
+++ b/apps/desktop/src/hooks/useBuffer.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createTauRPCProxy } from "@/bindings";
+import useRemotePeers from "./useRemotePeers";
 
 /** Query key for the live DMX buffer (the current value of every channel). */
 export const BUFFER_QUERY_KEY = ["buffer"] as const;
@@ -14,10 +15,13 @@ export const BUFFER_QUERY_KEY = ["buffer"] as const;
  * buffer it gets back straight into the cache (see lib/actions), which is what
  * keeps it current on iOS. On desktop the `bufferSet` event is also honored as
  * a fast path so out-of-band changes — a remote command over IoT — still show
- * live; that event just never reaches the webview on iOS.
+ * live; the poll below covers iOS where that event never reaches the webview,
+ * but only runs when another device or guest is connected.
  */
 export default function useBuffer(): number[] | null {
   const queryClient = useQueryClient();
+  const peers = useRemotePeers();
+  const hasPeers = !!peers?.length;
 
   const { data } = useQuery({
     queryKey: BUFFER_QUERY_KEY,
@@ -25,6 +29,7 @@ export default function useBuffer(): number[] | null {
       createTauRPCProxy()
         .sync.sync_buffer()
         .then((b) => b.buffer),
+    refetchInterval: hasPeers ? 200 : false,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- The `bufferSet` event never reaches the iOS webview, so when a guest or another device changes the buffer via the ctl frame path, the lights update but the phone UI stays frozen
- Poll `sync_buffer` at 200 ms while `useRemotePeers` reports at least one connected peer or guest — a cheap mutex read matching the state echo's coalesce window
- Polling stops entirely when the desk is solo; TanStack Query pauses it when the app is backgrounded

## Test plan

- [ ] Open a shared desk from a guest device, move a fader — verify the host phone's UI updates within ~200 ms
- [ ] Verify the host's desktop UI still updates instantly (event listener path unchanged)
- [ ] Close the guest desk / sign out — verify polling stops (no `sync_buffer` IPC calls in logs when solo)
- [ ] Verify fader drag on the host phone is still smooth (optimistic state, not affected by poll)